### PR TITLE
Add more info details for Purity//FB 3.2+ systems

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/128_add_32_to_info.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/128_add_32_to_info.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_info - Add extra info for Purity//FB 3.2+ systems


### PR DESCRIPTION
##### SUMMARY
Add new information for features added from Purity//FB 3.2

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_info.py

##### ADDITIONAL INFORMATION
Add following information in default section:
* EULA - signed or not
* Count of Object Store Virtual Hosts
* Count of API Clients