### PR TITLE
Add delete/eradicate for remote snapshots

### DIFF
--- a/changelogs/fragments/344_remote_snap.yaml
+++ b/changelogs/fragments/344_remote_snap.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_snap - Add support to delete/eradicate remote snapshots, including the latest replica


### PR DESCRIPTION
##### SUMMARY
Update delete and eradicate functions to use RESTv2 and therefore enable support of remote snapshots.
Added new parameter `latest_replica` to allow deletion of latest replica is required.

Fixes: #343 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_snap.py