### PR TITLE
Set undefined variables to zero

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/113_policy_cleanup.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/113_policy_cleanup.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_policy - Ensure undeclared variables are set correctly

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
@@ -246,6 +246,10 @@ def create_policy(module, blade):
                     module.params['timezone'] = _get_local_tz(module)
                     if module.params['timezone'] not in pytz.all_timezones_set:
                         module.fail_json(msg='Timezone {0} is not valid'.format(module.params['timezone']))
+            if not module.params['keep_for']:
+                module.params['keep_for'] = 0
+            if not module.params['every']:
+                module.params['every'] = 0
             if module.params['keep_for'] < module.params['every']:
                 module.fail_json(msg='Retention period cannot be less than snapshot interval.')
             if module.params['at'] and not module.params['timezone']:


### PR DESCRIPTION
##### SUMMARY
Undefined variables are required to be set to 0 before comparing them

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_policy.py