### PR TITLE
purefb_connect - Fix issue caused by breaking change in SDK 1.9.2+

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/90_delete_conn_fix.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/90_delete_conn_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefb_connect - Fix breaking change created in purity_fb SDK 1.9.2 for deletion of array connections

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_connect.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_connect.py
@@ -103,7 +103,7 @@ def break_connection(module, blade, target_blade):
         try:
             if target_blade.management_address is None:
                 module.fail_json(msg="disconnect can only happen from the array that formed the connection")
-            blade.array_connections.delete_array_connections(name=target_blade.remote.name, ids=[target_blade.id])
+            blade.array_connections.delete_array_connections(remote_names=[target_blade.remote.name])
         except Exception:
             module.fail_json(msg="Failed to disconnect {0} from {1}.".format(target_blade.remote.name, source_blade))
     module.exit_json(changed=changed)


### PR DESCRIPTION
##### SUMMARY
purity_fb SDK 1.9.2 created a breaking change from 1.9.1 for the `delete_array_connections` API call.

This PR resolves that making purity_fb 1.9.1 unsupported

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_connect.py