### PR TITLE
Add replication performance info

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/README.md
+++ b/collections/ansible_collections/purestorage/flashblade/README.md
@@ -12,7 +12,8 @@ The Pure Storage FlashBlade collection consists of the latest versions of the Fl
 - Ansible 2.9 or later
 - Pure Storage FlashBlade system running Purity//FB 2.1.2 or later
     - some modules require higher versions of Purity//FB
-- purity_fb >=v1.10
+- purity_fb >=v1.12.2
+- py-pure-client >=v1.13.0
 - python >=v2.7, >=3.2
 - netaddr
 

--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/121_replication_perf.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/121_replication_perf.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_info - Add replication performace statistics

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
@@ -505,21 +505,36 @@ def generate_perf_dict(blade):
         "write_bytes_per_sec": nfs_perf.items[0].write_bytes_per_sec,
         "writes_per_sec": nfs_perf.items[0].writes_per_sec,
     }
-    # TODO (SD): Only add in when new python SDK exists that support Python 3.7
-    # api_version = blade.api_version.list_versions().versions
-    # if REPLICATION_API_VERSION in api_version:
-    #     file_repl_perf = blade.array_connections.list_array_connections_performance_replication(type='file-system')
-    #     obj_repl_perf = blade.array_connections.list_array_connections_performance_replication(type='object-store')
-    #     if len(file_repl_perf.total):
-    #         perf_info['file_replication'] = {
-    #             'received_bytes_per_sec': file_repl_perf.total[0].async.received_bytes_per_sec,
-    #             'transmitted_bytes_per_sec': file_repl_perf.total[0].async.transmitted_bytes_per_sec,
-    #         }
-    #     if len(obj_repl_perf.total):
-    #         perf_info['object_replication'] = {
-    #             'received_bytes_per_sec': obj_repl_perf.total[0].async.received_bytes_per_sec,
-    #             'transmitted_bytes_per_sec': obj_repl_perf.total[0].async.transmitted_bytes_per_sec,
-    #         }
+    api_version = blade.api_version.list_versions().versions
+    if REPLICATION_API_VERSION in api_version:
+        file_repl_perf = (
+            blade.array_connections.list_array_connections_performance_replication(
+                type="file-system"
+            )
+        )
+        obj_repl_perf = (
+            blade.array_connections.list_array_connections_performance_replication(
+                type="object-store"
+            )
+        )
+        if len(file_repl_perf.total):
+            perf_info["file_replication"] = {
+                "received_bytes_per_sec": file_repl_perf.total[
+                    0
+                ].periodic.received_bytes_per_sec,
+                "transmitted_bytes_per_sec": file_repl_perf.total[
+                    0
+                ].periodic.transmitted_bytes_per_sec,
+            }
+        if len(obj_repl_perf.total):
+            perf_info["object_replication"] = {
+                "received_bytes_per_sec": obj_repl_perf.total[
+                    0
+                ].periodic.received_bytes_per_sec,
+                "transmitted_bytes_per_sec": obj_repl_perf.total[
+                    0
+                ].periodic.transmitted_bytes_per_sec,
+            }
     return perf_info
 
 

--- a/collections/ansible_collections/purestorage/flashblade/requirements.txt
+++ b/collections/ansible_collections/purestorage/flashblade/requirements.txt
@@ -1,3 +1,4 @@
 netaddr
-python == '3.6'
-purity-fb >= '1.11'
+python >= '3.6'
+purity-fb >= '1.12.2'
+py-pure-client >= '1.13.0'


### PR DESCRIPTION
##### SUMMARY
Add performance information for replication.
Requires purity_fb >= 1.12.1
Update docs to reference minimum required SDK version to support this.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefb_info.py