### PR TITLE
Add NFS Export Policy support

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/176_nfs_export_policies.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/176_nfs_export_policies.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+ - purefb_policy - Add NFS export policies, with rules, as a new policy type
+ - purefb_info - Add NFS export policies and rules
+ - purefb_fs - Add support for NFS export policies

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_fs.py
@@ -68,6 +68,7 @@ options:
       - Supported binary options are ro/rw, secure/insecure, fileid_32bit/no_fileid_32bit,
         root_squash/no_root_squash, all_squash/no_all_squash and atime/noatime
       - Supported non-binary options are anonuid=#, anongid=#, sec=(sys|krb5)
+      - Superceeded by I(export_policy) if provided
     required: false
     type: str
   smb:
@@ -171,6 +172,13 @@ options:
       - Only available from Purity//FB 3.1.1
     type: bool
     default: True
+  export_policy:
+    description:
+    - Name of NFS export policy to assign to filesystem
+    - Overrides I(nfs_rules)
+    - Only valid for Purity//FB 3.3.0 or higher
+    type: str
+    version_added: "1.9.0"
 extends_documentation_fragment:
     - purestorage.flashblade.purestorage.fb
 """
@@ -253,6 +261,16 @@ try:
 except ImportError:
     HAS_PURITY_FB = False
 
+HAS_PYPURECLIENT = True
+try:
+    from pypureclient.flashblade import (
+        FileSystemPatch,
+        NfsPatch,
+        Reference,
+    )
+except ImportError:
+    HAS_PYPURECLIENT = False
+
 HAS_JSON = True
 try:
     import json
@@ -262,6 +280,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule, human_to_bytes
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
     get_blade,
+    get_system,
     purefb_argument_spec,
 )
 
@@ -270,6 +289,7 @@ HARD_LIMIT_API_VERSION = "1.4"
 NFSV4_API_VERSION = "1.6"
 REPLICATION_API_VERSION = "1.9"
 MULTIPROTOCOL_API_VERSION = "1.11"
+EXPORT_POLICY_API_VERSION = "2.3"
 
 
 def get_fs(module, blade):
@@ -449,6 +469,25 @@ def create_fs(module, blade):
                             module.params["policy"], module.params["name"]
                         )
                     )
+        if EXPORT_POLICY_API_VERSION in api_version and module.params["export_policy"]:
+            system = get_system(module)
+            export_attr = FileSystemPatch(
+                nfs=NfsPatch(
+                    export_policy=Reference(name=module.params["export_policy"])
+                )
+            )
+            res = system.patch_file_systems(
+                names=[module.params["name"]], file_system=export_attr
+            )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Filesystem {0} created, but failed to assign export "
+                    "policy {1}. Error: {2}".format(
+                        module.params["name"],
+                        module.params["export_policy"],
+                        res.errors[0].message,
+                    )
+                )
     module.exit_json(changed=changed)
 
 
@@ -682,6 +721,38 @@ def modify_fs(module, blade):
                             module.params["name"], message
                         )
                     )
+    if EXPORT_POLICY_API_VERSION in api_version and module.params["export_policy"]:
+        system = get_system(module)
+        change_export = False
+        current_fs = list(
+            system.get_file_systems(filter="name='" + module.params["name"] + "'").items
+        )[0]
+        if (
+            current_fs.nfs.export_policy.name
+            and current_fs.nfs.export_policy.name != module.params["export_policy"]
+        ):
+            change_export = True
+        if not current_fs.nfs.export_policy.name and module.params["export_policy"]:
+            change_export = True
+        if change_export and not module.check_mode:
+            export_attr = FileSystemPatch(
+                nfs=NfsPatch(
+                    export_policy=Reference(name=module.params["export_policy"])
+                )
+            )
+            res = system.patch_file_systems(
+                names=[module.params["name"]], file_system=export_attr
+            )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Failed to modify export policy {1} for "
+                    "filesystem {0}. Error: {2}".format(
+                        module.params["name"],
+                        module.params["export_policy"],
+                        res.errors[0].message,
+                    )
+                )
+
     module.exit_json(changed=changed)
 
 
@@ -838,6 +909,7 @@ def main():
                 choices=["nfs", "smb", "shared", "independent", "mode-bits"],
             ),
             size=dict(type="str"),
+            export_policy=dict(type="str"),
         )
     )
 


### PR DESCRIPTION
##### SUMMARY

- Add support for NFS export policies
- Add `nfs` as new policy type in `purefb_policy` module
- Add export policy information in purefb_info` module - details of policies in the `policy` subset and add assigned policies to filesystems in `filesystem` subset

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_policy.py
purefb_info.py
purefb_fs.py