### PR TITLE
Remove code that break Python 3.7 due to reserved keywords

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
@@ -487,16 +487,17 @@ def generate_perf_dict(blade):
     if REPLICATION_API_VERSION in api_version:
         file_repl_perf = blade.array_connections.list_array_connections_performance_replication(type='file-system')
         obj_repl_perf = blade.array_connections.list_array_connections_performance_replication(type='object-store')
-        if len(file_repl_perf.total):
-            perf_info['file_replication'] = {
-                'received_bytes_per_sec': file_repl_perf.total[0].async.received_bytes_per_sec,
-                'transmitted_bytes_per_sec': file_repl_perf.total[0].async.transmitted_bytes_per_sec,
-            }
-        if len(obj_repl_perf.total):
-            perf_info['object_replication'] = {
-                'received_bytes_per_sec': obj_repl_perf.total[0].async.received_bytes_per_sec,
-                'transmitted_bytes_per_sec': obj_repl_perf.total[0].async.transmitted_bytes_per_sec,
-            }
+        # TODO (SD): Only add in when new python SDK exists that support Python 3.7
+        # if len(file_repl_perf.total):
+        #     perf_info['file_replication'] = {
+        #         'received_bytes_per_sec': file_repl_perf.total[0].async.received_bytes_per_sec,
+        #         'transmitted_bytes_per_sec': file_repl_perf.total[0].async.transmitted_bytes_per_sec,
+        #     }
+        # if len(obj_repl_perf.total):
+        #     perf_info['object_replication'] = {
+        #         'received_bytes_per_sec': obj_repl_perf.total[0].async.received_bytes_per_sec,
+        #         'transmitted_bytes_per_sec': obj_repl_perf.total[0].async.transmitted_bytes_per_sec,
+        #     }
     return perf_info
 
 


### PR DESCRIPTION
##### SUMMARY
`async` is a reserved work in Python 3.7 so we can't use these performance parameters

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_info.py