### PR TITLE
Add remote snap now support

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/154_add_snap_now.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/154_add_snap_now.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_snap - Add support for immeadiate snapshot to remote connected FlashBlade


### PR DESCRIPTION
##### SUMMARY
Add new parameters `now` and `targets` to allow a filesystem snapshot to be sent immediately to remote FlashBlades.
Remote FBs listed must all be correctly connected or call will fail.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_snap.py