### PR TITLE
Fix fb smtp encryption

### DIFF
--- a/changelogs/fragments/326_smtp_encryption_fix.yaml
+++ b/changelogs/fragments/326_smtp_encryption_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_smtp - Fix errors that occurred after adding support for smtp encrpytion and using the module on older FlashBlades.

--- a/plugins/modules/purefb_smtp.py
+++ b/plugins/modules/purefb_smtp.py
@@ -102,9 +102,7 @@ def set_smtp(module, blade):
             )
         else:
             res = blade.patch_smtp_servers(
-                smtp=SmtpServer(
-                    relay_host=relay_host, sender_domain=domain
-                )
+                smtp=SmtpServer(relay_host=relay_host, sender_domain=domain)
             )
         if res.status_code != 200:
             module.fail_json(

--- a/plugins/modules/purefb_smtp.py
+++ b/plugins/modules/purefb_smtp.py
@@ -126,8 +126,8 @@ def main():
     api_version = list(blade.get_versions().items)
     if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client SDK is required for this module")
-    if SMTP_ENCRYPT_API_VERSION not in api_version and module.params["encryption_mode"]:
-        module.fail_json(msg="Purity//FB must be upgraded to support encryption_mode.")
+    if SMTP_ENCRYPT_API_VERSION not in api_version and module.params["encryption"]:
+        module.fail_json(msg="Purity//FB must be upgraded to support encryption.")
 
     set_smtp(module, blade)
     module.exit_json(changed=False)


### PR DESCRIPTION
##### SUMMARY
The recent update to support setting the `encryption` option for the SMTP server caused errors when running the module on FlashBlades that don't support the `encryption_mode` parameter in their API version. 

As a note, I don't have a FlashBlade with the 2.15 API version to test this against to confirm that it still works to set the encryption settings on systems that support it. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_smtp
