### PR TITLE
Deal with exisitng reverse connection

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/80_support_reverse_replica_link.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/80_support_reverse_replica_link.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefb_connect - Support idempotency when exisitng connection is incoming

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_connect.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_connect.py
@@ -80,6 +80,15 @@ MIN_REQUIRED_API_VERSION = '1.9'
 def _check_connected(module, blade):
     connected_blades = blade.array_connections.list_array_connections()
     for target in range(0, len(connected_blades.items)):
+        if connected_blades.items[target].management_address is None:
+            try:
+                remote_system = PurityFb(module.params['target_url'])
+                remote_system.login(module.params['target_api'])
+                remote_array = remote_system.arrays.list_arrays().items[0].name
+                if connected_blades.items[target].remote.name == remote_array:
+                    return connected_blades.items[target]
+            except Exception:
+                module.fail_json(msg="Failed to connect to remote array {0}.".format(module.params['target_url']))
         if connected_blades.items[target].management_address == module.params['target_url'] and \
            connected_blades.items[target].status in ["connected", "connecting", "partially_connected"]:
             return connected_blades.items[target]


### PR DESCRIPTION
##### SUMMARY
If trying to create a connection where an existing is incoming then this will fail even if the incoming connection is wit the correct array.

This resolves the issue by double-checking the remote array name is the incoming mgmt address is None

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_connect