### PR TITLE
Add disable_warnings parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Pure Storage FlashBlade collection consists of the latest versions of the Fl
 - pytz
 - distro
 - pycountry
+- urllib3
 
 ## Installation
 

--- a/plugins/doc_fragments/purestorage.py
+++ b/plugins/doc_fragments/purestorage.py
@@ -30,6 +30,12 @@ options:
     description:
       - FlashBlade API token for admin privileged user.
     type: str
+  disable_warnings:
+    description:
+    - Disable insecure certificate warnings
+    type: bool
+    default: false
+    version_added: '1.18.0'
 notes:
   - This module requires the C(purity_fb) Python library
   - You must set C(PUREFB_URL) and C(PUREFB_API) environment variables
@@ -39,4 +45,5 @@ requirements:
   - purity_fb >= 1.9
   - netaddr
   - pytz
+  - urllib3
 """

--- a/plugins/module_utils/purefb.py
+++ b/plugins/module_utils/purefb.py
@@ -32,6 +32,12 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+HAS_URLLIB3 = True
+try:
+    import urllib3
+except ImportError:
+    HAS_URLLIB3 = False
+
 HAS_DISTRO = True
 try:
     import distro
@@ -60,6 +66,8 @@ API_AGENT_VERSION = "1.5"
 
 def get_blade(module):
     """Return System Object or Fail"""
+    if HAS_URLLIB3 and module.params["disable_warnings"]:
+        urllib3.disable_warnings()
     if HAS_DISTRO:
         user_agent = "%(base)s %(class)s/%(version)s (%(platform)s)" % {
             "base": USER_AGENT_BASE,
@@ -114,6 +122,8 @@ def get_blade(module):
 
 def get_system(module):
     """Return System Object or Fail"""
+    if module.params["disable_warnings"]:
+        urllib3.disable_warnings()
     if HAS_DISTRO:
         user_agent = "%(base)s %(class)s/%(version)s (%(platform)s)" % {
             "base": USER_AGENT_BASE,
@@ -167,4 +177,5 @@ def purefb_argument_spec():
     return dict(
         fb_url=dict(),
         api_token=dict(no_log=True),
+        disable_warnings=dict(type="bool", default=False),
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pycountry
 pytz
 purity-fb
 py-pure-client
+urllib3


### PR DESCRIPTION
##### SUMMARY
Add parameter `disable_warnings` (default is False) to apply to all modules.
If enabled, this will disable all insecure certificate warnings in debug messages.
Closes #283 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb.py