### PR TITLE
Fix incorrect API call for NFS export policy rule

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/185_nfs_export_rule.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/185_nfs_export_rule.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_policy - Fix incorrect API call for NFS export policy rule creation

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
@@ -703,7 +703,7 @@ def update_nfs_policy(module, blade):
                     changed = True
                     if not module.check_mode:
                         if module.params["before_rule"]:
-                            res = blade.post_object_store_access_policies_rules(
+                            res = blade.post_nfs_export_policies_rules(
                                 policy_names=[module.params["name"]],
                                 rule=rule,
                                 before_rule_name=(
@@ -891,7 +891,7 @@ def create_nfs_policy(module, blade):
                 secure=module.params["secure"],
                 security=module.params["security"],
             )
-            res = blade.post_object_store_access_policies_rules(
+            res = blade.post_nfs_export_policies_rules(
                 policy_names=[module.params["name"]],
                 rule=rule,
             )


### PR DESCRIPTION
##### SUMMARY
Use the correct API call for an NFS export policy rule

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_policy.py