### PR TITLE
Add support keys and encryption info

### DIFF
--- a/changelogs/fragments/215_encrypt_sec_info.yaml
+++ b/changelogs/fragments/215_encrypt_sec_info.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefb_info - Added `encryption` and `support_keys` information.

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -550,6 +550,12 @@ def generate_default_dict(module, blade):
                 blade_info, "product_type", "Unknown"
             )
         if SECURITY_API_VERSION in api_version:
+            dar = blade_info.encryption.data_at_rest
+            default_info["encryption"] = {
+                "data_at_rest_enabled": dar.enabled,
+                "data_at_rest_algorithms": dar.algorithms,
+                "data_at_rest_entropy_source": dar.entropy_source,
+            }
             keys = list(blade.get_support_verification_keys().items)
             default_info["support_keys"] = {}
             for key in range(0, len(keys)):

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -554,9 +554,7 @@ def generate_default_dict(module, blade):
             default_info["support_keys"] = {}
             for key in range(0, len(keys)):
                 keyname = keys[key].name
-                default_info["support_keys"][keyname] = {
-                    keys[key].verification_key
-                }
+                default_info["support_keys"][keyname] = {keys[key].verification_key}
             default_info["security_update"] = getattr(
                 blade_info, "security_update", None
             )

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -550,6 +550,13 @@ def generate_default_dict(module, blade):
                 blade_info, "product_type", "Unknown"
             )
         if SECURITY_API_VERSION in api_version:
+            keys = list(blade.get_support_verification_keys().items)
+            default_info["support_keys"] = {}
+            for key in range(0, len(keys)):
+                keyname = keys[key].name
+                default_info["support_keys"][keyname] = {
+                    keys[key].verification_key
+                }
             default_info["security_update"] = getattr(
                 blade_info, "security_update", None
             )


### PR DESCRIPTION
##### SUMMARY
Add `support_keys` and `encryption` information from REST 2.7

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_info.py