### PR TITLE
Fix that purefb_policy in check mode would try to refer to a variable that's only set when check mode is disabled

### DIFF
--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -2390,12 +2390,14 @@ def update_os_policy(module, blade):
                         rule=rule,
                         enforce_action_restrictions=module.params["ignore_enforcement"],
                     )
-                if res.status_code != 200:
-                    module.fail_json(
-                        msg="Failed to update rule {0} in policy {1}. Error: {2}".format(
-                            module.params["rule"], policy_name, res.errors[0].message
+                    if res.status_code != 200:
+                        module.fail_json(
+                            msg="Failed to update rule {0} in policy {1}. Error: {2}".format(
+                                module.params["rule"],
+                                policy_name,
+                                res.errors[0].message,
+                            )
                         )
-                    )
     if module.params["user"]:
         member_name = module.params["account"] + "/" + module.params["user"]
         res = blade.get_object_store_access_policies_object_store_users(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Bug in purefb_policy when there's a change and check mode is enabled

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
purefb_policy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- All new PRs must include a changelog fragment
- Details of naming convention and format can be found [here](https://docs.ansible.com/ansible/latest/community/development_process.html#creating-a-changelog-fragment)
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
line 3517, in <module>
  File "…/purestorage/flashblade/plugins/modules/purefb_policy.py", line 3213, in main
  File "…/purestorage/flashblade/plugins/modules/purefb_policy.py", line 2393, in update_os_policy
**UnboundLocalError: cannot access local variable 'res' where it is not associated with a value**
```
