### PR TITLE
Add ability to create a policy with fs and rl, and modify fs policy connections

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
@@ -64,6 +64,9 @@ options:
     description:
       - Define the NFS rules in operation.
       - If not set at filesystem creation time it defaults to I(*(rw,no_root_squash))
+      - Supported binary options are ro/rw, secure/insecure, fileid_32bit/no_fileid_32bit,
+        root_squash/no_root_squash, all_squash/no_all_squash and atime/noatime
+      - Supported non-binary options are anonuid=#, anongid=#, sec=(sys|krb5)
     required: false
     type: str
   smb:
@@ -72,6 +75,13 @@ options:
     required: false
     type: bool
     default: false
+  smb_aclmode:
+    description:
+      - Specify the ACL mode for the SMB protocol.
+    required: false
+    type: str
+    default: shared
+    choices: [ "shared", "native" ]
   http:
     description:
       - Define whether to HTTP/HTTPS protocol is enabled for the filesystem.
@@ -122,6 +132,18 @@ options:
     required: false
     type: str
     version_added: 2.9
+  policy:
+    description:
+      - Filesystem policy to assign to or remove from a filesystem.
+    required: false
+    type: str
+  policy_state:
+    description:
+    - Add or delete a policy from a filesystem
+    required: false
+    default: present
+    type: str
+    choices: [ "absent", "present" ]
 extends_documentation_fragment:
     - purestorage.flashblade.purestorage.fb
 '''
@@ -193,7 +215,7 @@ RETURN = '''
 
 HAS_PURITY_FB = True
 try:
-    from purity_fb import FileSystem, ProtocolRule, NfsRule
+    from purity_fb import FileSystem, ProtocolRule, NfsRule, SmbRule
 except ImportError:
     HAS_PURITY_FB = False
 
@@ -241,19 +263,35 @@ def create_fs(module, blade):
             api_version = blade.api_version.list_versions().versions
             if HARD_LIMIT_API_VERSION in api_version:
                 if NFSV4_API_VERSION in api_version:
-                    fs_obj = FileSystem(name=module.params['name'],
-                                        provisioned=size,
-                                        fast_remove_directory_enabled=module.params['fastremove'],
-                                        hard_limit_enabled=module.params['hard_limit'],
-                                        snapshot_directory_enabled=module.params['snapshot'],
-                                        nfs=NfsRule(v3_enabled=module.params['nfsv3'],
-                                                    v4_1_enabled=module.params['nfsv4'],
-                                                    rules=module.params['nfs_rules']),
-                                        smb=ProtocolRule(enabled=module.params['smb']),
-                                        http=ProtocolRule(enabled=module.params['http']),
-                                        default_user_quota=user_quota,
-                                        default_group_quota=group_quota
-                                        )
+                    if REPLICATION_API_VERSION in api_version:
+                        fs_obj = FileSystem(name=module.params['name'],
+                                            provisioned=size,
+                                            fast_remove_directory_enabled=module.params['fastremove'],
+                                            hard_limit_enabled=module.params['hard_limit'],
+                                            snapshot_directory_enabled=module.params['snapshot'],
+                                            nfs=NfsRule(v3_enabled=module.params['nfsv3'],
+                                                        v4_1_enabled=module.params['nfsv4'],
+                                                        rules=module.params['nfs_rules']),
+                                            smb=SmbRule(enabled=module.params['smb'],
+                                                        acl_mode=module.params['smb_aclmode']),
+                                            http=ProtocolRule(enabled=module.params['http']),
+                                            default_user_quota=user_quota,
+                                            default_group_quota=group_quota
+                                            )
+                    else:
+                        fs_obj = FileSystem(name=module.params['name'],
+                                            provisioned=size,
+                                            fast_remove_directory_enabled=module.params['fastremove'],
+                                            hard_limit_enabled=module.params['hard_limit'],
+                                            snapshot_directory_enabled=module.params['snapshot'],
+                                            nfs=NfsRule(v3_enabled=module.params['nfsv3'],
+                                                        v4_1_enabled=module.params['nfsv4'],
+                                                        rules=module.params['nfs_rules']),
+                                            smb=ProtocolRule(enabled=module.params['smb']),
+                                            http=ProtocolRule(enabled=module.params['http']),
+                                            default_user_quota=user_quota,
+                                            default_group_quota=group_quota
+                                            )
                 else:
                     fs_obj = FileSystem(name=module.params['name'],
                                         provisioned=size,
@@ -276,6 +314,20 @@ def create_fs(module, blade):
             blade.file_systems.create_file_systems(fs_obj)
         except Exception:
             module.fail_json(msg="Failed to create filesystem {0}.".format(module.params['name']))
+        if REPLICATION_API_VERSION in api_version:
+            if module.params['policy']:
+                try:
+                    blade.policies.list_policies(names=[module.params['policy']])
+                except Exception:
+                    _delete_fs(module, blade)
+                    module.fail_json(msg="Policy {0} doesn't exist.".format(module.params['policy']))
+                try:
+                    blade.policies.create_policy_filesystems(policy_names=[module.params['policy']],
+                                                             member_names=[module.params['name']])
+                except Exception:
+                    _delete_fs(module, blade)
+                    module.fail_json(msg="Failed to apply policy {0} when creating filesystem {1}.".format(module.params['policy'],
+                                                                                                           module.params['name']))
     module.exit_json(changed=changed)
 
 
@@ -283,8 +335,37 @@ def modify_fs(module, blade):
     """Modify Filesystem"""
     changed = True
     if not module.check_mode:
+        changed = False
         mod_fs = False
         attr = {}
+        if module.params['policy'] and module.params['policy_state'] == 'present':
+            try:
+                policy = blade.policies.list_policy_filesystems(policy_names=[module.params['policy']],
+                                                                member_names=[module.params['name']])
+            except Exception:
+                module.fail_json(msg='Policy {0} does not exist.'.format(module.params['policy']))
+            if not policy.items:
+                try:
+                    blade.policies.create_policy_filesystems(policy_names=[module.params['policy']],
+                                                             member_names=[module.params['name']])
+                    mod_fs = True
+                except Exception:
+                    module.fail_json(msg='Failed to add filesystem {0} to policy {1}.'.format(module.params['name'],
+                                                                                              module.params['polict']))
+        if module.params['policy'] and module.params['policy_state'] == 'absent':
+            try:
+                policy = blade.policies.list_policy_filesystems(policy_names=[module.params['policy']],
+                                                                member_names=[module.params['name']])
+            except Exception:
+                module.fail_json(msg='Policy {0} does not exist.'.format(module.params['policy']))
+            if len(policy.items) == 1:
+                try:
+                    blade.policies.delete_policy_filesystems(policy_names=[module.params['policy']],
+                                                             member_names=[module.params['name']])
+                    mod_fs = True
+                except Exception:
+                    module.fail_json(msg='Failed to remove filesystem {0} to policy {1}.'.format(module.params['name'],
+                                                                                                 module.params['polict']))
         if module.params['user_quota']:
             user_quota = human_to_bytes(module.params['user_quota'])
         if module.params['group_quota']:
@@ -333,12 +414,26 @@ def modify_fs(module, blade):
                 if fsys.nfs.rules != module.params['nfs_rules']:
                     attr['nfs'] = NfsRule(rules=module.params['nfs_rules'])
                     mod_fs = True
-        if module.params['smb'] and not fsys.smb.enabled:
-            attr['smb'] = ProtocolRule(enabled=module.params['smb'])
-            mod_fs = True
-        if not module.params['smb'] and fsys.smb.enabled:
-            attr['smb'] = ProtocolRule(enabled=module.params['smb'])
-            mod_fs = True
+        if REPLICATION_API_VERSION in api_version:
+            if module.params['smb'] and not fsys.smb.enabled:
+                attr['smb'] = SmbRule(enabled=module.params['smb'],
+                                      acl_mode=module.params['smb_aclmode'])
+                mod_fs = True
+            if not module.params['smb'] and fsys.smb.enabled:
+                attr['smb'] = ProtocolRule(enabled=module.params['smb'])
+                mod_fs = True
+            if module.params['smb'] and fsys.smb.enabled:
+                if fsys.smb.acl_mode != module.params['smb_aclmode']:
+                    attr['smb'] = SmbRule(enabled=module.params['smb'],
+                                          acl_mode=module.params['smb_aclmode'])
+                    mod_fs = True
+        else:
+            if module.params['smb'] and not fsys.smb.enabled:
+                attr['smb'] = ProtocolRule(enabled=module.params['smb'])
+                mod_fs = True
+            if not module.params['smb'] and fsys.smb.enabled:
+                attr['smb'] = ProtocolRule(enabled=module.params['smb'])
+                mod_fs = True
         if module.params['http'] and not fsys.http.enabled:
             attr['http'] = ProtocolRule(enabled=module.params['http'])
             mod_fs = True
@@ -357,7 +452,6 @@ def modify_fs(module, blade):
         if not module.params['fastremove'] and fsys.fast_remove_directory_enabled:
             attr['fast_remove_directory_enabled'] = module.params['fastremove']
             mod_fs = True
-        api_version = blade.api_version.list_versions().versions
         if HARD_LIMIT_API_VERSION in api_version:
             if not module.params['hard_limit'] and fsys.hard_limit_enabled:
                 attr['hard_limit_enabled'] = module.params['hard_limit']
@@ -373,26 +467,48 @@ def modify_fs(module, blade):
                 if module.params['writable'] and not fsys.writable and fsys.promotion_status == 'promoted':
                     attr['writable'] = module.params['writable']
                     mod_fs = True
-            if module.params['promote'] and fsys.promotion_status != 'promoted':
-                attr['requested_promotion_state'] = 'promoted'
-                mod_fs = True
-            if not module.params['promote'] and fsys.promotion_status == 'promoted':
-                # Demotion only allowed on filesystems in a replica-link
-                try:
-                    blade.file_system_replica_links.list_file_system_replica_links(local_file_system_names=[module.params['name']]).items[0]
-                except Exception:
-                    module.fail_json(msg='Filesystem {0} not demoted. Not in a replica-link'.format(module.params['name']))
-                attr['requested_promotion_state'] = module.params['promote']
-                mod_fs = True
+            if module.params['promote'] is not None:
+                if module.params['promote'] and fsys.promotion_status != 'promoted':
+                    attr['requested_promotion_state'] = 'promoted'
+                    mod_fs = True
+                if not module.params['promote'] and fsys.promotion_status == 'promoted':
+                    # Demotion only allowed on filesystems in a replica-link
+                    try:
+                        blade.file_system_replica_links.list_file_system_replica_links(local_file_system_names=[module.params['name']]).items[0]
+                    except Exception:
+                        module.fail_json(msg='Filesystem {0} not demoted. Not in a replica-link'.format(module.params['name']))
+                    attr['requested_promotion_state'] = module.params['promote']
+                    mod_fs = True
         if mod_fs:
             n_attr = FileSystem(**attr)
             try:
                 blade.file_systems.update_file_systems(name=module.params['name'], attributes=n_attr)
+                changed = True
             except Exception:
                 module.fail_json(msg="Failed to update filesystem {0}.".format(module.params['name']))
-        else:
-            changed = False
     module.exit_json(changed=changed)
+
+
+def _delete_fs(module, blade):
+    """ In module Delete Filesystem"""
+    api_version = blade.api_version.list_versions().versions
+    if NFSV4_API_VERSION in api_version:
+        blade.file_systems.update_file_systems(name=module.params['name'],
+                                               attributes=FileSystem(nfs=NfsRule(v3_enabled=False,
+                                                                                 v4_1_enabled=False),
+                                                                     smb=ProtocolRule(enabled=False),
+                                                                     http=ProtocolRule(enabled=False),
+                                                                     destroyed=True)
+                                               )
+    else:
+        blade.file_systems.update_file_systems(name=module.params['name'],
+                                               attributes=FileSystem(nfs=NfsRule(enabled=False),
+                                                                     smb=ProtocolRule(enabled=False),
+                                                                     http=ProtocolRule(enabled=False),
+                                                                     destroyed=True)
+                                               )
+
+    blade.file_systems.delete_file_systems(module.params['name'])
 
 
 def delete_fs(module, blade):
@@ -455,7 +571,10 @@ def main():
             fastremove=dict(default='false', type='bool'),
             hard_limit=dict(default='false', type='bool'),
             user_quota=dict(type='str'),
+            policy=dict(type='str'),
             group_quota=dict(type='str'),
+            smb_aclmode=dict(type='str', default='shared', choices=['shared', 'native']),
+            policy_state=dict(default='present', choices=['present', 'absent']),
             state=dict(default='present', choices=['present', 'absent']),
             size=dict(type='str')
         )


### PR DESCRIPTION
##### SUMMARY
Update snapshot policy creation to allow immediate addition of existing filesystems or filesystem replica links.

Add the ability to modify a filesystem and add and remove snapshot policies.

Add acl_mode setting for SMB filesystem.

Update filesystem docs section to identify all supported filesystem options for export rules.

##### ISSUE TYPE
- Feature Pull Request
- Docs Pull request

##### COMPONENT NAME
purefb_fs.py
purefb_policy.py