### PR TITLE
Add shared to capacity from REST 2.15

### DIFF
--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -632,6 +632,7 @@ def generate_capacity_dict(module, blade):
             "available_ratio": total_cap.space.available_ratio,
             "destroyed": total_cap.space.destroyed,
             "destroyed_virtual": total_cap.space.destroyed_virtual,
+            "shared": getattr(total_cap.space, "shared", None),
         }
         capacity_info["file-system"] = {
             "data_reduction": file_cap.space.data_reduction,
@@ -644,6 +645,7 @@ def generate_capacity_dict(module, blade):
             "available_ratio": total_cap.space.available_ratio,
             "destroyed": total_cap.space.destroyed,
             "destroyed_virtual": total_cap.space.destroyed_virtual,
+            "shared": getattr(total_cap.space, "shared", None),
         }
         capacity_info["object-store"] = {
             "data_reduction": object_cap.space.data_reduction,
@@ -656,6 +658,7 @@ def generate_capacity_dict(module, blade):
             "available_ratio": total_cap.space.available_ratio,
             "destroyed": total_cap.space.destroyed,
             "destroyed_virtual": total_cap.space.destroyed_virtual,
+            "shared": getattr(total_cap.space, "shared", None),
         }
     else:
         total_cap = blade.arrays.list_arrays_space()


### PR DESCRIPTION
##### SUMMARY
Add `shared` field to capacity information. Avaialble from REST 2.15.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_info.py