### PR TITLE
Long documentation URL causes Ansible collections publish to fail

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/galaxy.yml
+++ b/collections/ansible_collections/purestorage/flashblade/galaxy.yml
@@ -16,5 +16,5 @@ tags:
   - nfs
 dependencies: {}
 repository: https://github.com/Pure-Storage-Ansible/FlashBlade-Collection
-documentation: https://github.com/Pure-Storage-Ansible/FlashBlade-Collection/tree/master/collections/ansible_collections/purestorage/flashblade/docs
+documentation: https://github.com/Pure-Storage-Ansible/FlashBlade-Collection
 issues: https://github.com/Pure-Storage-Ansible/FlashBlade-Collection/issues


### PR DESCRIPTION
##### SUMMARY
Red Hat request reduce the length of documentation string as it breaks their import engine for collections publishing

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
galaxy.yaml