### PR TITLE
Add WORM support for buckets

### DIFF
--- a/changelogs/fragments/271_add_worm.yaml
+++ b/changelogs/fragments/271_add_worm.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_bucket - Add support for strict 17a-4 WORM compliance.


### PR DESCRIPTION
##### SUMMARY
Add strict 17a-4 WORM compliance support for buckets from REST 2.13 (Purity//FB 4.4.0).
Adds 3 new parameters:
- `eradication_delay` - number days between 1 and 30. Default is 1
- `manual_eradication` - boolean
- `eradication_mode` - options are `permission-based` or `retention-based`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_bucket.py