### PR TITLE
Add support for replica link bandwidth throttling

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/175_throttle_support.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/175_throttle_support.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - purefb_connect - Add support for array connections to have bandwidth throttling defined
+  - purefb_info - Show array connections bandwidth throttle information

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_connect.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_connect.py
@@ -44,6 +44,44 @@ options:
     description:
     - API token for target FlashBlade system
     type: str
+  target_repl:
+    description:
+    - Replication IP address of target FlashBlade system
+    - If not set at time of connection creation, will default to
+      all the replication addresses available on the target array
+      at the time of connection creation.
+    type: list
+    elements: str
+    version_added: "1.9.0"
+  default_limit:
+    description:
+    - Default maximum bandwidth threshold for outbound traffic in bytes.
+    - B, K, M, or G units. See examples.
+    - Must be 0 or between 5MB and 28GB
+    - Once exceeded, bandwidth throttling occurs
+    type: str
+    version_added: "1.9.0"
+  window_limit:
+    description:
+    - Maximum bandwidth threshold for outbound traffic during the specified
+      time range in bytes.
+    - B, K, M, or G units. See examples.
+    - Must be 0 or between 5MB and 28GB
+    - Once exceeded, bandwidth throttling occurs
+    type: str
+    version_added: "1.9.0"
+  window_start:
+    description:
+    - The window start time.
+    - The time must be set to the hour.
+    type: str
+    version_added: "1.9.0"
+  window_end:
+    description:
+    - The window end time.
+    - The time must be set to the hour.
+    type: str
+    version_added: "1.9.0"
 extends_documentation_fragment:
 - purestorage.flashblade.purestorage.fb
 """
@@ -52,16 +90,26 @@ EXAMPLES = r"""
 - name: Create a connection to remote FlashBlade system
   purefb_connect:
     target_url: 10.10.10.20
-    target_api: 9c0b56bc-f941-f7a6-9f85-dcc3e9a8f7d6
+    target_api: T-b3275b1c-8958-4190-9052-eb46b0bd09f8
     fb_url: 10.10.10.2
-    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+    api_token: T-91528421-fe42-47ee-bcb1-47eefb0a9220
+- name: Create a connection to remote FlashBlade system with bandwidth limits
+  purefb_connect:
+    target_url: 10.10.10.20
+    target_api: T-b3275b1c-8958-4190-9052-eb46b0bd09f8
+    window_limit: 28G
+    window_start: 1AM
+    window_end: 7AM
+    default_limit: 5M
+    fb_url: 10.10.10.2
+    api_token: T-91528421-fe42-47ee-bcb1-47eefb0a9220
 - name: Delete connection to target FlashBlade system
   purefb_connect:
     state: absent
     target_url: 10.10.10.20
-    target_api: 9c0b56bc-f941-f7a6-9f85-dcc3e9a8f7d6
+    target_api: T-b3275b1c-8958-4190-9052-eb46b0bd09f8
     fb_url: 10.10.10.2
-    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+    api_token: T-91528421-fe42-47ee-bcb1-47eefb0a9220
 """
 
 RETURN = r"""
@@ -73,14 +121,35 @@ try:
 except ImportError:
     HAS_PURITYFB = False
 
-from ansible.module_utils.basic import AnsibleModule
+HAS_PYPURECLIENT = True
+try:
+    from pypureclient import flashblade
+    from pypureclient.flashblade import ArrayConnection, ArrayConnectionPost
+except ImportError:
+    HAS_PYPURECLIENT = False
+
+from ansible.module_utils.basic import AnsibleModule, human_to_bytes
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
     get_blade,
+    get_system,
     purefb_argument_spec,
 )
 
 
+FAN_IN_MAXIMUM = 1
+FAN_OUT_MAXIMUM = 3
 MIN_REQUIRED_API_VERSION = "1.9"
+THROTTLE_API_VERSION = "2.3"
+
+
+def _convert_to_millisecs(hour):
+    if hour[-2:] == "AM" and hour[:2] == "12":
+        return 0
+    elif hour[-2:] == "AM":
+        return int(hour[:-2]) * 3600000
+    elif hour[-2:] == "PM" and hour[:2] == "12":
+        return 43200000
+    return (int(hour[:-2]) + 12) * 3600000
 
 
 def _check_connected(module, blade):
@@ -144,11 +213,10 @@ def create_connection(module, blade):
             remote_conn_cnt = (
                 remote_system.array_connections.list_array_connections().pagination_info.total_item_count
             )
-            # TODO: SD - Update with new max when fan-in/fan-out is enabled for FB
-            if remote_conn_cnt == 1:
+            if remote_conn_cnt == FAN_IN_MAXIMUM:
                 module.fail_json(
-                    msg="Remote array {0} already connected to another array. Fan-In not supported".format(
-                        remote_array
+                    msg="Remote array {0} already connected to {1} other array. Fan-In not supported".format(
+                        remote_array, remote_conn_cnt
                     )
                 )
             connection_key = (
@@ -156,7 +224,6 @@ def create_connection(module, blade):
                 .items[0]
                 .connection_key
             )
-            remote_array = remote_system.arrays.list_arrays().items[0].name
             connection_info = ArrayConnectionPost(
                 management_address=module.params["target_url"],
                 encrypted=module.params["encrypted"],
@@ -172,37 +239,220 @@ def create_connection(module, blade):
     module.exit_json(changed=changed)
 
 
+def create_v2_connection(module, blade):
+    """Create connection between REST 2 capable arrays"""
+    changed = True
+    if blade.get_array_connections().total_item_count == FAN_OUT_MAXIMUM:
+        module.fail_json(
+            msg="FlashBlade fan-out maximum of {0} already reached".format(
+                FAN_OUT_MAXIMUM
+            )
+        )
+    try:
+        remote_system = flashblade.Client(
+            target=module.params["target_url"], api_token=module.params["target_api"]
+        )
+    except Exception:
+        module.fail_json(
+            msg="Failed to connect to remote array {0}.".format(
+                module.params["target_url"]
+            )
+        )
+    remote_array = list(remote_system.get_arrays().items)[0].name
+    remote_conn_cnt = remote_system.get_array_connections().total_item_count
+    if remote_conn_cnt == FAN_IN_MAXIMUM:
+        module.fail_json(
+            msg="Remote array {0} already connected to {1} other array. Fan-In not supported".format(
+                remote_array, remote_conn_cnt
+            )
+        )
+    connection_key = list(remote_system.post_array_connections_connection_key().items)[
+        0
+    ].connection_key
+    if THROTTLE_API_VERSION in list(blade.get_versions().items):
+        if THROTTLE_API_VERSION not in list(remote_system.get_versions().items):
+            module.fail_json(msg="Remote array does not support throttling")
+        window = flashblade.TimeWindow(
+            start=_convert_to_millisecs(module.params["window_start"]),
+            end=_convert_to_millisecs(module.params["window_end"]),
+        )
+        throttle = flashblade.Throttle(
+            default_limit=human_to_bytes(module.params["default_limit"]),
+            window_limit=human_to_bytes(module.params["window_limit"]),
+            window=window,
+        )
+        connection_info = ArrayConnectionPost(
+            management_address=module.params["target_url"],
+            replication_addresses=module.params["target_repl"],
+            encrypted=module.params["encrypted"],
+            connection_key=connection_key,
+            throttle=throttle,
+        )
+    else:
+        connection_info = ArrayConnectionPost(
+            management_address=module.params["target_url"],
+            replication_addresses=module.params["target_repl"],
+            encrypted=module.params["encrypted"],
+            connection_key=connection_key,
+        )
+    if not module.check_mode:
+        res = blade.post_array_connections(array_connection=connection_info)
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to connect to remote array {0}. Error: {1}".format(
+                    remote_array, res.errors[0].message
+                )
+            )
+    module.exit_json(changed=changed)
+
+
 def update_connection(module, blade, target_blade):
     """Update array connection - only encryption currently"""
-    changed = True
-    if not module.check_mode:
-        if target_blade.management_address is None:
+    changed = False
+    if target_blade.management_address is None:
+        module.fail_json(
+            msg="Update can only happen from the array that formed the connection"
+        )
+    if module.params["encrypted"] != target_blade.encrypted:
+        if (
+            module.params["encrypted"]
+            and blade.file_system_replica_links.list_file_system_replica_links().pagination_info.total_item_count
+            != 0
+        ):
             module.fail_json(
-                msg="Update can only happen from the array that formed the connection"
+                msg="Cannot turn array connection encryption on if file system replica links exist"
             )
-        if module.params["encrypted"] != target_blade.encrypted:
-            if (
-                module.params["encrypted"]
-                and blade.file_system_replica_links.list_file_system_replica_links().pagination_info.total_item_count
-                != 0
-            ):
-                module.fail_json(
-                    msg="Cannot turn array connection encryption on if file system replica links exist"
+        new_attr = ArrayConnection(encrypted=module.params["encrypted"])
+        changed = True
+        if not module.check_mode:
+            try:
+                blade.array_connections.update_array_connections(
+                    remote_names=[target_blade.remote.name],
+                    array_connection=new_attr,
                 )
-            new_attr = ArrayConnection(encrypted=module.params["encrypted"])
-            changed = True
-            if not module.check_mode:
-                try:
-                    blade.array_connections.update_array_connections(
-                        remote_names=[target_blade.remote.name],
-                        array_connection=new_attr,
+            except Exception:
+                module.fail_json(
+                    msg="Failed to change encryption setting for array connection."
+                )
+    module.exit_json(changed=changed)
+
+
+def update_v2_connection(module, blade):
+    """Update REST 2 based array connection"""
+    changed = False
+    versions = list(blade.get_versions().items)
+    remote_blade = flashblade.Client(
+        target=module.params["target_url"], api_token=module.params["target_api"]
+    )
+    remote_name = list(remote_blade.get_arrays().items)[0].name
+    remote_connection = list(
+        blade.get_array_connections(filter="remote.name='" + remote_name + "'").items
+    )[0]
+    if remote_connection.management_address is None:
+        module.fail_json(
+            msg="Update can only happen from the array that formed the connection"
+        )
+    if module.params["encrypted"] != remote_connection.encrypted:
+        if (
+            module.params["encrypted"]
+            and blade.get_file_system_replica_links().total_item_count != 0
+        ):
+            module.fail_json(
+                msg="Cannot turn array connection encryption on if file system replica links exist"
+            )
+    current_connection = {
+        "encrypted": remote_connection.encrypted,
+        "replication_addresses": sorted(remote_connection.replication_addresses),
+        "throttle": [],
+    }
+    if (
+        not remote_connection.throttle.default_limit
+        and not remote_connection.throttle.window_limit
+    ):
+        if (
+            module.params["default_limit"] or module.params["window_limit"]
+        ) and blade.get_bucket_replica_links().total_item_count != 0:
+            module.fail_json(
+                msg="Cannot set throttle when bucket replica links already exist"
+            )
+    if THROTTLE_API_VERSION in versions:
+        current_connection["throttle"] = {
+            "default_limit": remote_connection.throttle.default_limit,
+            "window_limit": remote_connection.throttle.window_limit,
+            "start": remote_connection.throttle.window.start,
+            "end": remote_connection.throttle.window.end,
+        }
+    if module.params["encrypted"]:
+        encryption = module.params["encrypted"]
+    else:
+        encryption = remote_connection.encrypted
+    if module.params["target_repl"]:
+        target_repl = sorted(module.params["target_repl"])
+    else:
+        target_repl = remote_connection.replication_addresses
+    if module.params["default_limit"]:
+        default_limit = human_to_bytes(module.params["default_limit"])
+        if default_limit == 0:
+            default_limit = None
+    else:
+        default_limit = remote_connection.throttle.default_limit
+    if module.params["window_limit"]:
+        window_limit = human_to_bytes(module.params["window_limit"])
+    else:
+        window_limit = remote_connection.throttle.window_limit
+    if module.params["window_start"]:
+        start = _convert_to_millisecs(module.params["window_start"])
+    else:
+        start = remote_connection.throttle.window.start
+    if module.params["window_end"]:
+        end = _convert_to_millisecs(module.params["window_end"])
+    else:
+        end = remote_connection.throttle.window.end
+
+    new_connection = {
+        "encrypted": encryption,
+        "replication_addresses": target_repl,
+        "throttle": [],
+    }
+    if THROTTLE_API_VERSION in versions:
+        new_connection["throttle"] = {
+            "default_limit": default_limit,
+            "window_limit": window_limit,
+            "start": start,
+            "end": end,
+        }
+    if new_connection != current_connection:
+        changed = True
+        if not module.check_mode:
+            if THROTTLE_API_VERSION in versions:
+                window = flashblade.TimeWindow(
+                    start=new_connection["throttle"]["start"],
+                    end=new_connection["throttle"]["end"],
+                )
+                throttle = flashblade.Throttle(
+                    default_limit=new_connection["throttle"]["default_limit"],
+                    window_limit=new_connection["throttle"]["window_limit"],
+                    window=window,
+                )
+                connection_info = ArrayConnectionPost(
+                    replication_addresses=new_connection["replication_addresses"],
+                    encrypted=new_connection["encrypted"],
+                    throttle=throttle,
+                )
+            else:
+                connection_info = ArrayConnection(
+                    replication_addresses=new_connection["replication_addresses"],
+                    encrypted=new_connection["encrypted"],
+                )
+            res = blade.patch_array_connections(
+                remote_names=[remote_name], array_connection=connection_info
+            )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Failed to update connection to remote array {0}. Error: {1}".format(
+                        remote_name, res.errors[0].message
                     )
-                except Exception:
-                    module.fail_json(
-                        msg="Failed to change encryption setting for array connection."
-                    )
-        else:
-            changed = False
+                )
     module.exit_json(changed=changed)
 
 
@@ -214,6 +464,11 @@ def main():
             encrypted=dict(type="bool", default=False),
             target_url=dict(type="str", required=True),
             target_api=dict(type="str", no_log=True),
+            target_repl=dict(type="list", elements="str"),
+            default_limit=dict(type="str"),
+            window_limit=dict(type="str"),
+            window_start=dict(type="str"),
+            window_end=dict(type="str"),
         )
     )
 
@@ -236,20 +491,56 @@ def main():
                 MIN_REQUIRED_API_VERSION
             )
         )
+    if "2.0" in versions:
+        bladev2 = get_system(module)
+        if not HAS_PYPURECLIENT:
+            module.fail_json(msg="py-pure-client sdk is required for this module")
+        v2_connection = True
+        if module.params["default_limit"]:
+            if (
+                human_to_bytes(module.params["default_limit"]) != 0
+                and 5242880
+                >= human_to_bytes(module.params["default_limit"])
+                >= 30064771072
+            ):
+                module.fail_json(msg="Default Bandwidth must be between 5MB and 28GB")
+        if module.params["window_limit"]:
+            if (
+                human_to_bytes(module.params["window_limit"]) != 0
+                and 5242880
+                >= human_to_bytes(module.params["window_limit"])
+                >= 30064771072
+            ):
+                module.fail_json(msg="Window Bandwidth must be between 5MB and 28GB")
+    else:
+        if module.params["target_repl"]:
+            module.warn(
+                "Target Replication addresses can only be set for systems"
+                " that support REST 2.0 and higher"
+            )
+        v2_connection = False
 
     target_blade = _check_connected(module, blade)
     if state == "present" and not target_blade:
-        # TODO: SD - Update with new max when fan-out is supported
-        if (
-            blade.array_connections.list_array_connections().pagination_info.total_item_count
-            == 1
-        ):
-            module.fail_json(
-                msg="Source FlashBlade already connected to another array. Fan-Out not supported"
-            )
-        create_connection(module, blade)
+        # REST 1 does not support fan-out for replication
+        # REST 2 has a limit which we can checkt
+        # fail and expose the error message
+        if v2_connection:
+            create_v2_connection(module, bladev2)
+        else:
+            if (
+                blade.array_connections.list_array_connections().pagination_info.total_item_count
+                == 1
+            ):
+                module.fail_json(
+                    msg="Source FlashBlade already connected to another array. Fan-Out not supported"
+                )
+            create_connection(module, blade)
     elif state == "present" and target_blade:
-        update_connection(module, blade, target_blade)
+        if v2_connection:
+            update_v2_connection(module, bladev2)
+        else:
+            update_connection(module, blade, target_blade)
     elif state == "absent" and target_blade:
         break_connection(module, blade, target_blade)
 

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
@@ -449,6 +449,25 @@ SMB_MODE_API_VERSION = "2.2"
 NFS_POLICY_API_VERSION = "2.3"
 
 
+def _millisecs_to_time(millisecs):
+    if millisecs:
+        return (str(int(millisecs / 3600000 % 24)).zfill(2) + ":00",)
+    return None
+
+
+def _bytes_to_human(bytes_number):
+    if bytes_number:
+        labels = ["B/s", "KB/s", "MB/s", "GB/s", "TB/s", "PB/s"]
+        i = 0
+        double_bytes = bytes_number
+        while i < len(labels) and bytes_number >= 1024:
+            double_bytes = bytes_number / 1024.0
+            i += 1
+            bytes_number = bytes_number / 1024
+        return str(round(double_bytes, 2)) + " " + labels[i]
+    return None
+
+
 def generate_default_dict(module, blade):
     default_info = {}
     defaults = blade.arrays.list_arrays().items[0]
@@ -504,12 +523,13 @@ def generate_default_dict(module, blade):
         else:
             default_info["EULA"] = "Not Signed"
         if NFS_POLICY_API_VERSION in api_version:
-            admin_settings = list(blade.get_admin_settings().items)[0]
+            admin_settings = list(blade.get_admins_settings().items)[0]
             default_info["max_login_attempts"] = admin_settings.max_login_attempts
             default_info["min_password_length"] = admin_settings.min_password_length
-            default_info["lockout_duration"] = (
-                str(admin_settings.lockout_duration / 1000) + " seconds"
-            )
+            if admin_settings.lockout_duration:
+                default_info["lockout_duration"] = (
+                    str(admin_settings.lockout_duration / 1000) + " seconds"
+                )
         if NFS_POLICY_API_VERSION in api_version:
             default_info["smb_mode"] = blade_info.smb_mode
 
@@ -941,23 +961,44 @@ def generate_snap_transfer_dict(blade):
     return snap_transfer_info
 
 
-def generate_array_conn_dict(blade):
+def generate_array_conn_dict(module, blade):
     array_conn_info = {}
+    arraysv2 = {}
+    api_version = blade.api_version.list_versions().versions
     arrays = blade.array_connections.list_array_connections()
+    if NFS_POLICY_API_VERSION in api_version:
+        bladev2 = get_system(module)
+        arraysv2 = list(bladev2.get_array_connections().items)
     for arraycnt in range(0, len(arrays.items)):
         array = arrays.items[arraycnt].remote.name
         array_conn_info[array] = {
             "encrypted": arrays.items[arraycnt].encrypted,
             "replication_addresses": arrays.items[arraycnt].replication_addresses,
             "management_address": arrays.items[arraycnt].management_address,
-            "id": arrays.items[arraycnt].remote.id,
             "status": arrays.items[arraycnt].status,
             "version": arrays.items[arraycnt].version,
+            "throttle": [],
         }
         if arrays.items[arraycnt].encrypted:
             array_conn_info[array]["ca_certificate_group"] = arrays.items[
                 arraycnt
             ].ca_certificate_group.name
+        for v2array in range(0, len(arraysv2)):
+            if arraysv2[v2array].remote.name == array:
+                array_conn_info[array]["throttle"] = {
+                    "default_limit": _bytes_to_human(
+                        arraysv2[v2array].throttle.default_limit
+                    ),
+                    "window_limit": _bytes_to_human(
+                        arraysv2[v2array].throttle.window_limit
+                    ),
+                    "window_start": _millisecs_to_time(
+                        arraysv2[v2array].throttle.window.start
+                    ),
+                    "window_end": _millisecs_to_time(
+                        arraysv2[v2array].throttle.window.end
+                    ),
+                }
     return array_conn_info
 
 
@@ -1283,7 +1324,7 @@ def main():
             info["snapshot_policies"] = generate_policies_dict(blade)
     if REPLICATION_API_VERSION in api_version:
         if "arrays" in subset or "all" in subset:
-            info["arrays"] = generate_array_conn_dict(blade)
+            info["arrays"] = generate_array_conn_dict(module, blade)
         if "replication" in subset or "all" in subset:
             info["file_replication"] = generate_file_repl_dict(blade)
             info["bucket_replication"] = generate_bucket_repl_dict(module, blade)


### PR DESCRIPTION
##### SUMMARY
Add support for replication bandwidtrh throttling
Expose connection bandwidth through info module
Update connection module to set the bandwidth parameters
Additonally update FAN_IN and FAN_OUT to be parameters for future use and allow FAN_OUT to be 3 now if using REST 2 capable array

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_connect.py
purefb_info.py
