### PR TITLE
Fix multiple error scenarios with timezone in policy module

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/101_fix_policy_and_timezone_error.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/101_fix_policy_and_timezone_error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefa_policy - Resolve multiple issues related to incorrect use of timezones


### PR DESCRIPTION
##### SUMMARY
Resolve errors when a null timezone was causing errors with none timezone related policies and
also not reverting to system timezone if timezone parameter not defined

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_policy.py