### PR TITLE
Add remove_key option to s3user

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/107_add_remove_s3user_key.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/107_add_remove_s3user_key.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefb_s3user - Add ability to remove an S3 users existing access key


### PR DESCRIPTION
##### SUMMARY
Add `remove_key` as new `state` to allow an S3 users existing access key to be deleted

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_s3user.py

##### ADDITIONAL INFORMATION
Example playbook to create a user key and then delete it:
```
    - name: Create s3 user with key
      purefb_s3user:
        name:  demo
        account: test
        access_key: true
      register: user_info

    - name: Remove key
      purefb_s3user:
        name: demo
        account: test
        state: remove_key
        remove_key: "{{ user_info.s3user_info.fb_s3user.access_id }}"
      when: user_info.s3user_info.fb_s3user.access_id is defined
```