### PR TITLE
Update s3user error messages for policy application

### DIFF
--- a/changelogs/fragments/353_s3user_enhanced_policy_reporting.yaml
+++ b/changelogs/fragments/353_s3user_enhanced_policy_reporting.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefb_s3user - Updated failure messages for applying policies to an object user account.
+ - purefb_s3user - Changed ``key_state`` state to be ``keystate`` as ``key_state`` is reserved.


### PR DESCRIPTION
##### SUMMARY
Add better error reporting messages when policies are failed to be applied to an object user account.
Update example to use a policy that will never fail...
`state` of `key_state` renamed to `keystate` as `key_state` is reserved.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
purefb_s3user.py