### PR TITLE
Fix bucket idempotency

### DIFF
--- a/changelogs/fragments/327_bucket_idempotency.yaml
+++ b/changelogs/fragments/327_bucket_idempotency.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_bucket - Fixed issue with idempotency reported when ``hard_limit`` not provided.

--- a/plugins/modules/purefb_bucket.py
+++ b/plugins/modules/purefb_bucket.py
@@ -576,7 +576,10 @@ def update_bucket(module, blade, bucket):
             if quota != current_quota["quota"]:
                 change_quota = True
                 new_quota["quota"] = human_to_bytes(module.params["quota"])
-        if module.params["hard_limit"] != current_quota["hard"]:
+        if (
+            module.params["hard_limit"]
+            and module.params["hard_limit"] != current_quota["hard"]
+        ):
             change_quota = True
             new_quota["hard"] = module.params["hard_limit"]
         if current_quota != new_quota and not module.check_mode:


### PR DESCRIPTION
##### SUMMARY
Fix issue with idempotency alerting when `hard_limit` is not provided

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_bucket.py