### PR TITLE
Support multiple snapshot policy rules

### DIFF
--- a/changelogs/fragments/202_multiple_snap_rules.yaml
+++ b/changelogs/fragments/202_multiple_snap_rules.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_policy - Added support for multiple rules in snapshot policies


### PR DESCRIPTION
##### SUMMARY
Support multiple snapshot policy rules for Purity//FB 3.2.0 or higher.
Add new param `destroy_snapshots` which is required for removing snapshot policy rules
Only one policy rule can be added or removed at a time.
To update an existing rule just must delete and then re-add.
Purity//FB will deal with the restoration of any deleted snapshots created by the deleted role if the replacement rule would have created them. This is using a best-fit policy.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_policy.py

##### ADDITIONAL INFORMATION
Feature added to resolve #198 