### PR TITLE
Update S3 account and user to REST v2 and add key enablement

### DIFF
--- a/changelogs/fragments/338_update_s3.yaml
+++ b/changelogs/fragments/338_update_s3.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+ - purefb_s3acc - Fixed issue with public access config settings not being correctly for an account
+minor_changes:
+ - purefb_s3user - Changed ``remove_key`` parameter to ``key_name`` and add new ``state`` of ``key_state`` to allow a specificed key to be enabled/disabled using the new parameter ``enable_key``.


### PR DESCRIPTION
##### SUMMARY
Convert S3 modules to REST v2
Fix bug where public access config policies weren't being correctly set.
Change parameter `remove_key` to `key_name`, retaining `remove_name` as an alias.
Add new `state` of `key_state` to enable specified access key to be enabled or disabled, using the new boolean parameter `enable_key`.
Update module documentation where needed.
Closes #335 

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- REST Pull Request

##### COMPONENT NAME
purefb_s3acc.py
purefb_s3user.py