### PR TITLE
Fix incorrect argument count in policy

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
+++ b/collections/ansible_collections/purestorage/flashblade/plugins/modules/purefb_policy.py
@@ -1610,7 +1610,7 @@ def main():
                     )
                 )
         if policy and state == "present":
-            update_os_policy(module, blade, policy)
+            update_os_policy(module, blade)
         elif state == "present" and not policy:
             create_os_policy(module, blade)
         elif state == "absent" and policy:


### PR DESCRIPTION
##### SUMMARY
Fix an incorrect argument count when calling `update_os_policy`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_policy.py

##### ADDITIONAL INFORMATION
Fix for #189 