### PR TITLE
Fix return value of "changed" in check_mode for all modules

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/112_fix_check_mode.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/112_fix_check_mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefb_* - Return a correct value for `changed` in all modules when in check mode

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_alert.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_alert.py
@@ -113,23 +113,23 @@ def create_alert(module, blade):
 
 def update_alert(module, blade):
     """Update alert Watcher"""
-    changed = True
-    if not module.check_mode:
-        api_version = blade.api_version.list_versions().versions
-        mod_alert = False
-        try:
-            alert = blade.alert_watchers.list_alert_watchers(names=[module.params['address']])
-        except Exception:
-            module.fail_json(msg='Failed to get information for alert email: {0}'.format(module.params['address']))
-        current_state = {'enabled': alert.items[0].enabled,
-                         'severity': alert.items[0].minimum_notification_severity
-                         }
-        if current_state['enabled'] != module.params['enabled']:
+    api_version = blade.api_version.list_versions().versions
+    mod_alert = False
+    try:
+        alert = blade.alert_watchers.list_alert_watchers(names=[module.params['address']])
+    except Exception:
+        module.fail_json(msg='Failed to get information for alert email: {0}'.format(module.params['address']))
+    current_state = {'enabled': alert.items[0].enabled,
+                     'severity': alert.items[0].minimum_notification_severity
+                     }
+    if current_state['enabled'] != module.params['enabled']:
+        mod_alert = True
+    if MIN_REQUIRED_API_VERSION in api_version:
+        if current_state['severity'] != module.params['severity']:
             mod_alert = True
-        if MIN_REQUIRED_API_VERSION in api_version:
-            if current_state['severity'] != module.params['severity']:
-                mod_alert = True
-        if mod_alert:
+    if mod_alert:
+        changed = True
+        if not module.check_mode:
             if MIN_REQUIRED_API_VERSION in api_version:
                 watcher_settings = AlertWatcher(enabled=module.params['enabled'],
                                                 minimum_notification_severity=module.params['severity'])
@@ -139,20 +139,19 @@ def update_alert(module, blade):
                 blade.alert_watchers.update_alert_watchers(names=[module.params['address']], watcher_settings=watcher_settings)
             except Exception:
                 module.fail_json(msg='Failed to update alert email: {0}'.format(module.params['address']))
-        else:
-            changed = False
+    else:
+        changed = False
     module.exit_json(changed=changed)
 
 
 def delete_alert(module, blade):
     """Delete Alert Email"""
-    changed = False
+    changed = True
     if not module.check_mode:
         try:
             blade.alert_watchers.delete_alert_watchers(names=[module.params['address']])
         except Exception:
             module.fail_json(msg='Failed to delete alert email: {0}'.format(module.params['address']))
-    changed = True
 
     module.exit_json(changed=changed)
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_bucket.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_bucket.py
@@ -201,25 +201,27 @@ def recover_bucket(module, blade):
 
 def update_bucket(module, blade, bucket):
     """ Update Bucket """
-    changed = True
-    if not module.check_mode:
-        changed = False
-        api_version = blade.api_version.list_versions().versions
-        if VERSIONING_VERSION in api_version:
-            module.warn('{0}'.format(bucket.versioning))
-            if bucket.versioning != 'none':
-                if module.params['versioning'] == 'absent':
-                    versioning = 'suspended'
-                else:
-                    versioning = module.params['versioning']
-                if bucket.versioning != versioning:
+    changed = False
+    api_version = blade.api_version.list_versions().versions
+    if VERSIONING_VERSION in api_version:
+        module.warn('{0}'.format(bucket.versioning))
+        if bucket.versioning != 'none':
+            if module.params['versioning'] == 'absent':
+                versioning = 'suspended'
+            else:
+                versioning = module.params['versioning']
+            if bucket.versioning != versioning:
+                changed = True
+                if not module.check_mode:
                     try:
                         blade.buckets.update_buckets(names=[module.params['name']],
                                                      bucket=BucketPatch(versioning=versioning))
                         changed = True
                     except Exception:
                         module.fail_json(msg='Object Store Bucket {0}: Versioning change failed'.format(module.params['name']))
-            elif module.params['versioning'] != 'absent':
+        elif module.params['versioning'] != 'absent':
+            changed = True
+            if not module.check_mode:
                 try:
                     blade.buckets.update_buckets(names=[module.params['name']],
                                                  bucket=BucketPatch(versioning=module.params['versioning']))

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_bucket_replica.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_bucket_replica.py
@@ -162,11 +162,11 @@ def create_rl(module, blade, remote_cred):
 
 def update_rl_policy(module, blade, local_replica_link):
     """Update Bucket Replica Link"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        new_cred = local_replica_link.remote.name + '/' + module.params['credential']
-        if local_replica_link.paused != module.params['paused'] or local_replica_link.remote_credentials.name != new_cred:
+    changed = False
+    new_cred = local_replica_link.remote.name + '/' + module.params['credential']
+    if local_replica_link.paused != module.params['paused'] or local_replica_link.remote_credentials.name != new_cred:
+        changed = True
+        if not module.check_mode:
             try:
                 module.warn('{0}'.format(local_replica_link))
                 blade.bucket_replica_links.update_bucket_replica_links(

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_bucket_replica.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_bucket_replica.py
@@ -175,7 +175,6 @@ def update_rl_policy(module, blade, local_replica_link):
                     remote_names=[local_replica_link.remote.name],
                     bucket_replica_link=BucketReplicaLink(paused=module.params['paused'],
                                                           remote_credentials=ObjectStoreRemoteCredentials(name=new_cred)))
-                changed = True
             except Exception:
                 module.fail_json(msg="Failed to update bucket replica link {0}.".format(module.params['name']))
     module.exit_json(changed=changed)

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_certgrp.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_certgrp.py
@@ -112,15 +112,15 @@ def create_certgrp(module, blade):
 
 def update_certgrp(module, blade):
     """Update certificate group"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        try:
-            certs = blade.certificate_groups.list_certificate_group_certificates(certificate_group_names=[module.params['name']])
-        except Exception:
-            module.fail_json(msg="Failed to get certifates list for group {0}.".format(module.params['name']))
-        if not certs:
-            if module.params['state'] == 'present':
+    changed = False
+    try:
+        certs = blade.certificate_groups.list_certificate_group_certificates(certificate_group_names=[module.params['name']])
+    except Exception:
+        module.fail_json(msg="Failed to get certifates list for group {0}.".format(module.params['name']))
+    if not certs:
+        if module.params['state'] == 'present':
+            changed = True
+            if not module.check_mode:
                 try:
                     blade.certificate_groups.add_certificate_group_certificates(certificate_names=module.params['certificates'],
                                                                                 certificate_group_names=[module.params['name']])
@@ -128,22 +128,26 @@ def update_certgrp(module, blade):
                 except Exception:
                     module.fail_json(msg="Failed to add certifcates {0}. "
                                      "Please check they all exist".format(module.params['certificates']))
-        else:
-            current = []
-            for cert in range(0, len(certs.items)):
-                current.append(certs.items[cert].member.name)
-            for new_cert in range(0, len(module.params['certificates'])):
-                certificate = module.params['certificates'][new_cert]
-                if certificate in current:
-                    if module.params['state'] == 'absent':
+    else:
+        current = []
+        for cert in range(0, len(certs.items)):
+            current.append(certs.items[cert].member.name)
+        for new_cert in range(0, len(module.params['certificates'])):
+            certificate = module.params['certificates'][new_cert]
+            if certificate in current:
+                if module.params['state'] == 'absent':
+                    changed = True
+                    if not module.check_mode:
                         try:
                             blade.certificate_groups.remove_certificate_group_certificates(certificate_names=[certificate],
                                                                                            certificate_group_names=[module.params['name']])
                             changed = True
                         except Exception:
                             module.fail_json(msg="Failed to delete certifcate {0} from group {1}.".format(certificate, module.params['name']))
-                else:
-                    if module.params['state'] == 'present':
+            else:
+                if module.params['state'] == 'present':
+                    changed = True
+                    if not module.check_mode:
                         try:
                             blade.certificate_groups.add_certificate_group_certificates(certificate_names=[certificate],
                                                                                         certificate_group_names=[module.params['name']])

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_certgrp.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_certgrp.py
@@ -124,7 +124,6 @@ def update_certgrp(module, blade):
                 try:
                     blade.certificate_groups.add_certificate_group_certificates(certificate_names=module.params['certificates'],
                                                                                 certificate_group_names=[module.params['name']])
-                    changed = True
                 except Exception:
                     module.fail_json(msg="Failed to add certifcates {0}. "
                                      "Please check they all exist".format(module.params['certificates']))
@@ -141,7 +140,6 @@ def update_certgrp(module, blade):
                         try:
                             blade.certificate_groups.remove_certificate_group_certificates(certificate_names=[certificate],
                                                                                            certificate_group_names=[module.params['name']])
-                            changed = True
                         except Exception:
                             module.fail_json(msg="Failed to delete certifcate {0} from group {1}.".format(certificate, module.params['name']))
             else:
@@ -151,7 +149,6 @@ def update_certgrp(module, blade):
                         try:
                             blade.certificate_groups.add_certificate_group_certificates(certificate_names=[certificate],
                                                                                         certificate_group_names=[module.params['name']])
-                            changed = True
                         except Exception:
                             module.fail_json(msg="Failed to add certifcate {0} to group {1}".format(certificate, module.params['name']))
     module.exit_json(changed=changed)

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_connect.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_connect.py
@@ -143,10 +143,12 @@ def update_connection(module, blade, target_blade):
             if module.params['encrypted'] and blade.file_system_replica_links.list_file_system_replica_links().pagination_info.total_item_count != 0:
                 module.fail_json(msg='Cannot turn array connection encryption on if file system replica links exist')
             new_attr = ArrayConnection(encrypted=module.params['encrypted'])
-            try:
-                blade.array_connections.update_array_connections(remote_names=[target_blade.remote.name], array_connection=new_attr)
-            except Exception:
-                module.fail_json(msg='Failed to change encryption setting for array connection.')
+            changed = True
+            if not module.check_mode:
+                try:
+                    blade.array_connections.update_array_connections(remote_names=[target_blade.remote.name], array_connection=new_attr)
+                except Exception:
+                    module.fail_json(msg='Failed to change encryption setting for array connection.')
         else:
             changed = False
     module.exit_json(changed=changed)

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_dns.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_dns.py
@@ -106,22 +106,22 @@ def delete_dns(module, blade):
 
 def update_dns(module, blade):
     """Set DNS Settings"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        current_dns = blade.dns.list_dns()
-        if module.params['domain']:
-            if current_dns.items[0].domain != module.params['domain']:
+    changed = False
+    current_dns = blade.dns.list_dns()
+    if module.params['domain']:
+        if current_dns.items[0].domain != module.params['domain']:
+            changed = True
+            if not module.check_mode:
                 try:
                     blade.dns.update_dns(dns_settings=Dns(domain=module.params['domain']))
-                    changed = True
                 except Exception:
                     module.fail_json(msg='Update of DNS domain failed')
-        if module.params['nameservers']:
-            if sorted(module.params['nameservers']) != sorted(current_dns.items[0].nameservers):
+    if module.params['nameservers']:
+        if sorted(module.params['nameservers']) != sorted(current_dns.items[0].nameservers):
+            changed = True
+            if not module.check_mode:
                 try:
                     blade.dns.update_dns(dns_settings=Dns(nameservers=module.params['nameservers']))
-                    changed = True
                 except Exception:
                     module.fail_json(msg='Update of DNS nameservers failed')
     module.exit_json(changed=changed)

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_ds.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_ds.py
@@ -227,53 +227,51 @@ def delete_ds(module, blade):
 
 def update_ds(module, blade):
     """Update Directory Service"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        mod_ds = False
-        attr = {}
-        try:
-            ds_now = blade.directory_services.list_directory_services(names=[module.params['dstype']]).items[0]
-            if module.params['dstype'] == 'nfs' and module.params['nis_servers']:
-                if sorted(module.params['nis_servers']) != sorted(ds_now.nfs.nis_servers) or \
-                        module.params['nis_domain'] != ''.join(map(str, ds_now.nfs.nis_domains)):
-                    attr['nfs'] = {'nis_domains': [module.params['nis_domain']],
-                                   'nis_servers': module.params['nis_servers'][0:30]}
+    mod_ds = False
+    attr = {}
+    try:
+        ds_now = blade.directory_services.list_directory_services(names=[module.params['dstype']]).items[0]
+        if module.params['dstype'] == 'nfs' and module.params['nis_servers']:
+            if sorted(module.params['nis_servers']) != sorted(ds_now.nfs.nis_servers) or \
+                    module.params['nis_domain'] != ''.join(map(str, ds_now.nfs.nis_domains)):
+                attr['nfs'] = {'nis_domains': [module.params['nis_domain']],
+                               'nis_servers': module.params['nis_servers'][0:30]}
+                mod_ds = True
+        else:
+            if module.params['uri']:
+                if sorted(module.params['uri'][0:30]) != sorted(ds_now.uris):
+                    attr['uris'] = module.params['uri'][0:30]
                     mod_ds = True
-            else:
-                if module.params['uri']:
-                    if sorted(module.params['uri'][0:30]) != sorted(ds_now.uris):
-                        attr['uris'] = module.params['uri'][0:30]
-                        mod_ds = True
-                if module.params['base_dn']:
-                    if module.params['base_dn'] != ds_now.base_dn:
-                        attr['base_dn'] = module.params['base_dn']
-                        mod_ds = True
-                if module.params['bind_user']:
-                    if module.params['bind_user'] != ds_now.bind_user:
-                        attr['bind_user'] = module.params['bind_user']
-                        mod_ds = True
-                if module.params['enable']:
-                    if module.params['enable'] != ds_now.enabled:
-                        attr['enabled'] = module.params['enable']
-                        mod_ds = True
-                if module.params['bind_password']:
-                    attr['bind_password'] = module.params['bind_password']
+            if module.params['base_dn']:
+                if module.params['base_dn'] != ds_now.base_dn:
+                    attr['base_dn'] = module.params['base_dn']
                     mod_ds = True
-                if module.params['dstype'] == 'smb':
-                    if module.params['join_ou'] != ds_now.smb.join_ou:
-                        attr['smb'] = {'join_ou': module.params['join_ou']}
-                        mod_ds = True
-            if mod_ds:
+            if module.params['bind_user']:
+                if module.params['bind_user'] != ds_now.bind_user:
+                    attr['bind_user'] = module.params['bind_user']
+                    mod_ds = True
+            if module.params['enable']:
+                if module.params['enable'] != ds_now.enabled:
+                    attr['enabled'] = module.params['enable']
+                    mod_ds = True
+            if module.params['bind_password']:
+                attr['bind_password'] = module.params['bind_password']
+                mod_ds = True
+            if module.params['dstype'] == 'smb':
+                if module.params['join_ou'] != ds_now.smb.join_ou:
+                    attr['smb'] = {'join_ou': module.params['join_ou']}
+                    mod_ds = True
+        if mod_ds:
+            changed = True
+            if not module.check_mode:
                 n_attr = DirectoryService(**attr)
                 try:
                     blade.directory_services.update_directory_services(names=[module.params['dstype']],
                                                                        directory_service=n_attr)
                 except Exception:
                     module.fail_json(msg='Failed to change {0} directory service.'.format(module.params['dstype']))
-        except Exception:
-            module.fail_json(msg='Failed to get current {0} directory service.'.format(module.params['dstype']))
-        changed = True
+    except Exception:
+        module.fail_json(msg='Failed to get current {0} directory service.'.format(module.params['dstype']))
     module.exit_json(changed=changed)
 
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_dsrole.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_dsrole.py
@@ -96,17 +96,16 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb impo
 
 def update_role(module, blade):
     """Update Directory Service Role"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        role = blade.directory_services.list_directory_services_roles(names=[module.params['role']])
-        if role.items[0].group_base != module.params['group_base'] or role.items[0].group != module.params['group']:
+    changed = False
+    role = blade.directory_services.list_directory_services_roles(names=[module.params['role']])
+    if role.items[0].group_base != module.params['group_base'] or role.items[0].group != module.params['group']:
+        changed = True
+        if not module.check_mode:
             try:
                 role = DirectoryServiceRole(group_base=module.params['group_base'],
                                             group=module.params['group'])
                 blade.directory_services.update_directory_services_roles(names=[module.params['role']],
                                                                          directory_service_role=role)
-                changed = True
             except Exception:
                 module.fail_json(msg='Update Directory Service Role {0} failed'.format(module.params['role']))
     module.exit_json(changed=changed)

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
@@ -340,165 +340,163 @@ def create_fs(module, blade):
 
 def modify_fs(module, blade):
     """Modify Filesystem"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        mod_fs = False
-        attr = {}
-        if module.params['policy'] and module.params['policy_state'] == 'present':
+    changed = False
+    mod_fs = False
+    attr = {}
+    if module.params['policy'] and module.params['policy_state'] == 'present':
+        try:
+            policy = blade.policies.list_policy_filesystems(policy_names=[module.params['policy']],
+                                                            member_names=[module.params['name']])
+        except Exception:
+            module.fail_json(msg='Policy {0} does not exist.'.format(module.params['policy']))
+        if not policy.items:
             try:
-                policy = blade.policies.list_policy_filesystems(policy_names=[module.params['policy']],
-                                                                member_names=[module.params['name']])
+                blade.policies.create_policy_filesystems(policy_names=[module.params['policy']],
+                                                         member_names=[module.params['name']])
+                mod_fs = True
             except Exception:
-                module.fail_json(msg='Policy {0} does not exist.'.format(module.params['policy']))
-            if not policy.items:
-                try:
-                    blade.policies.create_policy_filesystems(policy_names=[module.params['policy']],
-                                                             member_names=[module.params['name']])
-                    mod_fs = True
-                except Exception:
-                    module.fail_json(msg='Failed to add filesystem {0} to policy {1}.'.format(module.params['name'],
-                                                                                              module.params['polict']))
-        if module.params['policy'] and module.params['policy_state'] == 'absent':
+                module.fail_json(msg='Failed to add filesystem {0} to policy {1}.'.format(module.params['name'],
+                                                                                          module.params['polict']))
+    if module.params['policy'] and module.params['policy_state'] == 'absent':
+        try:
+            policy = blade.policies.list_policy_filesystems(policy_names=[module.params['policy']],
+                                                            member_names=[module.params['name']])
+        except Exception:
+            module.fail_json(msg='Policy {0} does not exist.'.format(module.params['policy']))
+        if len(policy.items) == 1:
             try:
-                policy = blade.policies.list_policy_filesystems(policy_names=[module.params['policy']],
-                                                                member_names=[module.params['name']])
+                blade.policies.delete_policy_filesystems(policy_names=[module.params['policy']],
+                                                         member_names=[module.params['name']])
+                mod_fs = True
             except Exception:
-                module.fail_json(msg='Policy {0} does not exist.'.format(module.params['policy']))
-            if len(policy.items) == 1:
-                try:
-                    blade.policies.delete_policy_filesystems(policy_names=[module.params['policy']],
-                                                             member_names=[module.params['name']])
-                    mod_fs = True
-                except Exception:
-                    module.fail_json(msg='Failed to remove filesystem {0} to policy {1}.'.format(module.params['name'],
-                                                                                                 module.params['polict']))
-        if module.params['user_quota']:
-            user_quota = human_to_bytes(module.params['user_quota'])
-        if module.params['group_quota']:
-            group_quota = human_to_bytes(module.params['group_quota'])
-        fsys = get_fs(module, blade)
-        if fsys.destroyed:
-            attr['destroyed'] = False
+                module.fail_json(msg='Failed to remove filesystem {0} to policy {1}.'.format(module.params['name'],
+                                                                                             module.params['polict']))
+    if module.params['user_quota']:
+        user_quota = human_to_bytes(module.params['user_quota'])
+    if module.params['group_quota']:
+        group_quota = human_to_bytes(module.params['group_quota'])
+    fsys = get_fs(module, blade)
+    if fsys.destroyed:
+        attr['destroyed'] = False
+        mod_fs = True
+    if module.params['size']:
+        if human_to_bytes(module.params['size']) != fsys.provisioned:
+            attr['provisioned'] = human_to_bytes(module.params['size'])
             mod_fs = True
-        if module.params['size']:
-            if human_to_bytes(module.params['size']) != fsys.provisioned:
-                attr['provisioned'] = human_to_bytes(module.params['size'])
-                mod_fs = True
-        api_version = blade.api_version.list_versions().versions
-        if NFSV4_API_VERSION in api_version:
-            if module.params['nfsv3'] and not fsys.nfs.v3_enabled:
-                attr['nfs'] = NfsRule(v3_enabled=module.params['nfsv3'])
-                mod_fs = True
-            if not module.params['nfsv3'] and fsys.nfs.v3_enabled:
-                attr['nfs'] = NfsRule(v3_enabled=module.params['nfsv3'])
-                mod_fs = True
-            if module.params['nfsv4'] and not fsys.nfs.v4_1_enabled:
-                attr['nfs'] = NfsRule(v4_1_enabled=module.params['nfsv4'])
-                mod_fs = True
-            if not module.params['nfsv4'] and fsys.nfs.v4_1_enabled:
-                attr['nfs'] = NfsRule(v4_1_enabled=module.params['nfsv4'])
-                mod_fs = True
-            if module.params['nfsv3'] or module.params['nfsv4'] and fsys.nfs.v3_enabled or fsys.nfs.v4_1_enabled:
-                if module.params['nfs_rules'] is not None:
-                    if fsys.nfs.rules != module.params['nfs_rules']:
-                        attr['nfs'] = NfsRule(rules=module.params['nfs_rules'])
-                        mod_fs = True
-            if module.params['user_quota'] and user_quota != fsys.default_user_quota:
-                attr['default_user_quota'] = user_quota
-                mod_fs = True
-            if module.params['group_quota'] and group_quota != fsys.default_group_quota:
-                attr['default_group_quota'] = group_quota
-                mod_fs = True
-        else:
-            if module.params['nfsv3'] and not fsys.nfs.enabled:
-                attr['nfs'] = NfsRule(enabled=module.params['nfsv3'])
-                mod_fs = True
-            if not module.params['nfsv3'] and fsys.nfs.enabled:
-                attr['nfs'] = NfsRule(enabled=module.params['nfsv3'])
-                mod_fs = True
-            if module.params['nfsv3'] and fsys.nfs.enabled:
+    api_version = blade.api_version.list_versions().versions
+    if NFSV4_API_VERSION in api_version:
+        if module.params['nfsv3'] and not fsys.nfs.v3_enabled:
+            attr['nfs'] = NfsRule(v3_enabled=module.params['nfsv3'])
+            mod_fs = True
+        if not module.params['nfsv3'] and fsys.nfs.v3_enabled:
+            attr['nfs'] = NfsRule(v3_enabled=module.params['nfsv3'])
+            mod_fs = True
+        if module.params['nfsv4'] and not fsys.nfs.v4_1_enabled:
+            attr['nfs'] = NfsRule(v4_1_enabled=module.params['nfsv4'])
+            mod_fs = True
+        if not module.params['nfsv4'] and fsys.nfs.v4_1_enabled:
+            attr['nfs'] = NfsRule(v4_1_enabled=module.params['nfsv4'])
+            mod_fs = True
+        if module.params['nfsv3'] or module.params['nfsv4'] and fsys.nfs.v3_enabled or fsys.nfs.v4_1_enabled:
+            if module.params['nfs_rules'] is not None:
                 if fsys.nfs.rules != module.params['nfs_rules']:
                     attr['nfs'] = NfsRule(rules=module.params['nfs_rules'])
                     mod_fs = True
-        if REPLICATION_API_VERSION in api_version:
-            if module.params['smb'] and not fsys.smb.enabled:
+        if module.params['user_quota'] and user_quota != fsys.default_user_quota:
+            attr['default_user_quota'] = user_quota
+            mod_fs = True
+        if module.params['group_quota'] and group_quota != fsys.default_group_quota:
+            attr['default_group_quota'] = group_quota
+            mod_fs = True
+    else:
+        if module.params['nfsv3'] and not fsys.nfs.enabled:
+            attr['nfs'] = NfsRule(enabled=module.params['nfsv3'])
+            mod_fs = True
+        if not module.params['nfsv3'] and fsys.nfs.enabled:
+            attr['nfs'] = NfsRule(enabled=module.params['nfsv3'])
+            mod_fs = True
+        if module.params['nfsv3'] and fsys.nfs.enabled:
+            if fsys.nfs.rules != module.params['nfs_rules']:
+                attr['nfs'] = NfsRule(rules=module.params['nfs_rules'])
+                mod_fs = True
+    if REPLICATION_API_VERSION in api_version:
+        if module.params['smb'] and not fsys.smb.enabled:
+            attr['smb'] = SmbRule(enabled=module.params['smb'],
+                                  acl_mode=module.params['smb_aclmode'])
+            mod_fs = True
+        if not module.params['smb'] and fsys.smb.enabled:
+            attr['smb'] = ProtocolRule(enabled=module.params['smb'])
+            mod_fs = True
+        if module.params['smb'] and fsys.smb.enabled:
+            if fsys.smb.acl_mode != module.params['smb_aclmode']:
                 attr['smb'] = SmbRule(enabled=module.params['smb'],
                                       acl_mode=module.params['smb_aclmode'])
                 mod_fs = True
-            if not module.params['smb'] and fsys.smb.enabled:
-                attr['smb'] = ProtocolRule(enabled=module.params['smb'])
+    else:
+        if module.params['smb'] and not fsys.smb.enabled:
+            attr['smb'] = ProtocolRule(enabled=module.params['smb'])
+            mod_fs = True
+        if not module.params['smb'] and fsys.smb.enabled:
+            attr['smb'] = ProtocolRule(enabled=module.params['smb'])
+            mod_fs = True
+    if module.params['http'] and not fsys.http.enabled:
+        attr['http'] = ProtocolRule(enabled=module.params['http'])
+        mod_fs = True
+    if not module.params['http'] and fsys.http.enabled:
+        attr['http'] = ProtocolRule(enabled=module.params['http'])
+        mod_fs = True
+    if module.params['snapshot'] and not fsys.snapshot_directory_enabled:
+        attr['snapshot_directory_enabled'] = module.params['snapshot']
+        mod_fs = True
+    if not module.params['snapshot'] and fsys.snapshot_directory_enabled:
+        attr['snapshot_directory_enabled'] = module.params['snapshot']
+        mod_fs = True
+    if module.params['fastremove'] and not fsys.fast_remove_directory_enabled:
+        attr['fast_remove_directory_enabled'] = module.params['fastremove']
+        mod_fs = True
+    if not module.params['fastremove'] and fsys.fast_remove_directory_enabled:
+        attr['fast_remove_directory_enabled'] = module.params['fastremove']
+        mod_fs = True
+    if HARD_LIMIT_API_VERSION in api_version:
+        if not module.params['hard_limit'] and fsys.hard_limit_enabled:
+            attr['hard_limit_enabled'] = module.params['hard_limit']
+            mod_fs = True
+        if module.params['hard_limit'] and not fsys.hard_limit_enabled:
+            attr['hard_limit_enabled'] = module.params['hard_limit']
+            mod_fs = True
+    if REPLICATION_API_VERSION in api_version:
+        if module.params['writable'] is not None:
+            if not module.params['writable'] and fsys.writable:
+                attr['writable'] = module.params['writable']
                 mod_fs = True
-            if module.params['smb'] and fsys.smb.enabled:
-                if fsys.smb.acl_mode != module.params['smb_aclmode']:
-                    attr['smb'] = SmbRule(enabled=module.params['smb'],
-                                          acl_mode=module.params['smb_aclmode'])
-                    mod_fs = True
-        else:
-            if module.params['smb'] and not fsys.smb.enabled:
-                attr['smb'] = ProtocolRule(enabled=module.params['smb'])
+            if module.params['writable'] and not fsys.writable and fsys.promotion_status == 'promoted':
+                attr['writable'] = module.params['writable']
                 mod_fs = True
-            if not module.params['smb'] and fsys.smb.enabled:
-                attr['smb'] = ProtocolRule(enabled=module.params['smb'])
+        if module.params['promote'] is not None:
+            if module.params['promote'] and fsys.promotion_status != 'promoted':
+                attr['requested_promotion_state'] = 'promoted'
                 mod_fs = True
-        if module.params['http'] and not fsys.http.enabled:
-            attr['http'] = ProtocolRule(enabled=module.params['http'])
-            mod_fs = True
-        if not module.params['http'] and fsys.http.enabled:
-            attr['http'] = ProtocolRule(enabled=module.params['http'])
-            mod_fs = True
-        if module.params['snapshot'] and not fsys.snapshot_directory_enabled:
-            attr['snapshot_directory_enabled'] = module.params['snapshot']
-            mod_fs = True
-        if not module.params['snapshot'] and fsys.snapshot_directory_enabled:
-            attr['snapshot_directory_enabled'] = module.params['snapshot']
-            mod_fs = True
-        if module.params['fastremove'] and not fsys.fast_remove_directory_enabled:
-            attr['fast_remove_directory_enabled'] = module.params['fastremove']
-            mod_fs = True
-        if not module.params['fastremove'] and fsys.fast_remove_directory_enabled:
-            attr['fast_remove_directory_enabled'] = module.params['fastremove']
-            mod_fs = True
-        if HARD_LIMIT_API_VERSION in api_version:
-            if not module.params['hard_limit'] and fsys.hard_limit_enabled:
-                attr['hard_limit_enabled'] = module.params['hard_limit']
+            if not module.params['promote'] and fsys.promotion_status == 'promoted':
+                # Demotion only allowed on filesystems in a replica-link
+                try:
+                    blade.file_system_replica_links.list_file_system_replica_links(local_file_system_names=[module.params['name']]).items[0]
+                except Exception:
+                    module.fail_json(msg='Filesystem {0} not demoted. Not in a replica-link'.format(module.params['name']))
+                attr['requested_promotion_state'] = module.params['promote']
                 mod_fs = True
-            if module.params['hard_limit'] and not fsys.hard_limit_enabled:
-                attr['hard_limit_enabled'] = module.params['hard_limit']
-                mod_fs = True
-        if REPLICATION_API_VERSION in api_version:
-            if module.params['writable'] is not None:
-                if not module.params['writable'] and fsys.writable:
-                    attr['writable'] = module.params['writable']
-                    mod_fs = True
-                if module.params['writable'] and not fsys.writable and fsys.promotion_status == 'promoted':
-                    attr['writable'] = module.params['writable']
-                    mod_fs = True
-            if module.params['promote'] is not None:
-                if module.params['promote'] and fsys.promotion_status != 'promoted':
-                    attr['requested_promotion_state'] = 'promoted'
-                    mod_fs = True
-                if not module.params['promote'] and fsys.promotion_status == 'promoted':
-                    # Demotion only allowed on filesystems in a replica-link
-                    try:
-                        blade.file_system_replica_links.list_file_system_replica_links(local_file_system_names=[module.params['name']]).items[0]
-                    except Exception:
-                        module.fail_json(msg='Filesystem {0} not demoted. Not in a replica-link'.format(module.params['name']))
-                    attr['requested_promotion_state'] = module.params['promote']
-                    mod_fs = True
-        if mod_fs:
+    if mod_fs:
+        changed = True
+        if not module.check_mode:
             n_attr = FileSystem(**attr)
             if REPLICATION_API_VERSION in api_version:
                 try:
                     blade.file_systems.update_file_systems(name=module.params['name'], attributes=n_attr,
                                                            discard_non_snapshotted_data=module.params['discard_snaps'])
-                    changed = True
                 except Exception:
                     module.fail_json(msg="Failed to update filesystem {0}.".format(module.params['name']))
             else:
                 try:
                     blade.file_systems.update_file_systems(name=module.params['name'], attributes=n_attr)
-                    changed = True
                 except Exception:
                     module.fail_json(msg="Failed to update filesystem {0}.".format(module.params['name']))
     module.exit_json(changed=changed)

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs_replica.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs_replica.py
@@ -152,26 +152,25 @@ def create_rl(module, blade):
 
 def add_rl_policy(module, blade):
     """Add Policy to Filesystem Replica Link"""
-    changed = True
-    if not module.check_mode:
-        if not module.params['target_array']:
-            module.params['target_array'] = blade.file_system_replica_links.list_file_system_replica_links(
-                local_file_system_names=[module.params['name']]).items[0].remote.name
-        remote_array = _check_connected(module, blade)
-        try:
-            already_a_policy = blade.file_system_replica_links.list_file_system_replica_link_policies(
-                local_file_system_names=[module.params['name']],
-                policy_names=[module.params['policy']],
-                remote_names=[remote_array.remote.name])
-            if already_a_policy.items:
-                changed = False
-            else:
+    changed = False
+    if not module.params['target_array']:
+        module.params['target_array'] = blade.file_system_replica_links.list_file_system_replica_links(
+            local_file_system_names=[module.params['name']]).items[0].remote.name
+    remote_array = _check_connected(module, blade)
+    try:
+        already_a_policy = blade.file_system_replica_links.list_file_system_replica_link_policies(
+            local_file_system_names=[module.params['name']],
+            policy_names=[module.params['policy']],
+            remote_names=[remote_array.remote.name])
+        if not already_a_policy.items:
+            changed = True
+            if not module.check_mode:
                 blade.file_system_replica_links.create_file_system_replica_link_policies(
                     policy_names=[module.params['policy']],
                     local_file_system_names=[module.params['name']],
                     remote_names=[remote_array.remote.name])
-        except Exception:
-            module.fail_json(msg="Failed to add policy {0} to replica link {1}.".format(module.params['policy'], module.params['name']))
+    except Exception:
+        module.fail_json(msg="Failed to add policy {0} to replica link {1}.".format(module.params['policy'], module.params['name']))
     module.exit_json(changed=changed)
 
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_lifecycle.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_lifecycle.py
@@ -153,25 +153,25 @@ def create_rule(module, blade):
 
 def update_rule(module, blade, rule):
     """Update snapshot policy"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        current_rule = {'prefix': rule.prefix,
-                        'keep_previous_version_for': rule.keep_previous_version_for,
-                        'enabled': rule.enabled}
-        if not module.params['prefix']:
-            prefix = current_rule['prefix']
-        else:
-            prefix = module.params['prefix']
-        if not module.params['keep_for']:
-            keep_for = current_rule['keep_previous_version_for']
-        else:
-            keep_for = _convert_to_millisecs(module.params['keep_for'])
-        new_rule = {'prefix': prefix,
-                    'keep_previous_version_for': keep_for,
-                    'enabled': module.params['enabled']}
+    changed = False
+    current_rule = {'prefix': rule.prefix,
+                    'keep_previous_version_for': rule.keep_previous_version_for,
+                    'enabled': rule.enabled}
+    if not module.params['prefix']:
+        prefix = current_rule['prefix']
+    else:
+        prefix = module.params['prefix']
+    if not module.params['keep_for']:
+        keep_for = current_rule['keep_previous_version_for']
+    else:
+        keep_for = _convert_to_millisecs(module.params['keep_for'])
+    new_rule = {'prefix': prefix,
+                'keep_previous_version_for': keep_for,
+                'enabled': module.params['enabled']}
 
-        if current_rule != new_rule:
+    if current_rule != new_rule:
+        changed = True
+        if not module.check_mode:
             try:
                 attr = LifecycleRulePatch(keep_previous_version_for=new_rule['keep_previous_version_for'],
                                           prefix=new_rule['prefix'])
@@ -181,9 +181,7 @@ def update_rule(module, blade, rule):
                 changed = True
             except Exception:
                 module.fail_json(msg='Failed to update lifecycle rule {0} for bucket {1}.'.format(module.params['name'],
-                                                                                                  module.params['bucket']))
-        else:
-            changed = False
+                                                                                              module.params['bucket']))
     module.exit_json(changed=changed)
 
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_lifecycle.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_lifecycle.py
@@ -181,7 +181,7 @@ def update_rule(module, blade, rule):
                 changed = True
             except Exception:
                 module.fail_json(msg='Failed to update lifecycle rule {0} for bucket {1}.'.format(module.params['name'],
-                                                                                              module.params['bucket']))
+                                                                                                  module.params['bucket']))
     module.exit_json(changed=changed)
 
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_network.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_network.py
@@ -133,13 +133,13 @@ def create_iface(module, blade):
 
 def modify_iface(module, blade):
     """Modify Network Interface IP address"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        iface = get_iface(module, blade)
-        iface_new = []
-        iface_new.append(module.params['name'])
-        if module.params['address'] != iface.address:
+    changed = False
+    iface = get_iface(module, blade)
+    iface_new = []
+    iface_new.append(module.params['name'])
+    if module.params['address'] != iface.address:
+        changed = True
+        if not module.check_mode:
             try:
                 blade.network_interfaces.update_network_interfaces(names=iface_new,
                                                                    network_interface=NetworkInterface(address=module.params['address']))

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_proxy.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_proxy.py
@@ -70,26 +70,26 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb impo
 
 def delete_proxy(module, blade):
     """Delete proxy settings"""
-    changed = True
-    if not module.check_mode:
-        current_proxy = blade.support.list_support().items[0].proxy
-        if current_proxy != '':
+    changed = False
+    current_proxy = blade.support.list_support().items[0].proxy
+    if current_proxy != '':
+        changed = True
+        if not module.check_mode:
             try:
                 proxy_settings = Support(proxy='')
                 blade.support.update_support(support=proxy_settings)
             except Exception:
                 module.fail_json(msg='Delete proxy settigs failed')
-        else:
-            changed = False
     module.exit_json(changed=changed)
 
 
 def create_proxy(module, blade):
     """Set proxy settings"""
-    changed = True
-    if not module.check_mode:
-        current_proxy = blade.support.list_support().items[0].proxy
-        if current_proxy is not None:
+    changed = False
+    current_proxy = blade.support.list_support().items[0].proxy
+    if current_proxy is not None:
+        changed = True
+        if not module.check_mode:
             new_proxy = "https://" + module.params['host'] + ":" + str(module.params['port'])
             if new_proxy != current_proxy:
                 try:
@@ -97,8 +97,6 @@ def create_proxy(module, blade):
                     blade.support.update_support(support=proxy_settings)
                 except Exception:
                     module.fail_json(msg='Set phone home proxy failed.')
-            else:
-                changed = False
 
     module.exit_json(changed=changed)
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_s3acc.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_s3acc.py
@@ -74,9 +74,7 @@ def get_s3acc(module, blade):
 
 def update_s3acc(module, blade):
     """Update Object Store Account"""
-    changed = True
-    if not module.check_mode:
-        changed = False
+    changed = False
     module.exit_json(changed=changed)
 
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_s3user.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_s3user.py
@@ -137,33 +137,32 @@ def get_s3user(module, blade):
 
 def update_s3user(module, blade):
     """Update Object Store User"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        exists = False
-        s3user_facts = {}
-        user = module.params['account'] + "/" + module.params['name']
-        if module.params['access_key'] or module.params['imported_key']:
-            key_count = 0
-            keys = blade.object_store_access_keys.list_object_store_access_keys()
-            for key in range(0, len(keys.items)):
-                if module.params['imported_key']:
-                    versions = blade.api_version.list_versions().versions
-                    if IMPORT_KEY_API_VERSION in versions:
-                        if keys.items[key].name == module.params['imported_key']:
-                            module.warn('Imported key provided already belongs to a user')
-                            exists = True
-                if keys.items[key].user.name == user:
-                    key_count += 1
-            if not exists:
-                if key_count < 2:
+    changed = False
+    exists = False
+    s3user_facts = {}
+    user = module.params['account'] + "/" + module.params['name']
+    if module.params['access_key'] or module.params['imported_key']:
+        key_count = 0
+        keys = blade.object_store_access_keys.list_object_store_access_keys()
+        for key in range(0, len(keys.items)):
+            if module.params['imported_key']:
+                versions = blade.api_version.list_versions().versions
+                if IMPORT_KEY_API_VERSION in versions:
+                    if keys.items[key].name == module.params['imported_key']:
+                        module.warn('Imported key provided already belongs to a user')
+                        exists = True
+            if keys.items[key].user.name == user:
+                key_count += 1
+        if not exists:
+            if key_count < 2:
+                changed = True
+                if not module.check_mode:
                     try:
                         if module.params['access_key'] and module.params['imported_key']:
                             module.warn('\'access_key: true\' overrides imported keys')
                         if module.params['access_key']:
                             result = blade.object_store_access_keys.create_object_store_access_keys(
                                 object_store_access_key=ObjectStoreAccessKey(user={'name': user}))
-                            changed = True
                             s3user_facts['fb_s3user'] = {'user': user,
                                                          'access_key': result.items[0].secret_access_key,
                                                          'access_id': result.items[0].name}
@@ -173,14 +172,13 @@ def update_s3user(module, blade):
                                     names=[module.params['imported_key']],
                                     object_store_access_key=ObjectStoreAccessKeyPost(
                                         user={'name': user}, secret_access_key=module.params['imported_secret']))
-                                changed = True
                     except Exception:
                         if module.params['imported_key']:
                             module.fail_json(msg='Object Store User {0}: Access Key import failed'.format(user))
                         else:
                             module.fail_json(msg='Object Store User {0}: Access Key creation failed'.format(user))
-                else:
-                    module.warn('Object Store User {0}: Maximum Access Key count reached'.format(user))
+            else:
+                module.warn('Object Store User {0}: Maximum Access Key count reached'.format(user))
     module.exit_json(changed=changed, s3user_info=s3user_facts)
 
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_smtp.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_smtp.py
@@ -62,29 +62,32 @@ MIN_REQUIRED_API_VERSION = "1.6"
 
 def set_smtp(module, blade):
     """Configure SMTP settings"""
-    changed = True
-    if not module.check_mode:
-        current_smtp = blade.smtp.list_smtp().items[0]
-        if module.params['host'] and module.params['host'] != current_smtp.relay_host:
-            smtp_settings = Smtp(relay_host=module.params['host'])
+    changed = False
+    current_smtp = blade.smtp.list_smtp().items[0]
+    if module.params['host'] and module.params['host'] != current_smtp.relay_host:
+        smtp_settings = Smtp(relay_host=module.params['host'])
+        changed = True
+        if not module.check_mode:
             try:
                 blade.smtp.update_smtp(smtp_settings=smtp_settings)
             except Exception:
                 module.fail_json(msg='Configuring SMTP relay host failed')
-        elif current_smtp.relay_host and not module.params['host']:
-            smtp_settings = Smtp(relay_host='')
+    elif current_smtp.relay_host and not module.params['host']:
+        smtp_settings = Smtp(relay_host='')
+        changed = True
+        if not module.check_mode:
             try:
                 blade.smtp.update_smtp(smtp_settings=smtp_settings)
             except Exception:
                 module.fail_json(msg='Configuring SMTP relay host failed')
-        if module.params['domain'] != current_smtp.sender_domain:
-            smtp_settings = Smtp(sender_domain=module.params['domain'])
+    if module.params['domain'] != current_smtp.sender_domain:
+        smtp_settings = Smtp(sender_domain=module.params['domain'])
+        changed = True
+        if not module.check_mode:
             try:
                 blade.smtp.update_smtp(smtp_settings=smtp_settings)
             except Exception:
                 module.fail_json(msg='Configuring SMTP sender domain failed')
-        else:
-            changed = False
     module.exit_json(changed=changed)
 
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_snmp_agent.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_snmp_agent.py
@@ -96,30 +96,30 @@ MIN_REQUIRED_API_VERSION = "1.9"
 
 def update_agent(module, blade):
     """Update SNMP Agent"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        try:
-            agent = blade.snmp_agents.list_snmp_agents()
-        except Exception:
-            module.fail_json(msg="Failed to get configuration for SNMP agent.")
-        current_attr = {'community': agent.items[0].v2c.community,
-                        'version': agent.items[0].version,
-                        'auth_passphrase': agent.items[0].v3.auth_passphrase,
-                        'auth_protocol': agent.items[0].v3.auth_protocol,
-                        'privacy_passphrase': agent.items[0].v3.privacy_passphrase,
-                        'privacy_protocol': agent.items[0].v3.privacy_protocol,
-                        'user': agent.items[0].v3.user,
-                        }
-        new_attr = {'community': module.params['community'],
-                    'version': module.params['version'],
-                    'auth_passphrase': module.params['auth_passphrase'],
-                    'auth_protocol': module.params['auth_protocol'],
-                    'privacy_passphrase': module.params['privacy_passphrase'],
-                    'privacy_protocol': module.params['privacy_protocol'],
-                    'user': module.params['user']
+    changed = False
+    try:
+        agent = blade.snmp_agents.list_snmp_agents()
+    except Exception:
+        module.fail_json(msg="Failed to get configuration for SNMP agent.")
+    current_attr = {'community': agent.items[0].v2c.community,
+                    'version': agent.items[0].version,
+                    'auth_passphrase': agent.items[0].v3.auth_passphrase,
+                    'auth_protocol': agent.items[0].v3.auth_protocol,
+                    'privacy_passphrase': agent.items[0].v3.privacy_passphrase,
+                    'privacy_protocol': agent.items[0].v3.privacy_protocol,
+                    'user': agent.items[0].v3.user,
                     }
-        if current_attr != new_attr:
+    new_attr = {'community': module.params['community'],
+                'version': module.params['version'],
+                'auth_passphrase': module.params['auth_passphrase'],
+                'auth_protocol': module.params['auth_protocol'],
+                'privacy_passphrase': module.params['privacy_passphrase'],
+                'privacy_protocol': module.params['privacy_protocol'],
+                'user': module.params['user']
+                }
+    if current_attr != new_attr:
+        changed = True
+        if not module.check_mode:
             if new_attr['version'] == 'v2c':
                 updated_v2c_attrs = SnmpV2c(community=new_attr['community'])
                 updated_v2c_agent = SnmpAgent(version='v2c', v2c=updated_v2c_attrs)

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_snmp_mgr.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_snmp_mgr.py
@@ -133,34 +133,34 @@ MIN_REQUIRED_API_VERSION = "1.9"
 
 def update_manager(module, blade):
     """Update SNMP Manager"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        try:
-            mgr = blade.snmp_managers.list_snmp_managers(names=[module.params['name']])
-        except Exception:
-            module.fail_json(msg="Failed to get configuration for SNMP manager {0}.".format(module.params['name']))
-        current_attr = {'community': mgr.items[0].v2c.community,
-                        'notification': mgr.items[0].notification,
-                        'host': mgr.items[0].host,
-                        'version': mgr.items[0].version,
-                        'auth_passphrase': mgr.items[0].v3.auth_passphrase,
-                        'auth_protocol': mgr.items[0].v3.auth_protocol,
-                        'privacy_passphrase': mgr.items[0].v3.privacy_passphrase,
-                        'privacy_protocol': mgr.items[0].v3.privacy_protocol,
-                        'user': mgr.items[0].v3.user,
-                        }
-        new_attr = {'community': module.params['community'],
-                    'notification': module.params['notification'],
-                    'host': module.params['host'],
-                    'version': module.params['version'],
-                    'auth_passphrase': module.params['auth_passphrase'],
-                    'auth_protocol': module.params['auth_protocol'],
-                    'privacy_passphrase': module.params['privacy_passphrase'],
-                    'privacy_protocol': module.params['privacy_protocol'],
-                    'user': module.params['user']
+    changed = False
+    try:
+        mgr = blade.snmp_managers.list_snmp_managers(names=[module.params['name']])
+    except Exception:
+        module.fail_json(msg="Failed to get configuration for SNMP manager {0}.".format(module.params['name']))
+    current_attr = {'community': mgr.items[0].v2c.community,
+                    'notification': mgr.items[0].notification,
+                    'host': mgr.items[0].host,
+                    'version': mgr.items[0].version,
+                    'auth_passphrase': mgr.items[0].v3.auth_passphrase,
+                    'auth_protocol': mgr.items[0].v3.auth_protocol,
+                    'privacy_passphrase': mgr.items[0].v3.privacy_passphrase,
+                    'privacy_protocol': mgr.items[0].v3.privacy_protocol,
+                    'user': mgr.items[0].v3.user,
                     }
-        if current_attr != new_attr:
+    new_attr = {'community': module.params['community'],
+                'notification': module.params['notification'],
+                'host': module.params['host'],
+                'version': module.params['version'],
+                'auth_passphrase': module.params['auth_passphrase'],
+                'auth_protocol': module.params['auth_protocol'],
+                'privacy_passphrase': module.params['privacy_passphrase'],
+                'privacy_protocol': module.params['privacy_protocol'],
+                'user': module.params['user']
+                }
+    if current_attr != new_attr:
+        changed = True
+        if not module.check_mode:
             if new_attr['version'] == 'v2c':
                 updated_v2c_attrs = SnmpV2c(community=new_attr['community'])
                 updated_v2c_manager = SnmpManager(host=new_attr['host'], notification=new_attr['notification'],
@@ -170,7 +170,6 @@ def update_manager(module, blade):
                     blade.snmp_managers.update_snmp_managers(names=[module.params['name']],
                                                              snmp_manager=updated_v2c_manager
                                                              )
-                    changed = True
                 except Exception:
                     module.fail_json(msg="Failed to update v2c SNMP manager {0}.".format(module.params['name']))
             else:
@@ -187,7 +186,6 @@ def update_manager(module, blade):
                     blade.snmp_managers.update_snmp_managers(names=[module.params['name']],
                                                              snmp_manager=updated_v3_manager
                                                              )
-                    changed = True
                 except Exception:
                     module.fail_json(msg="Failed to update v3 SNMP manager {0}.".format(module.params['name']))
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_subnet.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_subnet.py
@@ -145,41 +145,44 @@ def create_subnet(module, blade):
 
 def modify_subnet(module, blade):
     """Modify Subnet settings"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        subnet = get_subnet(module, blade)
-        subnet_new = []
-        subnet_new.append(module.params['name'])
-        if module.params['prefix']:
-            if module.params['prefix'] != subnet.prefix:
+    changed = False
+    subnet = get_subnet(module, blade)
+    subnet_new = []
+    subnet_new.append(module.params['name'])
+    if module.params['prefix']:
+        if module.params['prefix'] != subnet.prefix:
+            changed = True
+            if not module.check_mode:
                 try:
                     blade.subnets.update_subnets(names=subnet_new,
                                                  subnet=Subnet(prefix=module.params['prefix']))
-                    changed = True
                 except Exception:
                     module.fail_json(msg='Failed to change subnet {0} prefix to {1}'.format(module.params['name'],
-                                                                                            module.params['prefix']))
-        if module.params['vlan']:
-            if module.params['vlan'] != subnet.vlan:
+                                                                                        module.params['prefix']))
+    if module.params['vlan']:
+        if module.params['vlan'] != subnet.vlan:
+            changed = True
+            if not module.check_mode:
                 try:
                     blade.subnets.update_subnets(names=subnet_new,
                                                  subnet=Subnet(vlan=module.params['vlan']))
-                    changed = True
                 except Exception:
                     module.fail_json(msg='Failed to change subnet {0} VLAN to {1}'.format(module.params['name'],
-                                                                                          module.params['vlan']))
-        if module.params['gateway']:
-            if module.params['gateway'] != subnet.gateway:
+                                                                                      module.params['vlan']))
+    if module.params['gateway']:
+        if module.params['gateway'] != subnet.gateway:
+            changed = True
+            if not module.check_mode:
                 try:
                     blade.subnets.update_subnets(names=subnet_new,
                                                  subnet=Subnet(gateway=module.params['gateway']))
-                    changed = True
                 except Exception:
                     module.fail_json(msg='Failed to change subnet {0} gateway to {1}'.format(module.params['name'],
-                                                                                             module.params['gateway']))
-        if module.params['mtu']:
-            if module.params['mtu'] != subnet.mtu:
+                                                                                         module.params['gateway']))
+    if module.params['mtu']:
+        if module.params['mtu'] != subnet.mtu:
+            changed = True
+            if not module.check_mode:
                 try:
                     blade.subnets.update_subnets(names=subnet_new,
                                                  subnet=Subnet(mtu=module.params['mtu']))

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_subnet.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_subnet.py
@@ -158,7 +158,7 @@ def modify_subnet(module, blade):
                                                  subnet=Subnet(prefix=module.params['prefix']))
                 except Exception:
                     module.fail_json(msg='Failed to change subnet {0} prefix to {1}'.format(module.params['name'],
-                                                                                        module.params['prefix']))
+                                                                                            module.params['prefix']))
     if module.params['vlan']:
         if module.params['vlan'] != subnet.vlan:
             changed = True
@@ -168,7 +168,7 @@ def modify_subnet(module, blade):
                                                  subnet=Subnet(vlan=module.params['vlan']))
                 except Exception:
                     module.fail_json(msg='Failed to change subnet {0} VLAN to {1}'.format(module.params['name'],
-                                                                                      module.params['vlan']))
+                                                                                          module.params['vlan']))
     if module.params['gateway']:
         if module.params['gateway'] != subnet.gateway:
             changed = True
@@ -178,7 +178,7 @@ def modify_subnet(module, blade):
                                                  subnet=Subnet(gateway=module.params['gateway']))
                 except Exception:
                     module.fail_json(msg='Failed to change subnet {0} gateway to {1}'.format(module.params['name'],
-                                                                                         module.params['gateway']))
+                                                                                             module.params['gateway']))
     if module.params['mtu']:
         if module.params['mtu'] != subnet.mtu:
             changed = True

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_syslog.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_syslog.py
@@ -93,15 +93,15 @@ MIN_REQUIRED_API_VERSION = '1.10'
 
 def delete_syslog(module, blade):
     """Delete Syslog Server"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        try:
-            server = blade.syslog.list_syslog_servers(names=[module.params['name']])
-        except Exception:
-            server = None
+    changed = False
+    try:
+        server = blade.syslog.list_syslog_servers(names=[module.params['name']])
+    except Exception:
+        server = None
 
-        if server:
+    if server:
+        changed = True
+        if not module.check_mode:
             try:
                 blade.syslog.delete_syslog_servers(names=[module.params['name']])
                 changed = True
@@ -113,27 +113,27 @@ def delete_syslog(module, blade):
 
 def add_syslog(module, blade):
     """Add Syslog Server"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        noport_address = module.params['protocol'] + "://" + module.params['address']
+    changed = False
+    noport_address = module.params['protocol'] + "://" + module.params['address']
 
-        if module.params['port']:
-            full_address = noport_address + ":" + module.params['port']
-        else:
-            full_address = noport_address
+    if module.params['port']:
+        full_address = noport_address + ":" + module.params['port']
+    else:
+        full_address = noport_address
 
-        address_list = blade.syslog.list_syslog_servers()
-        if len(address_list.items) == 3:
-            module.fail_json(msg='Maximum number of syslog servers (3) already configured.')
-        exists = False
+    address_list = blade.syslog.list_syslog_servers()
+    if len(address_list.items) == 3:
+        module.fail_json(msg='Maximum number of syslog servers (3) already configured.')
+    exists = False
 
-        if address_list:
-            for address in range(0, len(address_list.items)):
-                if address_list.items[address].name == module.params['name']:
-                    exists = True
-                    break
-        if not exists:
+    if address_list:
+        for address in range(0, len(address_list.items)):
+            if address_list.items[address].name == module.params['name']:
+                exists = True
+                break
+    if not exists:
+        changed = True
+        if not module.check_mode:
             try:
                 attr = SyslogServerPostOrPatch(uri=full_address)
                 blade.syslog.create_syslog_servers(syslog=attr, names=[module.params['name']])

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_target.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_target.py
@@ -121,21 +121,20 @@ def create_connection(module, blade):
 
 def update_connection(module, blade, connection):
     """Update target connection address"""
-    changed = True
-    if not module.check_mode:
-        connected_targets = blade.targets.list_targets()
-        for target in range(0, len(connected_targets.items)):
-            if connected_targets.items[target].address == module.params['address'] and \
-               connected_targets.items[target].name != module.params['name']:
-                module.fail_json(msg='Target already exists with same connection address')
-        if module.params['address'] != connection.address:
+    changed = False
+    connected_targets = blade.targets.list_targets()
+    for target in range(0, len(connected_targets.items)):
+        if connected_targets.items[target].address == module.params['address'] and \
+           connected_targets.items[target].name != module.params['name']:
+            module.fail_json(msg='Target already exists with same connection address')
+    if module.params['address'] != connection.address:
+        changed = True
+        if not module.check_mode:
             new_address = Target(name=module.params['name'], address=module.params['address'])
             try:
                 blade.targets.update_targets(names=[connection.name], target=new_address)
             except Exception:
                 module.fail_json(msg='Failed to change address for target {0}.'.format(module.params['name']))
-        else:
-            changed = False
     module.exit_json(changed=changed)
 
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_user.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_user.py
@@ -67,10 +67,11 @@ MIN_REQUIRED_API_VERSION = '1.3'
 
 def update_user(module, blade):
     """Create or Update Local User Account"""
-    changed = True
-    if not module.check_mode:
-        if module.params['password']:
-            if module.params['password'] != module.params['old_password']:
+    changed = False
+    if module.params['password']:
+        if module.params['password'] != module.params['old_password']:
+            changed = True
+            if not module.check_mode:
                 try:
                     newAdmin = Admin()
                     newAdmin.password = module.params['password']
@@ -79,9 +80,9 @@ def update_user(module, blade):
                 except Exception:
                     module.fail_json(msg='Local User {0}: Password reset failed. '
                                      'Check passwords. One of these is incorrect.'.format(module.params['name']))
-            else:
-                module.fail_json(msg='Local User Account {0}: Password change failed - '
-                                 'Old and new passwords are the same'.format(module.params['name']))
+        else:
+            module.fail_json(msg='Local User Account {0}: Password change failed - '
+                             'Old and new passwords are the same'.format(module.params['name']))
     module.exit_json(changed=changed)
 
 


### PR DESCRIPTION
##### SUMMARY
The plugins within this module do not currently support 'changed' in check mode correctly. This is not suitable for an enterprise storage solution such as FlashBlade. I have a basic initial setup, yet when I run Ansible in check mode I am met by a whole host of yellow changes. This PR fixes that. 

The logic already exists in pretty much every case, this PR is a case of shuffling where the `if not module.check_mode` is positioned, and then altering `changed` value.

This was picked up and highlighted in #110, where I was told support for this is some time away - as this PR shows, it is not a great deal of work to fix this, and is a very important aspect of Ansible modules, _especially_ for something as critical as a network storage system.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
All plugins

##### ADDITIONAL INFORMATION
I have tested this against my Pure with some, but not all of the modules. Actively tested:
- purefb_alert
- purefb_dns
- purefb_ds
- purefb_dsrole
- purefb_fs
- purefb_policy
- purefb_smtp
