### PR TITLE
Update purefb_snap.py

### DIFF
--- a/changelogs/fragments/328_immeadiate_snap_fix.yaml
+++ b/changelogs/fragments/328_immeadiate_snap_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_snap - Fixed issue where ``target`` incorrectly required for a regular snapshot

--- a/plugins/modules/purefb_snap.py
+++ b/plugins/modules/purefb_snap.py
@@ -191,9 +191,9 @@ def create_snapshot(module, blade):
     source = []
     # Special case as we have changed 'target' to be a string not a list of one string
     # so this provides backwards compatability
-    target = module.params["target"].replace("[", "").replace("'", "").replace("]", "")
     source.append(module.params["name"])
     if module.params["now"]:
+        target = module.params["target"].replace("[", "").replace("'", "").replace("]", "")
         blade2 = get_system(module)
         blade_exists = False
         connected_blades = blade.array_connections.list_array_connections().items

--- a/plugins/modules/purefb_snap.py
+++ b/plugins/modules/purefb_snap.py
@@ -193,7 +193,9 @@ def create_snapshot(module, blade):
     # so this provides backwards compatability
     source.append(module.params["name"])
     if module.params["now"]:
-        target = module.params["target"].replace("[", "").replace("'", "").replace("]", "")
+        target = (
+            module.params["target"].replace("[", "").replace("'", "").replace("]", "")
+        )
         blade2 = get_system(module)
         blade_exists = False
         connected_blades = blade.array_connections.list_array_connections().items


### PR DESCRIPTION
##### SUMMARY
snapshot looking for `target` when `now` not specified.
Caused by definition of `target` being incorrectly outside an `if-else` loop

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_snap.py
