### PR TITLE
Remove unneccessary version check

### DIFF
--- a/plugins/modules/purefb_bucket.py
+++ b/plugins/modules/purefb_bucket.py
@@ -501,8 +501,6 @@ def main():
     api_version = blade.api_version.list_versions().versions
     if MIN_REQUIRED_API_VERSION not in api_version:
         module.fail_json(msg="Purity//FB must be upgraded to support this module.")
-    if module.params["mode"] and VSO_VERSION not in api_version:
-        module.fail_json(msg="VSO mode requires Purity//FB 3.3.3 or higher.")
 
     bucket = get_bucket(module, blade)
     if not get_s3acc(module, blade):


### PR DESCRIPTION
##### SUMMARY
As `mode` is always provided due to `default` setting, the initial version check if mode exists is broken and causes module failure. 
Remove the initial check.

Closes #249 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_bucket.py