### PR TITLE
Add support to specify LAG in subnet creation

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/158_support_lags.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/158_support_lags.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefb_subnet - Add support for multiple LAGs.


### PR DESCRIPTION
##### SUMMARY
When multiple LAGs are present allow specific LAG to be used for subnet creation.
If no LAG is specified use the default `uplink` LAG

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_subnet.py