### PR TITLE
Fix error file system names passed as string instead of list

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs_replica.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs_replica.py
@@ -97,7 +97,7 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb impo
 def get_local_fs(module, blade):
     """Return Filesystem or None"""
     try:
-        res = blade.file_systems.list_file_systems(names=module.params['name'])
+        res = blade.file_systems.list_file_systems(names=[module.params['name']])
         return res.items[0]
     except Exception:
         return None


### PR DESCRIPTION
##### SUMMARY
Fixes file systems name error by converting names from string to list.  

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_fs_replica.py
