### PR TITLE
Add support for Object Store Access Policies

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/174_access_policies.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/174_access_policies.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefb_policy - Add support for Object Store Access Policies, associated rules and user grants
+ - purefb_policy - New parameter `policy_type` added. For backwards compatability, default to `snapshot` if not provided.

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
@@ -20,16 +20,141 @@ module: purefb_policy
 version_added: '1.0.0'
 short_description: Manage FlashBlade policies
 description:
-- Manage policies for filesystem and file replica links
+- Manage policies for filesystem, file replica links and object store access
 author:
 - Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:
-    - Create or delete policy
+    - Create or delete policy.
+    - Copy is applicable only to Object Store Access Policies Rules
     default: present
     type: str
-    choices: [ absent, present ]
+    choices: [ absent, present, copy ]
+  target:
+    description:
+    - Name of policy to copy rule to
+    type: str
+    version_added: "1.9.0"
+  target_rule:
+    description:
+    - Name of the rule to copy the exisitng rule to.
+    - If not defined the existing rule name is used.
+    type: str
+    version_added: "1.9.0"
+  policy_type:
+    description:
+    - Type of policy
+    default: snapshot
+    type: str
+    choices: [ snapshot, access ]
+    version_added: "1.9.0"
+  account:
+    description:
+    - Name of Object Store account policy applies to.
+    - B(Special Case) I(pure:policy) is used for the system-wide S3 policies
+    type: str
+    version_added: "1.9.0"
+  rule:
+    description:
+    - Name of the rule for the Object Store Access Policy
+    - Rules in system-wide policies cannot be deleted or modified
+    type: str
+    version_added: "1.9.0"
+  effect:
+    description:
+    - Allow S3 requests that match all of the I(actions) item selected.
+      Rules are additive.
+    type: str
+    default: allow
+    choices: [ allow ]
+    version_added: "1.9.0"
+  actions:
+    description:
+    - List of permissions to grant.
+    - System-wide policy rules cannot be deleted or modified
+    type: list
+    elements: str
+    choices: [ s3:*,
+              s3:AbortMultipartUpload,
+              s3:CreateBucket,
+              s3:DeleteBucket,
+              s3:DeleteObject,
+              s3:DeleteObjectVersion,
+              s3:ExtendSafemodeRetentionPeriod,
+              s3:GetBucketAcl,
+              s3:GetBucketLocation,
+              s3:GetBucketVersioning,
+              s3:GetLifecycleConfiguration,
+              s3:GetObject,
+              s3:GetObjectAcl,
+              s3:GetObjectVersion,
+              s3:ListAllMyBuckets,
+              s3:ListBucket,
+              s3:ListBucketMultipartUploads,
+              s3:ListBucketVersions,
+              s3:ListMultipartUploadParts,
+              s3:PutBucketVersioning,
+              s3:PutLifecycleConfiguration,
+              s3:PutObject ]
+    version_added: "1.9.0"
+  object_resources:
+    description:
+    - List of bucket names and object paths, with a wildcard (*) to
+      specify objects in a bucket; e.g., bucket1, bucket1/*, bucket2,
+      bucket2/*.
+    - System-wide policy rules cannot be deleted or modified
+    type: list
+    elements: str
+    version_added: "1.9.0"
+  source_ips:
+    description:
+    - List of IPs and subnets from which this rule should allow requests;
+      e.g., 10.20.30.40, 10.20.30.0/24, 2001:DB8:1234:5678::/64.
+    - System-wide policy rules cannot be deleted or modified
+    type: list
+    elements: str
+    version_added: "1.9.0"
+  s3_prefixes:
+    description:
+    - List of 'folders' (object key prefixes) for which object listings
+      may be requested.
+    - System-wide policy rules cannot be deleted or modified
+    type: list
+    elements: str
+    version_added: "1.9.0"
+  s3_delimiters:
+    description:
+    - List of delimiter characters allowed in object list requests.
+    - Grants permissions to list 'folder names' (prefixes ending in a
+      delimiter) instead of object keys.
+    - System-wide policy rules cannot be deleted or modified
+    type: list
+    elements: str
+    version_added: "1.9.0"
+  ignore_enforcement:
+    description:
+    - Certain combinations of actions and other rule elements are inherently
+      ignored if specified together in a rule.
+    - If set to true, operations which attempt to set these combinations will fail.
+    - If set to false, such operations will instead be allowed.
+    type: bool
+    default: True
+    version_added: "1.9.0"
+  user:
+    description:
+    - User in the I(account) that the policy is granted to.
+    type: str
+    version_added: "1.9.0"
+  force_delete:
+    description:
+    - Force the deletion of a Object Store Access Policy is this
+      has attached users.
+    - WARNING This can have undesired side-effects.
+    - System-wide policies cannot be deleted
+    type: bool
+    default: False
+    version_added: "1.9.0"
   name:
     description:
     - Name of the policy
@@ -76,14 +201,16 @@ extends_documentation_fragment:
 """
 
 EXAMPLES = r"""
-- name: Create a simple policy with no rules
+- name: Create a simple snapshot policy with no rules
   purefb_policy:
     name: test_policy
+    policy_type: snapshot
     fb_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
-- name: Create a policy and connect to existing filesystems and filesystem replica links
+- name: Create a snapshot policy and connect to existing filesystems and filesystem replica links
   purefb_policy:
     name: test_policy_with_members
+    policy_type: snapshot
     filesystem:
     - fs1
     - fs2
@@ -92,19 +219,91 @@ EXAMPLES = r"""
     - rl2
     fb_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
-- name: Create a policy with rules
+- name: Create a snapshot policy with rules
   purefb_policy:
     name: test_policy2
+    policy_type: snapshot
     at: 11AM
     keep_for: 86400
     every: 86400
     timezone: Asia/Shanghai
     fb_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
-- name: Delete a policy
+- name: Delete a snapshot policy
   purefb_policy:
     name: test_policy
+    policy_type: snapshot
     state: absent
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+- name: Create an empty object store access policy
+  purefb_policy:
+    name: test_os_policy
+    account: test
+    policy_type: access
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+- name: Create an empty object store access policy and assign user
+  purefb_policy:
+    name: test_os_policy
+    account: test
+    policy_type: access
+    user: fred
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+- name: Create a object store access policy with simple rule
+  purefb_policy:
+    name: test_os_policy_rule
+    policy_type: access
+    account: test
+    rule: rule1
+    actions: "s3:*"
+    object_resources: "*"
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+- name: Delete a rule from an object store access policy
+  purefb_policy:
+    name: test_os_policy_rule
+    account: test
+    policy_type: access
+    rule: rule1
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+- name: Delete a user from an object store access policy
+  purefb_policy:
+    name: test_os_policy_rule
+    account: test
+    user: fred
+    policy_type: access
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+- name: Delete an object store access policy with attached users (USE WITH CAUTION)
+  purefb_policy:
+    name: test_os_policy_rule
+    account: test
+    policy_type: access
+    force_delete: true
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+- name: Delete an object store access policy with no attached users
+  purefb_policy:
+    name: test_os_policy_rule
+    account: test
+    policy_type: access
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+- name: Copy an object store access policy rule to another exisitng policy
+  purefb_policy:
+    name: test_os_policy_rule
+    policy_type: access
+    account: test
+    target: "account2/anotherpolicy"
+    target_rule: new_rule1
+    state: copy
     fb_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
 """
@@ -117,6 +316,16 @@ try:
     from purity_fb import Policy, PolicyRule, PolicyPatch
 except ImportError:
     HAS_PURITYFB = False
+
+HAS_PYPURECLIENT = True
+try:
+    from pypureclient.flashblade import (
+        PolicyRuleObjectAccessCondition,
+        PolicyRuleObjectAccessPost,
+        PolicyRuleObjectAccess,
+    )
+except ImportError:
+    HAS_PYPURECLIENT = False
 
 HAS_PYTZ = True
 try:
@@ -133,11 +342,13 @@ from ansible.module_utils.facts.utils import get_file_content
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
     get_blade,
+    get_system,
     purefb_argument_spec,
 )
 
 
 MIN_REQUIRED_API_VERSION = "1.9"
+ACCESS_POLICY_API_VERSION = "2.2"
 
 
 def _convert_to_millisecs(hour):
@@ -229,6 +440,329 @@ def _get_local_tz(module, timezone="UTC"):
         module.warn("Could not find /etc/timezone. Assuming UTC")
 
     return timezone
+
+
+def delete_os_policy(module, blade):
+    """Delete Object Store Access Policy, Rule, or User
+
+    If rule is provided then delete the rule if it exists.
+    If user is provided then remove grant from user if granted.
+    If no user or rule provided delete the whole policy.
+    Cannot delete a policy with attached users, so delete all users
+    if the force_delete option is selected.
+    """
+
+    changed = False
+    policy_name = module.params["account"] + "/" + module.params["name"]
+    policy_delete = True
+    if module.params["rule"]:
+        policy_delete = False
+        res = blade.get_object_store_access_policies_rules(
+            policy_names=[policy_name], names=[module.params["rule"]]
+        )
+        if res.status_code == 200 and res.total_item_count != 0:
+            changed = True
+            if not module.check_mode:
+                res = blade.delete_object_store_access_policies_object_store_rules(
+                    policy_names=[policy_name], names=[module.params["rule"]]
+                )
+                if res.status_code != 200:
+                    module.fail_json(
+                        msg="Failed to delete users from policy {0}. Error: {1} - {2}".format(
+                            policy_name, res.errors[0].context, res.errors[0].message
+                        )
+                    )
+
+    if module.params["user"]:
+        member_name = module.params["account"] + "/" + module.params["user"]
+        policy_delete = False
+        res = blade.get_object_store_access_policies_object_store_users(
+            policy_names=[policy_name], member_names=[member_name]
+        )
+        if res.status_code == 200 and res.total_item_count != 0:
+            changed = True
+            if not module.check_mode:
+                member_name = module.params["account"] + "/" + module.params["user"]
+                res = blade.delete_object_store_access_policies_object_store_users(
+                    policy_names=[policy_name], member_names=[member_name]
+                )
+                if res.status_code != 200:
+                    module.fail_json(
+                        msg="Failed to delete users from policy {0}. Error: {1} - {2}".format(
+                            policy_name, res.errors[0].context, res.errors[0].message
+                        )
+                    )
+
+    if policy_delete:
+        if module.params["account"].lower() == "pure:policy":
+            module.fail_json(msg="System-Wide policies cannot be deleted.")
+        policy_users = list(
+            blade.get_object_store_access_policies_object_store_users(
+                policy_names=[policy_name]
+            ).items
+        )
+        if len(policy_users) == 0:
+            changed = True
+            if not module.check_mode:
+                res = blade.delete_object_store_access_policies(names=[policy_name])
+                if res.status_code != 200:
+                    module.fail_json(
+                        msg="Failed to delete policy {0}. Error: {1}".format(
+                            policy_name, res.errors[0].message
+                        )
+                    )
+        else:
+            if module.params["force_delete"]:
+                changed = True
+                if not module.check_mode:
+                    for user in range(0, len(policy_users)):
+                        res = blade.delete_object_store_access_policies_object_store_users(
+                            member_names=[policy_users[user].member.name],
+                            policy_names=[policy_name],
+                        )
+                        if res.status_code != 200:
+                            module.fail_json(
+                                msg="Failed to delete user {0} from policy {1}, "
+                                "Error: {2}".format(
+                                    policy_users[user].member,
+                                    policy_name,
+                                    res.errors[0].message,
+                                )
+                            )
+                    res = blade.delete_object_store_access_policies(names=[policy_name])
+                    if res.status_code != 200:
+                        module.fail_json(
+                            msg="Failed to delete policy {0}. Error: {1}".format(
+                                policy_name, res.errors[0].message
+                            )
+                        )
+            else:
+                module.fail_json(
+                    msg="Policy {0} cannot be deleted with connected users".format(
+                        policy_name
+                    )
+                )
+    module.exit_json(changed=changed)
+
+
+def create_os_policy(module, blade):
+    """Create Object Store Access Policy"""
+    changed = True
+    policy_name = module.params["account"] + "/" + module.params["name"]
+    if not module.check_mode:
+        res = blade.post_object_store_access_policies(names=[policy_name])
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to create access policy {0}.".format(policy_name)
+            )
+        if module.params["rule"]:
+            if not module.params["actions"] or not module.params["object_resources"]:
+                module.fail_json(
+                    msg="Parameters `actions` and `object_resources` "
+                    "are required to create a new rule"
+                )
+            conditions = PolicyRuleObjectAccessCondition(
+                source_ips=module.params["source_ips"],
+                s3_delimiters=module.params["s3_delimiters"],
+                s3_prefixes=module.params["s3_prefixes"],
+            )
+            rule = PolicyRuleObjectAccessPost(
+                actions=module.params["actions"],
+                resources=module.params["object_resources"],
+                conditions=conditions,
+            )
+            res = blade.post_object_store_access_policies_rules(
+                policy_names=policy_name,
+                names=[module.params["rule"]],
+                enforce_action_restrictions=module.params["ignore_enforcement"],
+                rule=rule,
+            )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Failed to create rule {0} to policy {1}. Error: {2}".format(
+                        module.params["rule"], policy_name, res.errors[0].message
+                    )
+                )
+        if module.params["user"]:
+            member_name = module.params["account"] + "/" + module.params["user"]
+            res = blade.post_object_store_access_policies_object_store_users(
+                member_names=[member_name], policy_names=[policy_name]
+            )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Failed to add users to policy {0}. Error: {1} - {2}".format(
+                        policy_name, res.errors[0].context, res.errors[0].message
+                    )
+                )
+    module.exit_json(changed=changed)
+
+
+def update_os_policy(module, blade, policy):
+    """Update Object Store Access Policy"""
+    changed = False
+    policy_name = module.params["account"] + "/" + module.params["name"]
+    if module.params["rule"]:
+        current_policy_rule = blade.get_object_store_access_policies_rules(
+            policy_names=[policy_name], names=[module.params["rule"]]
+        )
+        if current_policy_rule.status_code != 200:
+            conditions = PolicyRuleObjectAccessCondition(
+                source_ips=module.params["source_ips"],
+                s3_delimiters=module.params["s3_delimiters"],
+                s3_prefixes=module.params["s3_prefixes"],
+            )
+            rule = PolicyRuleObjectAccessPost(
+                actions=module.params["actions"],
+                resources=module.params["object_resources"],
+                conditions=conditions,
+            )
+            res = blade.post_object_store_access_policies_rules(
+                policy_names=policy_name,
+                names=[module.params["rule"]],
+                enforce_action_restrictions=module.params["ignore_enforcement"],
+                rule=rule,
+            )
+        else:
+            old_policy_rule = list(current_policy_rule.items)[0]
+            current_rule = {
+                "actions": old_policy_rule.actions,
+                "resources": old_policy_rule.resources,
+                "ips": getattr(old_policy_rule.conditions, "source_ips", None),
+                "prefixes": getattr(old_policy_rule.conditions, "s3_prefixes", None),
+                "delimiters": getattr(
+                    old_policy_rule.conditions, "s3_delimiters", None
+                ),
+            }
+            if module.params["actions"]:
+                new_actions = sorted(module.params["actions"])
+            else:
+                new_actions = sorted(current_rule["actions"])
+            if module.params["object_resources"]:
+                new_resources = sorted(module.params["object_resources"])
+            else:
+                new_resources = sorted(current_rule["resources"])
+            if module.params["s3_prefixes"]:
+                new_prefixes = sorted(module.params["s3_prefixes"])
+            elif current_rule["prefixes"]:
+                new_prefixes = sorted(current_rule["prefixes"])
+            else:
+                new_prefixes = None
+            if module.params["s3_delimiters"]:
+                new_delimiters = sorted(module.params["s3_delimiters"])
+            elif current_rule["delimiters"]:
+                new_delimiters = sorted(current_rule["delimiters"])
+            else:
+                new_delimiters = None
+            if module.params["source_ips"]:
+                new_ips = sorted(module.params["source_ips"])
+            elif current_rule["ips"]:
+                new_ips = sorted(current_rule["source_ips"])
+            else:
+                new_ips = None
+            new_rule = {
+                "actions": new_actions,
+                "resources": new_resources,
+                "ips": new_ips,
+                "prefixes": new_prefixes,
+                "delimiters": new_delimiters,
+            }
+            if current_rule != new_rule:
+                changed = True
+                if not module.check_mode:
+                    conditions = PolicyRuleObjectAccessCondition(
+                        source_ips=new_rule["ips"],
+                        s3_prefixes=new_rule["prefixes"],
+                        s3_delimiters=new_rule["delimiters"],
+                    )
+                    rule = PolicyRuleObjectAccess(
+                        actions=new_rule["actions"],
+                        resources=new_rule["resources"],
+                        conditions=conditions,
+                    )
+                    res = blade.patch_object_store_access_policies_rules(
+                        policy_names=[policy_name],
+                        names=[module.params["rule"]],
+                        rule=rule,
+                        enforce_action_restrictions=module.params["ignore_enforcement"],
+                    )
+                if res.status_code != 200:
+                    module.fail_json(
+                        msg="Failed to update rule {0} in policy {1}. Error: {2}".format(
+                            module.params["rule"], policy_name, res.errors[0].message
+                        )
+                    )
+    if module.params["user"]:
+        member_name = module.params["account"] + "/" + module.params["user"]
+        res = blade.get_object_store_access_policies_object_store_users(
+            policy_names=[policy_name], member_names=[member_name]
+        )
+        if res.status_code != 200 or (
+            res.status_code == 200 and res.total_item_count == 0
+        ):
+            changed = True
+            if not module.check_mode:
+                res = blade.post_object_store_access_policies_object_store_users(
+                    member_names=[member_name], policy_names=[policy_name]
+                )
+                if res.status_code != 200:
+                    module.fail_json(
+                        msg="Failed to add user {0} to policy {1}. Error: {2}".format(
+                            member_name, policy_name, res.errors[0].message
+                        )
+                    )
+    module.exit_json(changed=changed)
+
+
+def copy_os_policy_rule(module, blade):
+    """Copy an existing policy rule to a new policy"""
+    changed = True
+    policy_name = module.params["account"] + "/" + module.params["name"]
+    if not module.params["target_rule"]:
+        module.params["target_rule"] = module.params["rule"]
+    if (
+        blade.get_object_store_access_policies_rules(
+            policy_names=[module.params["target"]], names=[module.params["target_rule"]]
+        ).status_code
+        == 200
+    ):
+        module.fail_json(
+            msg="Target rule {0} already exists in policy {1}".format(
+                module.params["target_rule"], policy_name
+            )
+        )
+    current_rule = list(
+        blade.get_object_store_access_policies_rules(
+            policy_names=[policy_name], names=[module.params["rule"]]
+        ).items
+    )[0]
+    if not module.check_mode:
+        conditions = PolicyRuleObjectAccessCondition(
+            source_ips=current_rule.conditions.source_ips,
+            s3_delimiters=current_rule.conditions.s3_delimiters,
+            s3_prefixes=current_rule.conditions.s3_prefixes,
+        )
+        rule = PolicyRuleObjectAccessPost(
+            actions=current_rule.actions,
+            resources=current_rule.resources,
+            conditions=conditions,
+        )
+        res = blade.post_object_store_access_policies_rules(
+            policy_names=module.params["target"],
+            names=[module.params["target_rule"]],
+            enforce_action_restrictions=module.params["ignore_enforcement"],
+            rule=rule,
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to copy rule {0} from policy {1} to policy {2}. "
+                "Error: {3}".format(
+                    module.params["rule"],
+                    policy_name,
+                    module.params["target"],
+                    res.errors[0].message,
+                )
+            )
+    module.exit_json(changed=changed)
 
 
 def delete_policy(module, blade):
@@ -486,7 +1020,12 @@ def main():
     argument_spec = purefb_argument_spec()
     argument_spec.update(
         dict(
-            state=dict(type="str", default="present", choices=["absent", "present"]),
+            state=dict(
+                type="str", default="present", choices=["absent", "present", "copy"]
+            ),
+            policy_type=dict(
+                type="str", default="snapshot", choices=["snapshot", "access"]
+            ),
             enabled=dict(type="bool", default=True),
             timezone=dict(type="str"),
             name=dict(type="str"),
@@ -495,42 +1034,138 @@ def main():
             keep_for=dict(type="int"),
             filesystem=dict(type="list", elements="str"),
             replica_link=dict(type="list", elements="str"),
+            account=dict(type="str"),
+            target=dict(type="str"),
+            target_rule=dict(type="str"),
+            rule=dict(type="str"),
+            user=dict(type="str"),
+            effect=dict(type="str", default="allow", choices=["allow"]),
+            actions=dict(
+                type="list",
+                elements="str",
+                choices=[
+                    "s3:*",
+                    "s3:AbortMultipartUpload",
+                    "s3:CreateBucket",
+                    "s3:DeleteBucket",
+                    "s3:DeleteObject",
+                    "s3:DeleteObjectVersion",
+                    "s3:ExtendSafemodeRetentionPeriod",
+                    "s3:GetBucketAcl",
+                    "s3:GetBucketLocation",
+                    "s3:GetBucketVersioning",
+                    "s3:GetLifecycleConfiguration",
+                    "s3:GetObject",
+                    "s3:GetObjectAcl",
+                    "s3:GetObjectVersion",
+                    "s3:ListAllMyBuckets",
+                    "s3:ListBucket",
+                    "s3:ListBucketMultipartUploads",
+                    "s3:ListBucketVersions",
+                    "s3:ListMultipartUploadParts",
+                    "s3:PutBucketVersioning",
+                    "s3:PutLifecycleConfiguration",
+                    "s3:PutObject",
+                ],
+            ),
+            object_resources=dict(type="list", elements="str"),
+            source_ips=dict(type="list", elements="str"),
+            s3_prefixes=dict(type="list", elements="str"),
+            s3_delimiters=dict(type="list", elements="str"),
+            ignore_enforcement=dict(type="bool", default=True),
+            force_delete=dict(type="bool", default=False),
         )
     )
 
     required_together = [["keep_for", "every"]]
+    required_if = [["policy_type", "access", ["account", "name"]]]
 
     module = AnsibleModule(
-        argument_spec, required_together=required_together, supports_check_mode=True
+        argument_spec,
+        required_together=required_together,
+        required_if=required_if,
+        supports_check_mode=True,
     )
 
     if not HAS_PURITYFB:
-        module.fail_json(msg="purity_fb sdk is required for this module")
+        module.fail_json(msg="purity-fb sdk is required for this module")
     if not HAS_PYTZ:
         module.fail_json(msg="pytz is required for this module")
 
     state = module.params["state"]
     blade = get_blade(module)
     versions = blade.api_version.list_versions().versions
-
-    if MIN_REQUIRED_API_VERSION not in versions:
-        module.fail_json(
-            msg="Minimum FlashBlade REST version required: {0}".format(
-                MIN_REQUIRED_API_VERSION
+    if module.params["policy_type"] == "access":
+        if ACCESS_POLICY_API_VERSION not in versions:
+            module.fail_json(
+                msg="Minimum FlashBlade REST version required: {0}".format(
+                    MIN_REQUIRED_API_VERSION
+                )
             )
-        )
+        if not HAS_PYPURECLIENT:
+            module.fail_json(msg="py-pure-client sdk is required for this module")
+        blade = get_system(module)
+        try:
+            policy = list(
+                blade.get_object_store_access_policies(
+                    names=[module.params["account"] + "/" + module.params["name"]]
+                ).items
+            )[0]
+        except AttributeError:
+            policy = None
+        if module.params["user"]:
+            policy_name = module.params["account"] + "/" + module.params["name"]
+            member_name = module.params["account"] + "/" + module.params["user"]
+            res = blade.get_object_store_users(filter='name="member_name"')
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="User {0} does not exist in account {1}".format(
+                        module.params["user"], module.params["account"]
+                    )
+                )
+        if policy and state == "present":
+            update_os_policy(module, blade, policy)
+        elif state == "present" and not policy:
+            create_os_policy(module, blade)
+        elif state == "absent" and policy:
+            delete_os_policy(module, blade)
+        elif state == "copy" and module.params["target"] and module.params["rule"]:
+            if "/" not in module.params["target"]:
+                module.fail_json(
+                    msg='Incorrect format for target policy. Must be "<account>/<name>"'
+                )
+            if (
+                blade.get_object_store_access_policies(
+                    names=[module.params["target"]]
+                ).status_code
+                != 200
+            ):
+                module.fail_json(
+                    msg="Target policy {0} does not exist".format(
+                        module.params["target"]
+                    )
+                )
+            copy_os_policy_rule(module, blade)
+    else:
+        if MIN_REQUIRED_API_VERSION not in versions:
+            module.fail_json(
+                msg="Minimum FlashBlade REST version required: {0}".format(
+                    MIN_REQUIRED_API_VERSION
+                )
+            )
+        try:
+            policy = blade.policies.list_policies(names=[module.params["name"]]).items[
+                0
+            ]
+        except Exception:
+            policy = None
 
-    try:
-        policy = blade.policies.list_policies(names=[module.params["name"]])
-    except Exception:
-        policy = None
-
-    if policy and state == "present":
-        update_policy(module, blade, policy.items[0])
-    elif state == "present" and not policy:
-        create_policy(module, blade)
-    elif state == "absent" and policy:
-        delete_policy(module, blade)
+        if policy and state == "present":
+            update_policy(module, blade, policy)
+        elif state == "present" and not policy:
+            create_policy(module, blade)
+        elif state == "absent" and policy:
+            delete_policy(module, blade)
 
     module.exit_json(changed=False)
 


### PR DESCRIPTION
##### SUMMARY
- Add support for Object Store Access Policies.
- Rules for policies can be created, deleted and modified
- Users can be granted or ungranted permissions through the policies.
- New policies can be created, but existing `pure:policy` systemwide policies cannot be amended other than granting/ungranting users.
- Add parameter of `policy_type` to define which policy is worked on - `access` or `snapshot`
- For backwards compatibility the `policy_type` defaults to `snapshot` if not provided.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_policy.py

##### ADDITIONAL INFORMATION
Requires REST 2.2, Purity//FB 3.2.4