### PR TITLE
Add warning message if eradicate: true without state: absent

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_bucket.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_bucket.py
@@ -267,6 +267,9 @@ def main():
     if not get_s3acc(module, blade):
         module.fail_json(msg="Object Store Account {0} does not exist.".format(module.params['account']))
 
+    if module.params['eradicate'] and state == 'present':
+        module.warn('Eradicate flag ignored without state=absent')
+
     if state == 'present' and not bucket:
         create_bucket(module, blade)
     elif state == 'present' and bucket and bucket.destroyed:

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
@@ -590,6 +590,9 @@ def main():
     blade = get_blade(module)
     fsys = get_fs(module, blade)
 
+    if module.params['eradicate'] and state == 'present':
+        module.warn('Eradicate flag ignored without state=absent')
+
     if state == 'present' and not fsys:
         create_fs(module, blade)
     elif state == 'present' and fsys:


### PR DESCRIPTION
##### SUMMARY
If `eradicate: true` is set without `state: absent` then send a warning message

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_fs.py
purefb_bucket.py