### PR TITLE
Add bucket remaining time status

### DIFF
--- a/changelogs/fragments/306_bucket_status.yaml
+++ b/changelogs/fragments/306_bucket_status.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_info - Add ``time_remaining_status`` to bucket information from REST 2.14

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -817,6 +817,9 @@ def generate_bucket_dict(module, blade):
             "created": buckets.items[bckt].created,
             "destroyed": buckets.items[bckt].destroyed,
             "time_remaining": buckets.items[bckt].time_remaining,
+            "time_remaining_status": getattr(
+                buckets.item[bckt], "time_remaining_status", None
+            ),
             "lifecycle_rules": {},
         }
     api_version = blade.api_version.list_versions().versions


### PR DESCRIPTION
##### SUMMARY
Add new field to bucket info - `time_remaining_status` - only provided from REST 2.14 and higher

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_info.py