### PR TITLE
Enable multi-chassis lag ports

### DIFF
--- a/plugins/modules/purefb_lag.py
+++ b/plugins/modules/purefb_lag.py
@@ -163,16 +163,19 @@ def update_lag(module, blade):
                     )
     new_ports = []
     for port in range(0, len(module.params["ports"])):
-        new_ports.append(
-            module.params["ports"][port].split(".")[0].upper()
-            + ".FM1."
-            + module.params["ports"][port].split(".")[1].upper()
-        )
-        new_ports.append(
-            module.params["ports"][port].split(".")[0].upper()
-            + ".FM2."
-            + module.params["ports"][port].split(".")[1].upper()
-        )
+        if module.params["ports"][port].split(".")[0].upper()[0] != "X":
+            new_ports.append(
+                module.params["ports"][port].split(".")[0].upper()
+                + ".FM1."
+                + module.params["ports"][port].split(".")[1].upper()
+            )
+            new_ports.append(
+                module.params["ports"][port].split(".")[0].upper()
+                + ".FM2."
+                + module.params["ports"][port].split(".")[1].upper()
+            )
+        else:
+            new_ports.append(module.params["ports"][port].upper())
     ports = []
     for final_port in range(0, len(new_ports)):
         ports.append(flashblade.FixedReference(name=new_ports[final_port]))


### PR DESCRIPTION
##### SUMMARY
When using multi-chassis FB, do not add FM details to lap ports when XFM ports are specified
Closes #264 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_lag.py