### PR TITLE
Make join_ou not mandatory

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_ds.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_ds.py
@@ -293,8 +293,7 @@ def main():
     ))
 
     required_together = [['uri', 'bind_password', 'bind_user', 'base_dn'],
-                         ['nis_servers', 'nis_domain'],
-                         ['join_ou', 'uri']]
+                         ['nis_servers', 'nis_domain']]
     mutually_exclusive = [['uri', 'nis_domain']]
 
     module = AnsibleModule(argument_spec,


### PR DESCRIPTION
##### SUMMARY
Remove join_ou as a required option when uri is specified for SMB

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_ds.py