### PR TITLE
Add new module for snapshot policies

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/README.md
+++ b/collections/ansible_collections/purestorage/flashblade/README.md
@@ -17,6 +17,7 @@ The Pure Storage FlashBlade collection consists of the latest versions of the Fl
 - purefb_network - manage the network settings for a FlashBlade
 - purefb_ntp - manage the NTP settings for a FlashBlade
 - purefb_phonehome - manage the phone home settings for a FlashBlade
+- purefb_policy - manage the filesystem snapshot policies for a FlashBlade
 - purefb_proxy - manage the phone home HTTP proxy settings for a FlashBlade
 - purefb_ra - manage the Remote Assist connections on a FlashBlade
 - purefb_s3acc - manage the object store accounts on a FlashBlade

--- a/collections/ansible_collections/purestorage/flashblade/docs/purefb_policy.rst
+++ b/collections/ansible_collections/purestorage/flashblade/docs/purefb_policy.rst
@@ -1,0 +1,135 @@
+
+purefb_policy -- Manage FlashBlade policies
+===========================================
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+
+Manage policies for filesystem and file replica links
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.7
+- purity_fb >= 1.1
+- netaddr
+- pytz
+
+
+
+Parameters
+----------
+
+  fb_url (optional, str, None)
+    FlashBlade management IP address or Hostname.
+
+
+  state (optional, str, present)
+    Create or delete policy
+
+
+  every (optional, int, None)
+    Interval between snapshots in seconds
+
+    Range available 300 - 31536000 (equates to 5m to 365d)
+
+
+  name (True, str, None)
+    Name of the policy
+
+
+  api_token (optional, str, None)
+    FlashBlade API token for admin privileged user.
+
+
+  timezone (optional, str, None)
+    Time Zone used for the *at* parameter
+
+    If not provided, the module will attempt to get the current local timezone from the server
+
+
+  keep_for (optional, int, None)
+    How long to keep snapshots for
+
+    Range available 300 - 31536000 (equates to 5m to 365d)
+
+    Must not be set less than *every*
+
+
+  enabled (optional, bool, True)
+    State of policy
+
+
+  at (optional, str, None)
+    Provide a time in 12-hour AM/PM format, eg. 11AM
+
+
+
+
+
+Notes
+-----
+
+.. note::
+   - This module requires the ``purity_fb`` Python library
+   - You must set ``PUREFB_URL`` and ``PUREFB_API`` environment variables if *fb_url* and *api_token* arguments are not passed to the module directly
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create a simple policy with no rules
+      purefb_policy:
+        name: test_policy
+        fb_url: 10.10.10.2
+        api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+    - name: Create a policy with rules
+      purefb_policy:
+        name: test_policy2
+        at: 11AM
+        keep_for: 86400
+        every: 86400
+        timezone: Asia/Shanghai
+        fb_url: 10.10.10.2
+        api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+    - name: Delete a policy
+      purefb_policy:
+        name: test_policy
+        state: absent
+        fb_url: 10.10.10.2
+        api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+
+
+
+
+Status
+------
+
+
+
+
+- This  is not guaranteed to have a backwards compatible interface. *[preview]*
+
+
+- This  is maintained by community.
+
+
+
+Authors
+~~~~~~~
+
+- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+

--- a/collections/ansible_collections/purestorage/flashblade/plugins/doc_fragments/purestorage.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/doc_fragments/purestorage.py
@@ -35,4 +35,5 @@ requirements:
   - python >= 2.7
   - purity_fb >= 1.1
   - netaddr
+  - pytz
 '''

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
@@ -1,0 +1,372 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2020, Simon Dodsley (simon@purestorage.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: purefb_policy
+short_description: Manage FlashBlade policies
+description:
+- Manage policies for filesystem and file replica links
+author:
+- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+options:
+  state:
+    description:
+    - Create or delete policy
+    default: present
+    type: str
+    choices: [ absent, present ]
+  name:
+    description:
+    - Name of the policy
+    type: str
+    required: True
+  enabled:
+    description:
+    - State of policy
+    type: bool
+    default: True
+  every:
+    description:
+    - Interval between snapshots in seconds
+    - Range available 300 - 31536000 (equates to 5m to 365d)
+    type: int
+  keep_for:
+    description:
+    - How long to keep snapshots for
+    - Range available 300 - 31536000 (equates to 5m to 365d)
+    - Must not be set less than I(every)
+    type: int
+  at:
+    description:
+    - Provide a time in 12-hour AM/PM format, eg. 11AM
+    type: str
+  timezone:
+    description:
+    - Time Zone used for the I(at) parameter
+    - If not provided, the module will attempt to get the current local timezone from the server
+    type: str
+extends_documentation_fragment:
+- purestorage.fb
+'''
+
+EXAMPLES = r'''
+- name: Create a simple policy with no rules
+  purefb_policy:
+    name: test_policy
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+- name: Create a policy with rules
+  purefb_policy:
+    name: test_policy2
+    at: 11AM
+    keep_for: 86400
+    every: 86400
+    timezone: Asia/Shanghai
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+- name: Delete a policy
+  purefb_policy:
+    name: test_policy
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+'''
+
+RETURN = r'''
+'''
+
+HAS_PURITYFB = True
+try:
+    from purity_fb import Policy, PolicyRule, PolicyPatch
+except ImportError:
+    HAS_PURITYFB = False
+
+import os
+import re
+import platform
+import pytz
+
+from ansible.module_utils.common.process import get_bin_path
+from ansible.module_utils.facts.utils import get_file_content
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import get_blade, purefb_argument_spec
+
+
+MINIMUM_API_VERSION = '1.9'
+
+
+def _convert_to_millisecs(hour):
+    if hour[-2:] == "AM" and hour[:2] == "12":
+        return 0
+    elif hour[-2:] == "AM":
+        return int(hour[:-2]) * 3600000
+    elif hour[-2:] == "PM" and hour[:2] == "12":
+        return 43200000
+    return (int(hour[:-2]) + 12) * 3600000
+
+
+def _findstr(text, match):
+    for line in text.splitlines():
+        if match in line:
+            found = line
+    return found
+
+
+def _get_local_tz(module, timezone='UTC'):
+    """
+    We will attempt to get the local timezone of the server running the module and use that.
+    If we can't get the timezone then we will set the default to be UTC
+
+    Linnux has been tested and other opersting systems should be OK.
+    Failures cause assumption of UTC
+
+    Windows is not supported and will assume UTC
+    """
+    if platform.system() == 'Linux':
+        timedatectl = get_bin_path('timedatectl')
+        if timedatectl is not None:
+            rcode, stdout, stderr = module.run_command(timedatectl)
+            if rcode == 0 and stdout:
+                line = _findstr(stdout, 'Time zone')
+                full_tz = line.split(":", 1)[1].rstrip()
+                timezone = full_tz.split()[0]
+                return timezone
+        else:
+            if os.path.exists('/etc/timezone'):
+                timezone = get_file_content('/etc/timezone')
+            else:
+                module.warn('Could not find /etc/timezone. Assuming UTC')
+
+    elif platform.system() == 'SunOS':
+        if os.path.exists('/etc/default/init'):
+            for line in get_file_content('/etc/default/init', '').splitlines():
+                if line.startswith('TZ='):
+                    timezone = line.split('=', 1)[1]
+                    return timezone
+        else:
+            module.warn('Could not find /etc/default/init. Assuming UTC')
+
+    elif re.match('^Darwin', platform.platform()):
+        systemsetup = get_bin_path('systemsetup')
+        if systemsetup is not None:
+            rcode, stdout, stderr = module.execute(systemsetup, '-gettimezone')
+            if rcode == 0 and stdout:
+                timezone = stdout.split(':', 1)[1].lstrip()
+            else:
+                module.warn('Could not run systemsetup. Assuming UTC')
+        else:
+            module.warn('Could not find systemsetup. Assuming UTC')
+
+    elif re.match('^(Free|Net|Open)BSD', platform.platform()):
+        if os.path.exists('/etc/timezone'):
+            timezone = get_file_content('/etc/timezone')
+        else:
+            module.warn('Could not find /etc/timezone. Assuming UTC')
+
+    elif platform.system() == 'AIX':
+        aix_oslevel = int(platform.version() + platform.release())
+        if aix_oslevel >= 61:
+            if os.path.exists('/etc/environment'):
+                for line in get_file_content('/etc/environment', '').splitlines():
+                    if line.startswith('TZ='):
+                        timezone = line.split('=', 1)[1]
+                        return timezone
+            else:
+                module.warn('Could not find /etc/environment. Assuming UTC')
+        else:
+            module.warn('Cannot determine timezone when AIX os level < 61. Assuming UTC')
+
+    else:
+        module.warn('Could not find /etc/timezone. Assuming UTC')
+
+    return timezone
+
+
+def delete_policy(module, blade):
+    """Delete policy"""
+    changed = True
+    if not module.check_mode:
+        try:
+            blade.policies.delete_policies(names=[module.params['name']])
+        except Exception:
+            module.fail_json(msg="Failed to delete policy {0}.".format(module.params['name']))
+    module.exit_json(changed=changed)
+
+
+def create_policy(module, blade):
+    """Create snapshot policy"""
+    changed = True
+    if not module.check_mode:
+        try:
+            if module.params['at'] and module.params['every']:
+                if not module.params['every'] % 86400 == 0:
+                    module.fail_json(msg='At time can only be set if every value is a multiple of 86400')
+                if not module.params['timezone']:
+                    module.params['timezone'] = _get_local_tz(module)
+                    if module.params['timezone'] not in pytz.all_timezones_set:
+                        module.fail_json(msg='Timezone {0} is not valid'.format(module.params['timezone']))
+            if module.params['keep_for'] < module.params['every']:
+                module.fail_json(msg='Retention period cannot be less than snapshot interval.')
+            if module.params['at'] and not module.params['timezone']:
+                module.params['timezone'] = _get_local_tz(module)
+                if module.params['timezone'] not in set(pytz.all_timezones_set):
+                    module.fail_json(msg='Timezone {0} is not valid'.format(module.params['timezone']))
+
+            if module.params['keep_for']:
+                if not 300 <= module.params['keep_for'] <= 34560000:
+                    module.fail_json(msg="keep_for parameter is out of range (300 to 34560000)")
+                if not 300 <= module.params['every'] <= 34560000:
+                    module.fail_json(msg="every parameter is out of range (300 to 34560000)")
+                if module.params['at']:
+                    attr = Policy(enabled=module.params['enabled'], rules=[PolicyRule(keep_for=module.params['keep_for'] * 1000,
+                                                                                      every=module.params['every'] * 1000,
+                                                                                      at=_convert_to_millisecs(module.params['at']),
+                                                                                      time_zone=module.params['timezone'])])
+                else:
+                    attr = Policy(enabled=module.params['enabled'], rules=[PolicyRule(keep_for=module.params['keep_for'] * 1000,
+                                                                                      every=module.params['every'] * 1000)])
+            else:
+                attr = Policy(enabled=module.params['enabled'])
+            blade.policies.create_policies(names=[module.params['name']], policy=attr)
+        except Exception:
+            module.fail_json(msg="Failed to create policy {0}.".format(module.params['name']))
+    module.exit_json(changed=changed)
+
+
+def update_policy(module, blade, policy):
+    """Update snapshot policy"""
+    changed = True
+    if not module.check_mode:
+        changed = False
+        if not policy.rules:
+            current_policy = {'time_zone': None,
+                              'every': 0,
+                              'keep_for': 0,
+                              'at': 0,
+                              'enabled': policy.enabled}
+        else:
+            if policy.rules[0].keep_for != 0:
+                policy.rules[0].keep_for = int(policy.rules[0].keep_for / 1000)
+            if policy.rules[0].every != 0:
+                policy.rules[0].every = int(policy.rules[0].every / 1000)
+
+            current_policy = {'time_zone': policy.rules[0].time_zone,
+                              'every': policy.rules[0].every,
+                              'keep_for': policy.rules[0].keep_for,
+                              'at': policy.rules[0].at,
+                              'enabled': policy.enabled}
+        if not module.params['every']:
+            every = 0
+        else:
+            every = module.params['every']
+        if not module.params['keep_for']:
+            keep_for = 0
+        else:
+            keep_for = module.params['keep_for']
+        if module.params['at']:
+            at_time = _convert_to_millisecs(module.params['at'])
+        else:
+            at_time = 0
+        new_policy = {'time_zone': module.params['timezone'],
+                      'every': every,
+                      'keep_for': keep_for,
+                      'at': at_time,
+                      'enabled': module.params['enabled']}
+        if new_policy['time_zone'] and new_policy['time_zone'] not in pytz.all_timezones_set:
+            module.fail_json(msg='Timezone {0} is not valid'.format(module.params['timezone']))
+
+        if current_policy != new_policy:
+            if not module.params['at']:
+                module.params['at'] = current_policy['at']
+            if not module.params['keep_for']:
+                module.params['keep_for'] = current_policy['keep_for']
+            if not module.params['every']:
+                module.params['every'] = current_policy['every']
+            if not module.params['timezone']:
+                module.params['timezone'] = current_policy['time_zone']
+            if module.params['at'] and module.params['every']:
+                if not module.params['every'] % 86400 == 0:
+                    module.fail_json(msg='At time can only be set if every value is a multiple of 86400')
+            if not module.params['timezone']:
+                module.params['timezone'] = _get_local_tz(module)
+                if module.params['timezone'] not in pytz.all_timezones_set:
+                    module.fail_json(msg='Timezone {0} is not valid'.format(module.params['timezone']))
+            if module.params['keep_for'] < module.params['every']:
+                module.fail_json(msg='Retention period cannot be less than snapshot interval.')
+            if module.params['at'] and not module.params['timezone']:
+                module.params['timezone'] = _get_local_tz(module)
+                if module.params['timezone'] not in set(pytz.all_timezones_set):
+                    module.fail_json(msg='Timezone {0} is not valid'.format(module.params['timezone']))
+
+            try:
+                attr = PolicyPatch()
+                attr.enabled = module.params['enabled']
+                attr.add_rules = [PolicyRule(keep_for=module.params['keep_for'] * 1000,
+                                             every=module.params['every'] * 1000,
+                                             at=at_time,
+                                             time_zone=module.params['timezone'])]
+                attr.remove_rules = [PolicyRule(keep_for=current_policy['keep_for'] * 1000,
+                                                every=current_policy['every'] * 1000,
+                                                at=current_policy['at'],
+                                                time_zone=current_policy['time_zone'])]
+                blade.policies.update_policies(names=[module.params['name']],
+                                               policy_patch=attr)
+                changed = True
+            except Exception:
+                module.fail_json(msg='Failed to update policy {0}.'.format(module.params['name']))
+        else:
+            changed = False
+    module.exit_json(changed=changed)
+
+
+def main():
+    argument_spec = purefb_argument_spec()
+    argument_spec.update(dict(
+        state=dict(type='str', default='present', choices=['absent', 'present']),
+        enabled=dict(type='bool', default=True),
+        timezone=dict(type='str'),
+        name=dict(type='str'),
+        at=dict(type='str'),
+        every=dict(type='int'),
+        keep_for=dict(type='int'),
+    ))
+
+    required_together = [['keep_for', 'every']]
+
+    module = AnsibleModule(argument_spec,
+                           required_together=required_together,
+                           supports_check_mode=True)
+
+    if not HAS_PURITYFB:
+        module.fail_json(msg='purity_fb sdk is required for this module')
+
+    state = module.params['state']
+    blade = get_blade(module)
+    try:
+        policy = blade.policies.list_policies(names=[module.params['name']])
+    except Exception:
+        policy = None
+
+    if policy and state == 'present':
+        update_policy(module, blade, policy.items[0])
+    elif state == 'present'and not policy:
+        create_policy(module, blade)
+    elif state == 'absent'and policy:
+        delete_policy(module, blade)
+
+    module.exit_json(changed=False)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
New module to manage snapshot policies

##### ISSUE TYPE
- Docs Pull Request
- New Module Pull Request

##### COMPONENT NAME
purefb_policy.py

##### ADDITIONAL INFORMATION
When specifying an `at` time with no timezone, the module will attempt to calculate the local timezone of the server running the playbook.
If the local timezone cannot be determined it will default to UTC.
There are about 593 approved timezones, but some you would expect to work, like EDT, are not official and therefore will fail and revert back to UTC.