### PR TITLE
Allow non-secure proxy protocol

### DIFF
--- a/changelogs/fragments/200_proxy.yaml
+++ b/changelogs/fragments/200_proxy.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_proxy - Added new boolean parameter `secure`. Default of true (for backwards compatability) sets the protocol to be `https://`. False sets `http://`


### PR DESCRIPTION
##### SUMMARY
Currenty only `https://` is the allowed protocol for the proxy.
Add new `secure` boolean parameter, to allow this to be either `http://` or `https://`.
Default is `True`, ie `https://` retaining backwards compatibility.
Resolves #199 

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefb_proxy.py