### PR TITLE
Add changelog note for purefb_lag issue

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/166_lag_mac_note.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/166_lag_mac_note.yaml
@@ -1,0 +1,2 @@
+known_issues:
+ - purefb_lag - The mac_address field in the response is not populated. This will be fixed in a future FlashBlade update.


### PR DESCRIPTION
##### SUMMARY
Add note to cover the unpopulated `mac_address` field in the `purefb_lag` response

##### ISSUE TYPE
- Docs Pull Request