### PR TITLE
Add support for public buckets

### DIFF
--- a/changelogs/fragments/258_add_public_buckets.yaml
+++ b/changelogs/fragments/258_add_public_buckets.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+ - purefb_s3acc - Add support for public buckets
+ - purefb_s3acc - Remove default requirements for ``hard_limit`` and ``default_hard_limit``
+ - purefb_bucket - Add support for public buckets


### PR DESCRIPTION
##### SUMMARY
Add support for public buckets in object store account settings and for bucket creation and update.
Remove `default` values for `hard_limit` and `default_hard_limit` for object store accounts. These are now defined programatically.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefb_buckey.py
purefb_s3acc.py