### PR TITLE
Add object store account info to purefb_info

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/137_add_object_accounts_to_info.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/137_add_object_accounts_to_info.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_info - Add object store account and user details option


### PR DESCRIPTION
##### SUMMARY
Add new option `accounts` to `gather_subnets`.
Adds details for all object store accounts and users and associated keys and policies

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_info.py