### PR TITLE
Add SMB Continuous Availability option

### DIFF
--- a/changelogs/fragments/255_smb_ca.yaml
+++ b/changelogs/fragments/255_smb_ca.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_fs - Added SMB Continuous Availability parameter. Requires REST 2.12 or higher.


### PR DESCRIPTION
##### SUMMARY
Add new option `continuous_availability` for SMB filesystems.
Default is True
Requires REST 2.12 or higher

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_fs.py