### PR TITLE
Fix info crash for encrypted array connection

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/97_fix_encrpyted_array_connection_info.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/97_fix_encrpyted_array_connection_info.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_info - Fix issue getting array info when encrypted connection exists

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
@@ -764,7 +764,7 @@ def generate_array_conn_dict(blade):
             'version': arrays.items[arraycnt].version,
         }
         if arrays.items[arraycnt].encrypted:
-            array_conn_info[array]['ca_certificate_group'] = arrays.items[arraycnt].ca_certificate_group
+            array_conn_info[array]['ca_certificate_group'] = arrays.items[arraycnt].ca_certificate_group.name
     return array_conn_info
 
 


### PR DESCRIPTION
##### SUMMARY
Resolve bug for info module getting connected arrays info when connection is encrypted
Raised by issue #93 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_info.py