### PR TITLE
Allow human readable quotas for S3 account

### DIFF
--- a/changelogs/fragments/227_s3acc_human_quota.yaml
+++ b/changelogs/fragments/227_s3acc_human_quota.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_s3acc - Allow human readable quota sizes; eg. 1T, 230K, etc


### PR DESCRIPTION
##### SUMMARY
Allow human readable `quota` and `default` quota values as well as the original values of bytes.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_s3acc.py