### PR TITLE
SMB Directory Service removed from Purity//FB 4.5.2 and higher

### DIFF
--- a/changelogs/fragments/342_no_smb_ds.yaml
+++ b/changelogs/fragments/342_no_smb_ds.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_ds - SMB directory services deprecated from Purity//FB 4.5.2

--- a/plugins/modules/purefb_ds.py
+++ b/plugins/modules/purefb_ds.py
@@ -153,6 +153,7 @@ RETURN = r"""
 
 
 NIS_API_VERSION = "1.7"
+NO_SMB_VERSION = "2.16"
 HAS_PURITY_FB = True
 try:
     from purity_fb import DirectoryService
@@ -447,6 +448,11 @@ def main():
     state = module.params["state"]
     blade = get_blade(module)
     api_version = blade.api_version.list_versions().versions
+    if NO_SMB_VERSION in api_version and module.params["dstype"] == "smb":
+        module.warn(
+            msg="Directory Service for SMB no " "longer supported by FlashBlade"
+        )
+        module.exit_json(changed=False)
     ds_configured = False
     dirserv = blade.directory_services.list_directory_services(
         names=[module.params["dstype"]]


### PR DESCRIPTION
##### SUMMARY
If `dstype` is set to `smb` and FlashBlade is at Purity//FB 4.5.2 or higher when fail out cleanly.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_ds.py