### PR TITLE
Add two new options for filesystem deletion and modification

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/81_purefb_fs_new_options.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/81_purefb_fs_new_options.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefb_fs - Add new options for filesystem control (https://github.com/Pure-Storage-Ansible/FlashBlade-Collection/pull/81)


### PR DESCRIPTION
##### SUMMARY
Add new options:

delete_link - allows a filesystem to be deleted if connected to a replica link (default: false)
discard_snaps - allow a filesystem to be demoted if snapshots exist (default: false)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_fs.py

#### ADDITONAL INFORMATION

**delete_link** - If set to `true`, the file system can be destroyed, even if it has a replica link. If set to `false`, the file system cannot be destroyed if it has a replica link. Defaults to `false`.
**discard_snaps** - This parameter must be set to `true` in order to demote a file system (which restores the file system from the common baseline snapshot). Setting this parameter to `true` is an acknowledgement that any non-snapshotted data currently in the file system will be irretrievably lost. Defaults to `false`