### PR TITLE
Update filesystem Replica module

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/78_update_filesystem_replica_link.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/78_update_filesystem_replica_link.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefb_fs_replica - Remove condition to attach/detach policies on unhealthy replica-link

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs_replica.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs_replica.py
@@ -229,9 +229,6 @@ def main():
     if not local_fs:
         module.fail_json(msg='Selected local filesystem {0} does not exist.'.format(module.params['name']))
 
-    if local_replica_link:
-        if local_replica_link.status == 'unhealthy':
-            module.fail_json(msg='Replca Link unhealthy - please check remote array')
     if module.params['policy']:
         try:
             policy = blade.policies.list_policies(names=[module.params['policy']])

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
@@ -830,10 +830,6 @@ def generate_fs_dict(blade):
                 'is_local': fsys.items[fsystem].source.is_local,
                 'name': fsys.items[fsystem].source.name
             }
-            fs_info[share]['policies'] = []
-            fpolicy = blade.file_systems.list_filesystem_policies(member_names=[share])
-            for item in fpolicy.items:
-                fs_info[share]['policies'].append(item.policy.name)
     return fs_info
 
 


### PR DESCRIPTION
##### SUMMARY
purefb_fs_replica: Remove condition, where the module does not allow to attach/detach policies on unhealthy replica-link. Replica-link becomes unhealthy when both filesystems are promoted. This is an expected temporary state during failover. 

##### ISSUE TYPE
- Bugfix Pull Request
