### PR TITLE
Fix missing attributes for SMB client policy rules

### DIFF
--- a/changelogs/fragments/237_info_policy.yaml
+++ b/changelogs/fragments/237_info_policy.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_info - Fixed missing atributes for SMB client policy rules

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -913,10 +913,19 @@ def generate_smb_client_policies_dict(blade):
             policies_info[policy_name]["rules"].append(
                 {
                     "name": policies[policy].rules[rule].name,
-                    "change": policies[policy].rules[rule].change,
-                    "full_control": policies[policy].rules[rule].full_control,
-                    "principal": policies[policy].rules[rule].principal,
-                    "read": policies[policy].rules[rule].read,
+                    "change": getattr(policies[policy].rules[rule], "change", None),
+                    "full_control": getattr(
+                        policies[policy].rules[rule], "full_control", None
+                    ),
+                    "principal": getattr(
+                        policies[policy].rules[rule], "principal", None
+                    ),
+                    "read": getattr(policies[policy].rules[rule], "read", None),
+                    "client": getattr(policies[policy].rules[rule], "client", None),
+                    "index": getattr(policies[policy].rules[rule], "index", None),
+                    "permission": getattr(
+                        policies[policy].rules[rule], "permission", None
+                    ),
                 }
             )
     return policies_info


### PR DESCRIPTION
##### SUMMARY
Add missing attributes for SMB client policy rules

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_info.py