### PR TITLE
Fix parameter typo

### DIFF
--- a/changelogs/fragments/309_param_typo.yaml
+++ b/changelogs/fragments/309_param_typo.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_certs - Fix parameter mispelling of ``intermeadiate_cert`` to ``intermediate_cert``. Keep original mispelling as an alias.

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -488,7 +488,7 @@ def main():
             key_size=dict(type="int", default=2048, choices=[1024, 2048, 4096]),
             certificate=dict(type="str", no_log=True, aliases=["contents"]),
             intermediate_cert=dict(
-                type="str", no_log=True, aliases=["intermediate_cert"]
+                type="str", no_log=True, aliases=["intermeadiate_cert"]
             ),
             key=dict(type="str", no_log=True, aliases=["private_key"]),
             export_file=dict(type="str"),

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -102,7 +102,8 @@ options:
     - A valid signed certicate in PEM format (Base64 encoded)
     - Includes the "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----" lines
     - Does not exceed 3000 characters in length
-  intermeadiate_cert:
+  intermediate_cert:
+    aliases: [ intermeadiate_cert ]
     type: str
     description:
     - Intermeadiate certificate provided by the CA
@@ -334,7 +335,7 @@ def import_cert(module, blade, reimport=False):
         if reimport:
             certificate = flashblade.CertificatePatch(
                 certificate=module.params["certificate"],
-                intermediate_certificate=module.params["intermeadiate_cert"],
+                intermediate_certificate=module.params["intermediate_cert"],
                 passphrase=module.params["passphrase"],
                 private_key=module.params["key"],
             )
@@ -344,7 +345,7 @@ def import_cert(module, blade, reimport=False):
         else:
             certificate = flashblade.CertificatePost(
                 certificate=module.params["certificate"],
-                intermediate_certificate=module.params["intermeadiate_cert"],
+                intermediate_certificate=module.params["intermediate_cert"],
                 key_size=module.params["key_size"],
                 passphrase=module.params["passphrase"],
                 status="imported",
@@ -354,7 +355,7 @@ def import_cert(module, blade, reimport=False):
             )
             certificate = flashblade.CertificatePatch(
                 certificate=module.params["certificate"],
-                intermediate_certificate=module.params["intermeadiate_cert"],
+                intermediate_certificate=module.params["intermediate_cert"],
                 passphrase=module.params["passphrase"],
                 private_key=module.params["key"],
             )
@@ -486,7 +487,7 @@ def main():
             email=dict(type="str"),
             key_size=dict(type="int", default=2048, choices=[1024, 2048, 4096]),
             certificate=dict(type="str", no_log=True, aliases=["contents"]),
-            intermeadiate_cert=dict(type="str", no_log=True),
+            intermediate_cert=dict(type="str", no_log=True, aliases=["intermediate_cert"]),
             key=dict(type="str", no_log=True, aliases=["private_key"]),
             export_file=dict(type="str"),
             passphrase=dict(type="str", no_log=True),

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -487,7 +487,9 @@ def main():
             email=dict(type="str"),
             key_size=dict(type="int", default=2048, choices=[1024, 2048, 4096]),
             certificate=dict(type="str", no_log=True, aliases=["contents"]),
-            intermediate_cert=dict(type="str", no_log=True, aliases=["intermediate_cert"]),
+            intermediate_cert=dict(
+                type="str", no_log=True, aliases=["intermediate_cert"]
+            ),
             key=dict(type="str", no_log=True, aliases=["private_key"]),
             export_file=dict(type="str"),
             passphrase=dict(type="str", no_log=True),


### PR DESCRIPTION
##### SUMMARY
Fix incorrect spelling of `intermeadiate_cert` to `intermediate_cert`.
Keep the original spelling as an alias for backwards compatibility.
Closes #308 

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
purefb_certs.py