### PR TITLE
Change CI tests to use Python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
##### SUMMARY
Change CI workflow to use Python 3.8 - required version for Ansible 2.11

