### PR TITLE
Add condition to exit module gracefully when state is absent and filesystem not eradicated

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
@@ -600,7 +600,6 @@ def main():
         eradicate_fs(module, blade)
     elif state == 'absent' and not fsys:
         module.exit_json(changed=False)
-    
     module.exit_json(changed=False)
 
 if __name__ == '__main__':

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
@@ -598,6 +598,8 @@ def main():
         delete_fs(module, blade)
     elif state == 'absent' and fsys and fsys.destroyed and module.params['eradicate']:
         eradicate_fs(module, blade)
+    elif state == 'absent' and fsys and fsys.destroyed:
+        module.exit_json(changed=False)
     elif state == 'absent' and not fsys:
         module.exit_json(changed=False)
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
@@ -598,11 +598,10 @@ def main():
         delete_fs(module, blade)
     elif state == 'absent' and fsys and fsys.destroyed and module.params['eradicate']:
         eradicate_fs(module, blade)
-    elif state == 'absent' and fsys and fsys.destroyed:
-        module.exit_json(changed=False)
     elif state == 'absent' and not fsys:
         module.exit_json(changed=False)
-
+    
+    module.exit_json(changed=False)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
Add a condition to exit module gracefully when the state is absent and filesystem not eradicated

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_fs.py
