### PR TITLE
Add ability to update the array certificate + private key

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/114_certificate_update.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/114_certificate_update.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add update functionality for array cert in purefb_certs

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_certs.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_certs.py
@@ -60,6 +60,14 @@ EXAMPLES = r'''
     state: absent
     fb_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+- name: Update SSL certificate
+  purefb_certs:
+    name: global
+    contents: "{{ lookup('file', 'certificate_file_name') }}"
+    private_key: "{{ lookup('file', 'certificate_key_file_name') }}"
+    passphrase: 'mypassword'
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
 '''
 
 RETURN = r'''

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_certs.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_certs.py
@@ -35,6 +35,14 @@ options:
     description:
     - SSL certifcate text
     type: str
+  private_key:
+    description:
+    - SSL certificate private key test
+    type: str
+  passphrase:
+    description:
+    - Passphrase for the private_key
+    type: str
 extends_documentation_fragment:
 - purestorage.flashblade.purestorage.fb
 '''


### PR DESCRIPTION
##### SUMMARY
Extend purefb_certs to allow updating the global array certificate

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_certs

##### ADDITIONAL INFORMATION

```paste below
- name: Set HTTPS certificate
  purestorage.flashblade.purefb_certs:
    name: global
    contents: "{{ lookup('file', 'mycertificate') }}"
    private_key: "{{ lookup('file', 'mycertificate.key') }}"
    passphrase: 'mypassword'
```

Tested on Pure 3.0.9