### PR TITLE
Remove Python 3.9 for devel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,8 @@ jobs:
             ansible: stable-2.15
           - python-version: 3.8
             ansible: devel
+          - python_version: 3.9
+            ansible: devel
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
             ansible: stable-2.15
           - python-version: 3.8
             ansible: devel
-          - python_version: 3.9
+          - python-version: 3.9
             ansible: devel
     steps:
     - name: Check out code


### PR DESCRIPTION
Remove Python 3.9 from testing for the devel branch based on https://github.com/ansible/ansible/pull/80973
