### PR TITLE
Remove unnecessary FM reference in port names

### DIFF
--- a/plugins/modules/purefb_lag.py
+++ b/plugins/modules/purefb_lag.py
@@ -163,16 +163,7 @@ def update_lag(module, blade):
                     )
     new_ports = []
     for port in range(0, len(module.params["ports"])):
-        new_ports.append(
-            module.params["ports"][port].split(".")[0].upper()
-            + ".FM1."
-            + module.params["ports"][port].split(".")[1].upper()
-        )
-        new_ports.append(
-            module.params["ports"][port].split(".")[0].upper()
-            + ".FM2."
-            + module.params["ports"][port].split(".")[1].upper()
-        )
+        new_ports.append(module.params["ports"][port].upper())
     ports = []
     for final_port in range(0, len(new_ports)):
         ports.append(flashblade.FixedReference(name=new_ports[final_port]))
@@ -224,16 +215,7 @@ def create_lag(module, blade):
             )
     new_ports = []
     for new_port in range(0, len(module.params["ports"])):
-        new_ports.append(
-            module.params["ports"][new_port].split(".")[0].upper()
-            + ".FM1."
-            + module.params["ports"][new_port].split(".")[1].upper()
-        )
-        new_ports.append(
-            module.params["ports"][new_port].split(".")[0].upper()
-            + ".FM2."
-            + module.params["ports"][new_port].split(".")[1].upper()
-        )
+        new_ports.append(module.params["ports"][new_port].upper())
     ports = []
     for final_port in range(0, len(new_ports)):
         ports.append(flashblade.FixedReference(name=new_ports[final_port]))


### PR DESCRIPTION
##### SUMMARY
Remove the FM1/2 when creating or updating a LAG in the port name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_lag.py