### PR TITLE
Allow service to be a list

### DIFF
--- a/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/194_lists_for_service.yaml
+++ b/collections/ansible_collections/purestorage/flashblade/changelogs/fragments/194_lists_for_service.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_ad - Allow service to be a list


### PR DESCRIPTION
##### SUMMARY
Allow `service` to be a list.
This ensures that we can have multiple SPNs per AD account

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_ad.py