### PR TITLE
Fix state show for userpolicies

### DIFF
--- a/changelogs/fragments/238_user_policy.yaml
+++ b/changelogs/fragments/238_user_policy.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_userpolicy - Fixed `show` state for all user policies

--- a/plugins/modules/purefb_userpolicy.py
+++ b/plugins/modules/purefb_userpolicy.py
@@ -249,6 +249,7 @@ def main():
             names=[module.params["account"] + "/" + module.params["name"]]
         ).status_code
         != 200
+        and state != "show"
     ):
         module.fail_json(
             msg="Account User {0}/{1} does not exist".format(


### PR DESCRIPTION
##### SUMMARY
Fix issue where `state: show` does not work when requesting all user policies.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_userpolicy.py