### PR TITLE
Add Fleet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ All modules are idempotent with the exception of modules that change or set pass
 - purefb_ds - manage Directory Services settings on a FlashBlade
 - purefb_dsrole - manage Directory Service Roles on a FlashBlade
 - purefb_eula - manage EULA on FlashBlade
+- purefb_fleet - manage Fusion fleet members
 - purefb_fs - manage filesystems on a FlashBlade
 - purefb_fs_replica - manage filesystem replica links on a FlashBlade
 - purefb_groupquota - manage individual group quotas on FlashBlade filesystems

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -1,0 +1,344 @@
+# Vendored copy of distutils/version.py from CPython 3.9.5
+#
+# Implements multiple version numbering conventions for the
+# Python Module Distribution Utilities.
+#
+# PSF License (see PSF-license.txt or https://opensource.org/licenses/Python-2.0)
+#
+
+"""Provides classes to represent module version numbers (one class for
+each style of version numbering).  There are currently two such classes
+implemented: StrictVersion and LooseVersion.
+
+Every version number class implements the following interface:
+  * the 'parse' method takes a string and parses it to some internal
+    representation; if the string is an invalid version number,
+    'parse' raises a ValueError exception
+  * the class constructor takes an optional string argument which,
+    if supplied, is passed to 'parse'
+  * __str__ reconstructs the string that was passed to 'parse' (or
+    an equivalent string -- ie. one that will generate an equivalent
+    version number instance)
+  * __repr__ generates Python code to recreate the version number instance
+  * _cmp compares the current instance with either another instance
+    of the same class or a string (which will be parsed to an instance
+    of the same class, thus must follow the same rules)
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import re
+
+try:
+    RE_FLAGS = re.VERBOSE | re.ASCII
+except AttributeError:
+    RE_FLAGS = re.VERBOSE
+
+
+class Version:
+    """Abstract base class for version numbering classes.  Just provides
+    constructor (__init__) and reproducer (__repr__), because those
+    seem to be the same for all version numbering classes; and route
+    rich comparisons to _cmp.
+    """
+
+    def __init__(self, vstring=None):
+        if vstring:
+            self.parse(vstring)
+
+    def __repr__(self):
+        return "%s ('%s')" % (self.__class__.__name__, str(self))
+
+    def __eq__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c == 0
+
+    def __lt__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c < 0
+
+    def __le__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c <= 0
+
+    def __gt__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c > 0
+
+    def __ge__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c >= 0
+
+
+# Interface for version-number classes -- must be implemented
+# by the following classes (the concrete ones -- Version should
+# be treated as an abstract class).
+#    __init__ (string) - create and take same action as 'parse'
+#                        (string parameter is optional)
+#    parse (string)    - convert a string representation to whatever
+#                        internal representation is appropriate for
+#                        this style of version numbering
+#    __str__ (self)    - convert back to a string; should be very similar
+#                        (if not identical to) the string supplied to parse
+#    __repr__ (self)   - generate Python code to recreate
+#                        the instance
+#    _cmp (self, other) - compare two version numbers ('other' may
+#                        be an unparsed version string, or another
+#                        instance of your version class)
+
+
+class StrictVersion(Version):
+    """Version numbering for anal retentives and software idealists.
+    Implements the standard interface for version number classes as
+    described above.  A version number consists of two or three
+    dot-separated numeric components, with an optional "pre-release" tag
+    on the end.  The pre-release tag consists of the letter 'a' or 'b'
+    followed by a number.  If the numeric components of two version
+    numbers are equal, then one with a pre-release tag will always
+    be deemed earlier (lesser) than one without.
+
+    The following are valid version numbers (shown in the order that
+    would be obtained by sorting according to the supplied cmp function):
+
+        0.4       0.4.0  (these two are equivalent)
+        0.4.1
+        0.5a1
+        0.5b3
+        0.5
+        0.9.6
+        1.0
+        1.0.4a3
+        1.0.4b1
+        1.0.4
+
+    The following are examples of invalid version numbers:
+
+        1
+        2.7.2.2
+        1.3.a4
+        1.3pl1
+        1.3c4
+
+    The rationale for this version numbering system will be explained
+    in the distutils documentation.
+    """
+
+    version_re = re.compile(r"^(\d+) \. (\d+) (\. (\d+))? ([ab](\d+))?$", RE_FLAGS)
+
+    def parse(self, vstring):
+        match = self.version_re.match(vstring)
+        if not match:
+            raise ValueError("invalid version number '%s'" % vstring)
+
+        (major, minor, patch, prerelease, prerelease_num) = match.group(1, 2, 4, 5, 6)
+
+        if patch:
+            self.version = tuple(map(int, [major, minor, patch]))
+        else:
+            self.version = tuple(map(int, [major, minor])) + (0,)
+
+        if prerelease:
+            self.prerelease = (prerelease[0], int(prerelease_num))
+        else:
+            self.prerelease = None
+
+    def __str__(self):
+        if self.version[2] == 0:
+            vstring = ".".join(map(str, self.version[0:2]))
+        else:
+            vstring = ".".join(map(str, self.version))
+
+        if self.prerelease:
+            vstring = vstring + self.prerelease[0] + str(self.prerelease[1])
+
+        return vstring
+
+    def _cmp(self, other):
+        if isinstance(other, str):
+            other = StrictVersion(other)
+        elif not isinstance(other, StrictVersion):
+            return NotImplemented
+
+        if self.version != other.version:
+            # numeric versions don't match
+            # prerelease stuff doesn't matter
+            if self.version < other.version:
+                return -1
+            else:
+                return 1
+
+        # have to compare prerelease
+        # case 1: neither has prerelease; they're equal
+        # case 2: self has prerelease, other doesn't; other is greater
+        # case 3: self doesn't have prerelease, other does: self is greater
+        # case 4: both have prerelease: must compare them!
+
+        if not self.prerelease and not other.prerelease:
+            return 0
+        elif self.prerelease and not other.prerelease:
+            return -1
+        elif not self.prerelease and other.prerelease:
+            return 1
+        elif self.prerelease and other.prerelease:
+            if self.prerelease == other.prerelease:
+                return 0
+            elif self.prerelease < other.prerelease:
+                return -1
+            else:
+                return 1
+        else:
+            raise AssertionError("never get here")
+
+
+# end class StrictVersion
+
+# The rules according to Greg Stein:
+# 1) a version number has 1 or more numbers separated by a period or by
+#    sequences of letters. If only periods, then these are compared
+#    left-to-right to determine an ordering.
+# 2) sequences of letters are part of the tuple for comparison and are
+#    compared lexicographically
+# 3) recognize the numeric components may have leading zeroes
+#
+# The LooseVersion class below implements these rules: a version number
+# string is split up into a tuple of integer and string components, and
+# comparison is a simple tuple comparison.  This means that version
+# numbers behave in a predictable and obvious way, but a way that might
+# not necessarily be how people *want* version numbers to behave.  There
+# wouldn't be a problem if people could stick to purely numeric version
+# numbers: just split on period and compare the numbers as tuples.
+# However, people insist on putting letters into their version numbers;
+# the most common purpose seems to be:
+#   - indicating a "pre-release" version
+#     ('alpha', 'beta', 'a', 'b', 'pre', 'p')
+#   - indicating a post-release patch ('p', 'pl', 'patch')
+# but of course this can't cover all version number schemes, and there's
+# no way to know what a programmer means without asking him.
+#
+# The problem is what to do with letters (and other non-numeric
+# characters) in a version number.  The current implementation does the
+# obvious and predictable thing: keep them as strings and compare
+# lexically within a tuple comparison.  This has the desired effect if
+# an appended letter sequence implies something "post-release":
+# eg. "0.99" < "0.99pl14" < "1.0", and "5.001" < "5.001m" < "5.002".
+#
+# However, if letters in a version number imply a pre-release version,
+# the "obvious" thing isn't correct.  Eg. you would expect that
+# "1.5.1" < "1.5.2a2" < "1.5.2", but under the tuple/lexical comparison
+# implemented here, this just isn't so.
+#
+# Two possible solutions come to mind.  The first is to tie the
+# comparison algorithm to a particular set of semantic rules, as has
+# been done in the StrictVersion class above.  This works great as long
+# as everyone can go along with bondage and discipline.  Hopefully a
+# (large) subset of Python module programmers will agree that the
+# particular flavour of bondage and discipline provided by StrictVersion
+# provides enough benefit to be worth using, and will submit their
+# version numbering scheme to its domination.  The free-thinking
+# anarchists in the lot will never give in, though, and something needs
+# to be done to accommodate them.
+#
+# Perhaps a "moderately strict" version class could be implemented that
+# lets almost anything slide (syntactically), and makes some heuristic
+# assumptions about non-digits in version number strings.  This could
+# sink into special-case-hell, though; if I was as talented and
+# idiosyncratic as Larry Wall, I'd go ahead and implement a class that
+# somehow knows that "1.2.1" < "1.2.2a2" < "1.2.2" < "1.2.2pl3", and is
+# just as happy dealing with things like "2g6" and "1.13++".  I don't
+# think I'm smart enough to do it right though.
+#
+# In any case, I've coded the test suite for this module (see
+# ../test/test_version.py) specifically to fail on things like comparing
+# "1.2a2" and "1.2".  That's not because the *code* is doing anything
+# wrong, it's because the simple, obvious design doesn't match my
+# complicated, hairy expectations for real-world version numbers.  It
+# would be a snap to fix the test suite to say, "Yep, LooseVersion does
+# the Right Thing" (ie. the code matches the conception).  But I'd rather
+# have a conception that matches common notions about version numbers.
+
+
+class LooseVersion(Version):
+    """Version numbering for anarchists and software realists.
+    Implements the standard interface for version number classes as
+    described above.  A version number consists of a series of numbers,
+    separated by either periods or strings of letters.  When comparing
+    version numbers, the numeric components will be compared
+    numerically, and the alphabetic components lexically.  The following
+    are all valid version numbers, in no particular order:
+
+        1.5.1
+        1.5.2b2
+        161
+        3.10a
+        8.02
+        3.4j
+        1996.07.12
+        3.2.pl0
+        3.1.1.6
+        2g6
+        11g
+        0.960923
+        2.2beta29
+        1.13++
+        5.5.kw
+        2.0b1pl0
+
+    In fact, there is no such thing as an invalid version number under
+    this scheme; the rules for comparison are simple and predictable,
+    but may not always give the results you want (for some definition
+    of "want").
+    """
+
+    component_re = re.compile(r"(\d+ | [a-z]+ | \.)", re.VERBOSE)
+
+    def __init__(self, vstring=None):
+        if vstring:
+            self.parse(vstring)
+
+    def parse(self, vstring):
+        # I've given up on thinking I can reconstruct the version string
+        # from the parsed tuple -- so I just store the string here for
+        # use by __str__
+        self.vstring = vstring
+        components = [x for x in self.component_re.split(vstring) if x and x != "."]
+        for i, obj in enumerate(components):
+            try:
+                components[i] = int(obj)
+            except ValueError:
+                pass
+
+        self.version = components
+
+    def __str__(self):
+        return self.vstring
+
+    def __repr__(self):
+        return "LooseVersion ('%s')" % str(self)
+
+    def _cmp(self, other):
+        if isinstance(other, str):
+            other = LooseVersion(other)
+        elif not isinstance(other, LooseVersion):
+            return NotImplemented
+
+        if self.version == other.version:
+            return 0
+        if self.version < other.version:
+            return -1
+        if self.version > other.version:
+            return 1
+
+
+# end class LooseVersion

--- a/plugins/modules/purefb_fleet.py
+++ b/plugins/modules/purefb_fleet.py
@@ -1,0 +1,377 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2025, Simon Dodsley (simon@purestorage.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefb_fleet
+version_added: '1.20.0'
+short_description: Manage Fusion Fleet
+description:
+- Create/Modify/Delete Fusion fleet and members
+author:
+- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+options:
+  name:
+    description:
+    - Name of the fleet.
+    - If not provided local array will be used.
+    type: str
+  state:
+    description:
+    - Define whether to add or remove member from a fleet.
+    - Create a new fleet if one does not exist.
+      This will use the current array as the first member.
+    - Fleet deletion can only occiur when the current array
+      is the only fleet member.
+    default: present
+    choices: [ absent, present, create ]
+    type: str
+  member_url:
+    description:
+    - Management IP address/FQDN of array to add to fleet.
+    type: str
+  member_api:
+    description:
+    - API token for target array
+    type: str
+  rename:
+    description:
+    - new name for fleet
+    type: str
+extends_documentation_fragment:
+- purestorage.flashblade.purestorage.fb
+"""
+
+EXAMPLES = r"""
+- name: Create a new fleet
+  purestorage.flashblade.purefb_fleet:
+    name: foo
+    state: create
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Add a member to fleet foo
+  purestorage.flashblade.purefb_fleet:
+    name: foo
+    member_url: array2
+    member_api: c6033033-fe69-2515-a9e8-966bb7fe4b40
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Delete a member from fleet foo
+  purestorage.flashblade.purefb_fleet:
+    name: foo
+    member_url: array2
+    member_api: c6033033-fe69-2515-a9e8-966bb7fe4b40
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Delete fleet foo
+  purestorage.flashblade.purefb_fleet:
+    name: foo
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+"""
+
+RETURN = r"""
+"""
+
+HAS_URLLIB3 = True
+try:
+    import urllib3
+except ImportError:
+    HAS_URLLIB3 = False
+
+HAS_DISTRO = True
+try:
+    import distro
+except ImportError:
+    HAS_DISTRO = False
+
+HAS_PURESTORAGE = True
+try:
+    from pypureclient import flashblade
+    from pypureclient import flasharray
+    from pypureclient.flashblade import (
+        FleetMemberPost,
+        FleetmemberpostMember,
+        FleetmemberpostMembers,
+        FleetPatch,
+    )
+except ImportError:
+    HAS_PURESTORAGE = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
+    get_system,
+    purefb_argument_spec,
+)
+from ansible_collections.purestorage.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
+import platform
+
+VERSION = 1.5
+USER_AGENT_BASE = "Ansible"
+MIN_REQUIRED_API_VERSION = "2.17"
+MIN_FA_VERSION = "2.42"
+
+
+def create_fleet(module, blade):
+    """Create new fleet - only ever called once per fleet"""
+    changed = True
+    if not module.check_mode:
+        res = blade.post_fleets(names=[module.params["name"]])
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to create fleet {0}. Error: {1}".format(
+                    module.params["name"], res.errors[0].message
+                )
+            )
+    module.exit_json(changed=changed)
+
+
+def delete_fleet(module, blade):
+    """Delete the fleet.
+
+    Only works when the current array is the only remaining
+    memebr of the fleet'
+    """
+    changed = True
+    res = blade.delete_fleets(names=[module.params["name"]])
+    if res.status_code != 200:
+        module.fail_json(
+            msg="Fleet {0} deletion failed. Error: {1}".format(
+                module.params["name"], res.errors[0].message
+            )
+        )
+    module.exit_json(changed=changed)
+
+
+def add_fleet_members(module, blade):
+    """Add new member to the fleet"""
+    changed = False
+    existing = False
+    if not module.params["member_url"] and not module.params["member_api"]:
+        module.fail_json(msg="missing required arguments: member_api, member_url")
+    try:
+        fleet_key = list(blade.post_fleets_fleet_key().items)[0].fleet_key
+    except Exception:
+        module.fail_json(msg="Fleet key generation failed")
+    if HAS_URLLIB3 and module.params["disable_warnings"]:
+        urllib3.disable_warnings()
+    if HAS_DISTRO:
+        user_agent = "%(base)s %(class)s/%(version)s (%(platform)s)" % {
+            "base": USER_AGENT_BASE,
+            "class": __name__,
+            "version": VERSION,
+            "platform": distro.name(pretty=True),
+        }
+    else:
+        user_agent = "%(base)s %(class)s/%(version)s (%(platform)s)" % {
+            "base": USER_AGENT_BASE,
+            "class": __name__,
+            "version": VERSION,
+            "platform": platform.platform(),
+        }
+    # FlashBlade API tokens start with "T-" so use that to differentiate
+    # fleet member platform type
+    if "T-" in module.params["member_api"]:
+        remote_system = flashblade.Client(
+            target=module.params["member_url"],
+            api_token=module.params["member_api"],
+            user_agent=user_agent,
+        )
+    else:
+        remote_system = flasharray.Client(
+            target=module.params["member_url"],
+            api_token=module.params["member_api"],
+            user_agent=user_agent,
+        )
+        remote_api = remote_system.get_rest_version()
+        if LooseVersion(MIN_FA_VERSION) > LooseVersion(remote_api):
+            module.fail_json(
+                msg="FlashArray must be a minimum of Purity//FA 6.8.5"
+                " to join a fleet containing FlashBlades"
+            )
+    local_name = list(remote_system.get_arrays().items)[0].name
+    members = list(blade.get_fleets_members().items)
+    for member in range(0, len(members)):
+        if members[member].member.name == local_name:
+            existing = True
+    if not existing:
+        changed = True
+        if not module.check_mode:
+            res = remote_system.post_fleets_members(
+                fleet_names=[module.params["name"]],
+                members=FleetMemberPost(
+                    members=[
+                        FleetmemberpostMembers(
+                            key=fleet_key,
+                            member=FleetmemberpostMember(
+                                name=local_name, resource_type="remote-arrays"
+                            ),
+                        )
+                    ]
+                ),
+            )
+            if res.status_code != 200:
+                module.fail_json(
+                    "Array {0} failed to join fleet {1}. Error: {2}".format(
+                        local_name, module.params["name"], res.errors[0].message
+                    )
+                )
+    module.exit_json(changed=changed)
+
+
+def delete_fleet_members(module, blade):
+    """Delete member from a fleet"""
+    changed = False
+    if HAS_URLLIB3 and module.params["disable_warnings"]:
+        urllib3.disable_warnings()
+    if HAS_DISTRO:
+        user_agent = "%(base)s %(class)s/%(version)s (%(platform)s)" % {
+            "base": USER_AGENT_BASE,
+            "class": __name__,
+            "version": VERSION,
+            "platform": distro.name(pretty=True),
+        }
+    else:
+        user_agent = "%(base)s %(class)s/%(version)s (%(platform)s)" % {
+            "base": USER_AGENT_BASE,
+            "class": __name__,
+            "version": VERSION,
+            "platform": platform.platform(),
+        }
+    # FlashBlade API tokens start with "T-" so use that to differentiate
+    # fleet member platform type
+    if "T-" in module.params["member_api"]:
+        remote_system = flashblade.Client(
+            target=module.params["member_url"],
+            api_token=module.params["member_api"],
+            user_agent=user_agent,
+        )
+    else:
+        remote_system = flasharray.Client(
+            target=module.params["member_url"],
+            api_token=module.params["member_api"],
+            user_agent=user_agent,
+        )
+    local_name = list(remote_system.get_arrays().items)[0].name
+    members = list(blade.get_fleets_members().items)
+    for member in range(0, len(members)):
+        if members[member].member.name == local_name:
+            changed = True
+            if not module.check_mode:
+                if members[member].status not in [
+                    "joined",
+                    "connected",
+                    "partially connected",
+                ]:
+                    res = blade.delete_fleets_members(
+                        member_names=[local_name], unreachable=True
+                    )
+                else:
+                    res = blade.delete_fleets_members(member_names=[local_name])
+                if res.status_code != 200:
+                    module.fail_json(
+                        "Array {0} failed to be removed from fleet. Error: {1}".format(
+                            module.params["member_url"], res.errors[0].message
+                        )
+                    )
+    module.exit_json(changed=changed)
+
+
+def rename_fleet(module, blade):
+    """Rename the fleet"""
+    changed = False
+    fleet = list(blade.get_fleets().items)[0].name
+    if module.params["rename"] != fleet:
+        changed = True
+        if not module.check_mode:
+            res = blade.patch_fleets(
+                names=[module.params["name"]],
+                fleet=FleetPatch(name=module.params["rename"]),
+            )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Fleet rename failed. Error: {0}".format(res.errors[0].message)
+                )
+    module.exit_json(changed=changed)
+
+
+def main():
+    argument_spec = purefb_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(type="str"),
+            state=dict(
+                type="str", default="present", choices=["absent", "present", "create"]
+            ),
+            member_url=dict(type="str"),
+            member_api=dict(type="str"),
+            rename=dict(type="str"),
+        )
+    )
+
+    required_together = [["member_url", "member_api"]]
+
+    module = AnsibleModule(
+        argument_spec, required_together=required_together, supports_check_mode=True
+    )
+
+    if not HAS_PURESTORAGE:
+        module.fail_json(msg="py-pure-client sdk is required for this module")
+
+    blade = get_system(module)
+    api_version = list(blade.get_versions().items)
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
+        module.fail_json(
+            msg="FlashBlade REST version not supported. "
+            "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
+        )
+    state = module.params["state"]
+
+    fleet_res = blade.get_fleets()
+    if fleet_res.status_code == 404:
+        module.fail_json(
+            msg="Fusion is not enabled on this system. "
+            "Please speak to Pure Support to enable this feature"
+        )
+    else:
+        try:
+            fleet = list(fleet_res.items)
+        except Exception:
+            fleet = False
+
+    if state == "create" and not fleet:
+        create_fleet(module, blade)
+    elif state == "present" and module.params["rename"]:
+        rename_fleet(module, blade)
+    elif state == "present" and fleet:
+        add_fleet_members(module, blade)
+    elif state == "absent" and fleet and module.params["member_url"]:
+        delete_fleet_members(module, blade)
+    elif state == "absent" and fleet:
+        delete_fleet(module, blade)
+    else:
+        module.exit_json(changed=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/output/.tmp/sanity/import/minimal-py38/bin/importer.py
+++ b/tests/output/.tmp/sanity/import/minimal-py38/bin/importer.py
@@ -1,1 +1,0 @@
-/usr/local/lib/python2.7/dist-packages/ansible_test/_data/sanity/import/importer.py

--- a/tests/output/.tmp/sanity/import/minimal-py38/bin/yaml_to_json.py
+++ b/tests/output/.tmp/sanity/import/minimal-py38/bin/yaml_to_json.py
@@ -1,1 +1,0 @@
-/usr/local/lib/python2.7/dist-packages/ansible_test/_data/sanity/import/yaml_to_json.py


### PR DESCRIPTION
##### SUMMARY
Add new fleet module to allow fleet support.
FA can only be added if Purity//FA 6.8.5+
Add `module_utils/version.py` to use `LooseVersion` going forward
Add `fleet` subset for `purefa_info` module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_fleet.py
purefa_info.py
module_utils/version.py

##### ADDITIONAL INFORMATION
Requires Purity//FB 4.5.6 minimum