### PR TITLE
Add no_log for some arguments

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_remote_cred.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_remote_cred.py
@@ -196,7 +196,7 @@ def main():
         dict(
             state=dict(type="str", default="present", choices=["present", "absent"]),
             name=dict(type="str", required=True),
-            access_key=dict(type="str"),
+            access_key=dict(type="str", no_log=False),
             secret=dict(type="str", no_log=True),
             target=dict(type="str", required=True),
         )

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_s3user.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_s3user.py
@@ -306,8 +306,8 @@ def main():
             name=dict(required=True, type="str"),
             account=dict(required=True, type="str"),
             access_key=dict(default="false", type="bool"),
-            imported_key=dict(type="str"),
-            remove_key=dict(type="str"),
+            imported_key=dict(type="str", no_log=False),
+            remove_key=dict(type="str", no_log=False),
             imported_secret=dict(type="str", no_log=True),
             state=dict(default="present", choices=["present", "absent", "remove_key"]),
         )


### PR DESCRIPTION
##### SUMMARY
Ansible 2.11 Sanity Tests detect some arguments as potentially requiring the `no_log` parameter.
Add `no_log=False` for these

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_remote_cred.py
purefb_s3user.py