### PR TITLE
Add support for multiple DNS configurations

### DIFF
--- a/changelogs/fragments/331_multi_dns.yaml
+++ b/changelogs/fragments/331_multi_dns.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefb_dns - Added support for multiple DNS configurations.
+ - purefb_info - Added support for multiple DNS configurations.

--- a/plugins/modules/purefb_dns.py
+++ b/plugins/modules/purefb_dns.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2020, Simon Dodsley (simon@purestorage.com)
+# (c) 20124, Simon Dodsley (simon@purestorage.com)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -18,21 +18,28 @@ DOCUMENTATION = r"""
 ---
 module: purefb_dns
 version_added: '1.0.0'
-short_description: Configure Pure Storage FlashBlade DNS settings
+short_description: Configure FlashBlade DNS settings
 description:
-- Set or erase DNS configuration for Pure Storage FlashBlades.
+- Set or erase configuration for the DNS settings.
+- Nameservers provided will overwrite any existing nameservers.
 author:
 - Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
+  name:
+    description:
+    - Name of the DNS configuration.
+    - Default value only supported for management service
+    default: management
+    type: str
   state:
     description:
-    - Create or delete DNS servers configuration
-    type: str
+    - Set or delete directory service configuration
     default: present
+    type: str
     choices: [ absent, present ]
   domain:
     description:
-    - Domain suffix to be appended when perofrming DNS lookups.
+    - Domain suffix to be appended when performing DNS lookups.
     type: str
   nameservers:
     description:
@@ -40,32 +47,38 @@ options:
       IPv4 or IPv6 - No validation is done of the addresses is performed.
     type: list
     elements: str
-  search:
+  source:
     description:
-    - Ordered list of domain names to search
-    - Deprecated option. Will be removed in Collection v1.6.0, There is no replacement for this.
-    type: list
-    elements: str
+    - A virtual network interface (vip)
+    - The network interfaces must have a I(service) value of I(data)
+    type: str
 extends_documentation_fragment:
 - purestorage.flashblade.purestorage.fb
 """
 
 EXAMPLES = r"""
-- name: Delete exisitng DNS settings
-  purestorage.flashblade.purefb_dns:
-    state: absent
-    fa_url: 10.10.10.2
-    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
-
-- name: Set DNS settings
+- name: Set managemnt DNS settings
   purestorage.flashblade.purefb_dns:
     domain: purestorage.com
     nameservers:
       - 8.8.8.8
       - 8.8.4.4
-    search:
-      - purestorage.com
-      - acme.com
+    fa_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+
+- name: Delete exisitng management DNS settings
+  purestorage.flashblade.purefb_dns:
+    state: absent
+    fa_url: 10.10.10.2
+    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
+
+- name: Set DNS settings with alternate name
+  purestorage.flashblade.purefb_dns:
+    name: server1
+    domain: purestorage.com
+    nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
     fa_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
 """
@@ -73,18 +86,19 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURITY_FB = True
+HAS_PURESTORAGE = True
 try:
-    from purity_fb import Dns
+    from pypureclient.flashblade import Dns, DnsPatch, DnsPost, ReferenceNoId
 except ImportError:
-    HAS_PURITY_FB = False
-
+    HAS_PURESTORAGE = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
-    get_blade,
+    get_system,
     purefb_argument_spec,
 )
+
+NON_MGMT_DNS = "2.15"
 
 
 def remove(duplicate):
@@ -95,47 +109,161 @@ def remove(duplicate):
     return final_list
 
 
+def _get_source(module, blade):
+    res = blade.get_network_interfaces(names=[module.params["source"]])
+    if res.status_code == 200:
+        return True
+    else:
+        return False
+
+
 def delete_dns(module, blade):
-    """Delete DNS Settings"""
-    changed = True
-    if not module.check_mode:
-        changed = False
-        current_dns = blade.dns.list_dns()
-        if current_dns.items[0].domain or current_dns.items[0].nameservers != []:
-            try:
-                blade.dns.update_dns(dns_settings=Dns(domain="", nameservers=[]))
-                changed = True
-            except Exception:
-                module.fail_json(msg="Deletion of DNS settings failed")
+    """Delete DNS settings"""
+    changed = False
+    current_dns = list(blade.get_dns().items)[0]
+    if getattr(current_dns, "domain", None) in ["", None] and getattr(
+        current_dns, "nameservers", None
+    ) in [[""], None]:
+        module.exit_json(changed=changed)
+    else:
+        changed = True
+        if not module.check_mode:
+            res = blade.delete_dns(names=["management"])
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Delete DNS settigs failed. Error: {0}".format(
+                    res.errors[0].message
+                )
+            )
     module.exit_json(changed=changed)
 
 
-def update_dns(module, blade):
-    """Set DNS Settings"""
+def create_dns(module, blade):
+    """Set DNS settings"""
     changed = False
-    current_dns = blade.dns.list_dns()
-    if module.params["domain"]:
-        if current_dns.items[0].domain != module.params["domain"]:
-            changed = True
-            if not module.check_mode:
-                try:
-                    blade.dns.update_dns(
-                        dns_settings=Dns(domain=module.params["domain"])
+    current_dns = list(blade.get_dns().items)[0]
+    if current_dns["domain"] != module.params["domain"] or sorted(
+        module.params["nameservers"]
+    ) != sorted(current_dns["nameservers"]):
+        changed = True
+        if not module.check_mode:
+            res = blade.post_dns(
+                names=["management"],
+                dns=DnsPatch(
+                    domain=module.params["domain"],
+                    nameservers=module.params["nameservers"][0:3],
+                ),
+            )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Set DNS settings failed. Error: {0}".format(res.errors[0].message)
+            )
+    module.exit_json(changed=changed)
+
+
+def update_multi_dns(module, blade):
+    """Update a DNS configuration"""
+    changed = False
+    current_dns = list(blade.get_dns(names=[module.params["name"]]).items)[0]
+    new_dns = current_dns
+    if module.params["domain"] and current_dns.domain != module.params["domain"]:
+        new_dns.domain = module.params["domain"]
+        changed = True
+    if module.params["service"] and current_dns.services != [module.params["service"]]:
+        module.fail_json(msg="Changing service type is not permitted")
+    if module.params["nameservers"] and sorted(current_dns.nameservers) != sorted(
+        module.params["nameservers"]
+    ):
+        new_dns.nameservers = module.params["nameservers"]
+        changed = True
+    if (module.params["source"] or module.params["source"] == "") and getattr(
+        current_dns.source, "name", ""
+    ) != module.params["source"]:
+        new_dns.source.name = module.params["source"]
+        changed = True
+    if changed and not module.check_mode:
+        res = blade.patch_dns(
+            names=[module.params["name"]],
+            dns=Dns(
+                domain=new_dns.domain,
+                nameservers=new_dns.nameservers,
+                source=ReferenceNoId(module.params["source"]),
+            ),
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Update to DNS service {0} failed. Error: {1}".format(
+                    module.params["name"], res.errors[0].message
+                )
+            )
+    module.exit_json(changed=changed)
+
+
+def delete_multi_dns(module, blade):
+    """Delete a DNS configuration"""
+    changed = True
+    if module.params["name"] == "management":
+        res = blade.patch_dns(
+            names=[module.params["name"]],
+            dns=DnsPatch(domain="", nameservers=[]),
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Management DNS configuration not deleted. Error: {0}".format(
+                    res.errors[0].message
+                )
+            )
+    else:
+        if not module.check_mode:
+            res = blade.delete_dns(names=[module.params["name"]])
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Failed to delete DNS configuration {0}. Error: {1}".format(
+                        module.params["name"], res.errors[0].message
                     )
-                except Exception:
-                    module.fail_json(msg="Update of DNS domain failed")
-    if module.params["nameservers"]:
-        if sorted(module.params["nameservers"]) != sorted(
-            current_dns.items[0].nameservers
-        ):
-            changed = True
-            if not module.check_mode:
-                try:
-                    blade.dns.update_dns(
-                        dns_settings=Dns(nameservers=module.params["nameservers"])
-                    )
-                except Exception:
-                    module.fail_json(msg="Update of DNS nameservers failed")
+                )
+    module.exit_json(changed=changed)
+
+
+def create_multi_dns(module, blade):
+    """Create a DNS configuration"""
+    changed = True
+    if not module.check_mode:
+        if module.params["service"] == "file":
+            if module.params["source"]:
+                res = blade.post_dns(
+                    names=[module.params["name"]],
+                    dns=DnsPost(
+                        services=[module.params["service"]],
+                        domain=module.params["domain"],
+                        nameservers=module.params["nameservers"],
+                        source=ReferenceNoId(module.params["source"].lower()),
+                    ),
+                )
+            else:
+                res = blade.post_dns(
+                    names=[module.params["name"]],
+                    dns=DnsPost(
+                        services=[module.params["service"]],
+                        domain=module.params["domain"],
+                        nameservers=module.params["nameservers"],
+                    ),
+                )
+        else:
+            res = blade.create_dns(
+                names=[module.params["name"]],
+                services=[module.params["service"]],
+                domain=module.params["domain"],
+                nameservers=module.params["nameservers"],
+            )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to create {0} DNS configuration {1}. Error: {2}".format(
+                    module.params["service"],
+                    module.params["name"],
+                    res.errors[0].message,
+                )
+            )
     module.exit_json(changed=changed)
 
 
@@ -143,32 +271,54 @@ def main():
     argument_spec = purefb_argument_spec()
     argument_spec.update(
         dict(
-            nameservers=dict(type="list", elements="str"),
-            search=dict(type="list", elements="str"),
-            domain=dict(type="str"),
             state=dict(type="str", default="present", choices=["absent", "present"]),
+            name=dict(type="str", default="management"),
+            domain=dict(type="str"),
+            source=dict(type="str"),
+            nameservers=dict(type="list", elements="str"),
         )
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
 
-    if not HAS_PURITY_FB:
-        module.fail_json(msg="purity_fb sdk is required for this module")
+    state = module.params["state"]
+    blade = get_system(module)
+    api_version = list(blade.get_versions().items)
+    if module.params["nameservers"]:
+        module.params["nameservers"] = remove(module.params["nameservers"])
 
-    blade = get_blade(module)
-
-    if module.params["state"] == "absent":
-        delete_dns(module, blade)
-    elif module.params["state"] == "present":
-        if module.params["nameservers"]:
-            module.params["nameservers"] = remove(module.params["nameservers"])
-        if module.params["search"]:
-            module.warn(
-                "'search' parameter is deprecated and will be removed in Collection v1.6.0"
+    if NON_MGMT_DNS in api_version:
+        configs = list(blade.get_dns().items)
+        exists = False
+        for config in range(0, len(configs)):
+            if configs[config].name == module.params["name"]:
+                exists = True
+        if module.params["name"] != "management" and not exists:
+            module.warn("Overriding configuration name to management")
+            module.params["name"] = "management"
+        if module.params["source"] and not _get_source(module, blade):
+            module.fail_json(
+                msg="Specified VIP {0} does not exist.".format(module.params["source"])
             )
-        update_dns(module, blade)
+        if state == "present" and exists:
+            update_multi_dns(module, blade)
+        elif state == "present" and not exists:
+            create_multi_dns(module, blade)
+        elif exists and state == "absent":
+            delete_multi_dns(module, blade)
+        else:
+            module.exit_json(changed=False)
     else:
-        module.exit_json(changed=False)
+        if state == "absent":
+            delete_dns(module, blade)
+        elif state == "present":
+            if not module.params["domain"] or not module.params["nameservers"]:
+                module.fail_json(
+                    msg="`domain` and `nameservers` are required for DNS configuration"
+                )
+            create_dns(module, blade)
+        else:
+            module.exit_json(changed=False)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -114,6 +114,7 @@ PUBLIC_API_VERSION = "2.12"
 NAP_API_VERSION = "2.13"
 RA_DURATION_API_VERSION = "2.14"
 SMTP_ENCRYPT_API_VERSION = "2.15"
+SERVERS_API_VERSION = "2.16"
 
 
 def _millisecs_to_time(millisecs):
@@ -342,7 +343,19 @@ def generate_config_dict(module, blade):
     config_info = {}
     bladev2 = get_system(module)
     api_version = blade.api_version.list_versions().versions
-    config_info["dns"] = blade.dns.list_dns().items[0].to_dict()
+    if SERVERS_API_VERSION in api_version:
+        config_info["dns"] = {}
+        dns_configs = list(bladev2.get_dns().items)
+        for config in range(0, len(dns_configs)):
+            config_info["dns"][dns_configs[config].name] = {
+                "nameservers": dns_configs[config].nameservers,
+                "domain": dns_configs[config].domain,
+            }
+            config_info["dns"][dns_configs[config].name]["source"] = getattr(
+                dns_configs[config].source, "name", None
+            )
+    else:
+        config_info["dns"] = blade.dns.list_dns().items[0].to_dict()
     if SMTP_ENCRYPT_API_VERSION in api_version:
         snmp_config = list(bladev2.get_smtp_servers().items)[0]
         config_info["smtp"] = {


### PR DESCRIPTION
##### SUMMARY
From Purity//FB 4.5.1 multiple DNS configurations are allowed. 
Update DNS module to cater for these and update info module as well.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_dns.py
purefb_info.py