### PR TITLE
Bump Python version to 3.10 in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
##### SUMMARY
Upgrade CI workflow to use Python 3.10