### PR TITLE
Add snapshot creation date-time

### DIFF
--- a/changelogs/fragments/340_snap_creation.yaml
+++ b/changelogs/fragments/340_snap_creation.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_info - Added snapshot creation date-time and time_remaining, if snapshot is not deleted, to the ``snapshots`` response.

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -91,7 +91,7 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb impo
     get_system,
     purefb_argument_spec,
 )
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 MIN_REQUIRED_API_VERSION = "1.3"
@@ -733,6 +733,11 @@ def generate_snap_dict(blade):
             "source": snaps.items[snap].source,
             "suffix": snaps.items[snap].suffix,
             "source_destroyed": snaps.items[snap].source_destroyed,
+            "created": datetime.fromtimestamp(
+                snaps.items[snap].created / 1000,
+                tz=timezone.utc,
+            ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "time_remaining": getattr(snaps.items[snap], "time_remaining", None),
         }
         if REPLICATION_API_VERSION in api_version:
             snap_info[snapshot]["owner"] = snaps.items[snap].owner.name


### PR DESCRIPTION
##### SUMMARY
Add snapshot creation date/time to the dict for each snapshot.
Add time_remaining for snapshot if it has been deleted.
Closes #339 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_info.py