### PR TITLE
Fix for non-policy created snapshots

### DIFF
--- a/changelogs/fragments/329_no_policy_snap.yaml
+++ b/changelogs/fragments/329_no_policy_snap.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_info - Fixed ``AttributeError`` for ``snapshot`` subset when snapshot had been created manually, rather than using a snapshot policy

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -743,15 +743,16 @@ def generate_snap_dict(blade):
             ].source_location.name
             snap_info[snapshot]["policies"] = []
             if PUBLIC_API_VERSION in api_version:
-                for policy in range(0, len(snaps.items[snap].policies)):
-                    snap_info[snapshot]["policies"].append(
-                        {
-                            "name": snaps.items[snap].policies[policy].name,
-                            "location": snaps.items[snap]
-                            .policies[policy]
-                            .location.name,
-                        }
-                    )
+                if hasattr(snaps.items[snap], "policies"):
+                    for policy in range(0, len(snaps.items[snap].policies)):
+                        snap_info[snapshot]["policies"].append(
+                            {
+                                "name": snaps.items[snap].policies[policy].name,
+                                "location": snaps.items[snap]
+                                .policies[policy]
+                                .location.name,
+                            }
+                        )
     return snap_info
 
 


### PR DESCRIPTION
##### SUMMARY
Fix `AttributeError` when snapshot has been created manually, rather than using a snapshot policy.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_info.py