### PR TITLE
multiple_keys param

### DIFF
--- a/changelogs/fragments/232_multiple_keys.yaml
+++ b/changelogs/fragments/232_multiple_keys.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_s3user - Add new boolean parameter I(multiple_keys) to limit access keys for a user to a single key.

--- a/plugins/modules/purefb_s3user.py
+++ b/plugins/modules/purefb_s3user.py
@@ -53,6 +53,7 @@ options:
     - Allow multiple access keys to be created for the user.
     type: bool
     default: false
+    version_added: "1.12.0"
   remove_key:
     description:
     - Access key to be removed from user
@@ -194,7 +195,10 @@ def update_s3user(module, blade):
                             and module.params["imported_key"]
                         ):
                             module.warn("'access_key: true' overrides imported keys")
-                        if module.params["access_key"] and module.params['multiple_keys']:
+                        if (
+                            module.params["access_key"]
+                            and module.params["multiple_keys"]
+                        ):
                             result = blade.object_store_access_keys.create_object_store_access_keys(
                                 object_store_access_key=ObjectStoreAccessKey(
                                     user={"name": user}

--- a/plugins/modules/purefb_s3user.py
+++ b/plugins/modules/purefb_s3user.py
@@ -188,10 +188,7 @@ def update_s3user(module, blade):
         if not exists:
             if key_count < 2:
                 try:
-                    if (
-                        module.params["access_key"]
-                        and module.params["imported_key"]
-                    ):
+                    if module.params["access_key"] and module.params["imported_key"]:
                         module.warn("'access_key: true' overrides imported keys")
                     if module.params["access_key"]:
                         if key_count == 0 or (

--- a/plugins/modules/purefb_s3user.py
+++ b/plugins/modules/purefb_s3user.py
@@ -212,7 +212,7 @@ def update_s3user(module, blade):
                     else:
                         if IMPORT_KEY_API_VERSION in versions:
                             changed = True
-                            if no module.check_mode:
+                            if not module.check_mode:
                                 blade.object_store_access_keys.create_object_store_access_keys(
                                     names=[module.params["imported_key"]],
                                     object_store_access_key=ObjectStoreAccessKeyPost(

--- a/plugins/modules/purefb_s3user.py
+++ b/plugins/modules/purefb_s3user.py
@@ -48,6 +48,11 @@ options:
     - If enabled this will override I(imported_key)
     type: bool
     default: false
+  multiple_keys:
+    description:
+    - Allow multiple access keys to be created for the user.
+    type: bool
+    default: false
   remove_key:
     description:
     - Access key to be removed from user
@@ -189,7 +194,7 @@ def update_s3user(module, blade):
                             and module.params["imported_key"]
                         ):
                             module.warn("'access_key: true' overrides imported keys")
-                        if module.params["access_key"]:
+                        if module.params["access_key"] and module.params['multiple_keys']:
                             result = blade.object_store_access_keys.create_object_store_access_keys(
                                 object_store_access_key=ObjectStoreAccessKey(
                                     user={"name": user}
@@ -370,6 +375,7 @@ def main():
             name=dict(required=True, type="str"),
             account=dict(required=True, type="str"),
             access_key=dict(default="false", type="bool"),
+            multiple_keys=dict(default="false", type="bool"),
             imported_key=dict(type="str", no_log=False),
             remove_key=dict(type="str", no_log=False),
             imported_secret=dict(type="str", no_log=True),

--- a/plugins/modules/purefb_s3user.py
+++ b/plugins/modules/purefb_s3user.py
@@ -195,20 +195,20 @@ def update_s3user(module, blade):
                             and module.params["imported_key"]
                         ):
                             module.warn("'access_key: true' overrides imported keys")
-                        if (
-                            module.params["access_key"]
-                            and module.params["multiple_keys"]
-                        ):
-                            result = blade.object_store_access_keys.create_object_store_access_keys(
-                                object_store_access_key=ObjectStoreAccessKey(
-                                    user={"name": user}
+                        if module.params["access_key"]:
+                            if key_count == 0 or (
+                                key_count >= 1 and module.params["multiple_keys"]
+                            ):
+                                result = blade.object_store_access_keys.create_object_store_access_keys(
+                                    object_store_access_key=ObjectStoreAccessKey(
+                                        user={"name": user}
+                                    )
                                 )
-                            )
-                            s3user_facts["fb_s3user"] = {
-                                "user": user,
-                                "access_key": result.items[0].secret_access_key,
-                                "access_id": result.items[0].name,
-                            }
+                                s3user_facts["fb_s3user"] = {
+                                    "user": user,
+                                    "access_key": result.items[0].secret_access_key,
+                                    "access_id": result.items[0].name,
+                                }
                         else:
                             if IMPORT_KEY_API_VERSION in versions:
                                 blade.object_store_access_keys.create_object_store_access_keys(


### PR DESCRIPTION
##### SUMMARY
Add new parameter `multiple_keys` to allow more than 1 access key to be created for a user, to the maximum allowed by Purity//FB.
Default is `false` which will only allow a single access key for the user.
Leaving this as the default will only allow 1 access key for the user, stopping additional keys being added on multiple
runs of a playbook. 
Makes the module more idempotent.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_s3user.py