### PR TITLE
Add support for multiprotocol ACL implementation

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/115_multiprotocol.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/115_multiprotocol.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_fs - Add multiprotocol ACL support

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
@@ -156,6 +156,7 @@ options:
     description:
       - The access control style that is utilized for client actions such
         as setting file and directory ACLs.
+      - Only available from Purity//FB 3.1.1
     type: str
     default: shared
     choices: [ 'nfs', 'smb', 'shared', 'independent', 'mode-bits' ]
@@ -164,6 +165,7 @@ options:
       - Safeguards ACLs on a filesystem.
       - Performs different roles depending on the filesystem protocol enabled.
       - See Purity//FB documentation for detailed description.
+      - Only available from Purity//FB 3.1.1
     type: bool
     default: True
 extends_documentation_fragment:


### PR DESCRIPTION
##### SUMMARY
Add support multiprotocol ACL implementation available from Purity 3.1.1
Also, add better error reporting on create and modify - use the actual array error messages

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_fs.py

##### ADDITIONAL INFORMATION
Add new parameters `safeguard_acls` and `access_control`.
`smb_aclmode` deprecated in favour of `access_control` from Purity 3.1.1 (SDK 1.11)