### PR TITLE
Add group_ownership option for filesystems

### DIFF
--- a/changelogs/fragments/270_add_go.yaml
+++ b/changelogs/fragments/270_add_go.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_fs - Add ``group_ownership`` parameter from Purity//FB 4.4.0.


### PR DESCRIPTION
##### SUMMARY
Add parameter `group_ownership` to file systems from REST 2.13 (Purity//FB 4.4.0).
Options available are `creator` or `parent-directory`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_fs.py