### PR TITLE
Add bucket_type support to support VSO mode

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/188_bucket_type.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/188_bucket_type.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefb_info - Expose object store bucket type from Purity//FB 3.3.3
+ - purefb_bucket - Allow setting of bucket type to support VSO - requires Purity//FB 3.3.3 or higher

--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_info.py
@@ -97,6 +97,7 @@ purefb_info:
         "buckets": {
             "central": {
                 "account_name": "jake",
+                "bucket_type": "classic",
                 "created": 1628900154000,
                 "data_reduction": null,
                 "destroyed": false,
@@ -1027,6 +1028,7 @@ def generate_bucket_dict(module, blade):
         bucket = buckets.items[bckt].name
         bucket_info[bucket] = {
             "versioning": buckets.items[bckt].versioning,
+            "bucket_type": getattr(buckets.items[bckt], "bucket_type", None),
             "object_count": buckets.items[bckt].object_count,
             "id": buckets.items[bckt].id,
             "account_name": buckets.items[bckt].account.name,
@@ -1082,6 +1084,12 @@ def generate_bucket_dict(module, blade):
                     rule
                 ].cleanup_expired_object_delete_marker,
             }
+        if VSO_VERSION in api_version:
+            buckets = list(blade.get_buckets().items)
+            for bucket in range(0, len(buckets)):
+                bucket_info[buckets[bucket].name]["bucket_type"] = bucket_info[
+                    buckets[bucket]
+                ].bucket_type
     return bucket_info
 
 


### PR DESCRIPTION
##### SUMMARY
Add support for VSO Mode bucket types

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_bucket.py
purefb_info.py

##### ADDITIONAL INFORMATION
bucket type can be `classic` or `multi-site`
`multi-site` can only be used when enabled by Pure Technical Support
This requires Purity//FB 3.3.3 or higher