### PR TITLE
purefb_bucket: Fix 'dict' object has no attribute errors

### DIFF
--- a/plugins/modules/purefb_bucket.py
+++ b/plugins/modules/purefb_bucket.py
@@ -617,10 +617,10 @@ def update_bucket(module, blade, bucket):
         }
         if current_pac != new_pac:
             change_pac = True
-            pac = BucketPatch(
+            pac = flashblade.BucketPatch(
                 public_access_config=flashblade.PublicAccessConfig(
-                    block_new_public_policies=new_pac.block_new_public_policies,
-                    block_public_access=new_pac.block_public_access,
+                    block_new_public_policies=new_pac["block_new_public_policies"],
+                    block_public_access=new_pac["block_public_access"],
                 )
             )
         if change_pac and not module.check_mode:
@@ -661,11 +661,11 @@ def update_bucket(module, blade, bucket):
         }
         if current_worm != new_worm:
             change_worm = True
-            worm = BucketPatch(
+            worm = flashblade.BucketPatch(
                 public_access_config=flashblade.BucketEradicationConfig(
-                    eradication_delay=new_worm.eradication_delay,
-                    manual_eradication=new_worm.manual_eradication,
-                    eradication_mode=new_worm.eradication_mode,
+                    eradication_delay=new_worm["eradication_delay"],
+                    manual_eradication=new_worm["manual_eradication"],
+                    eradication_mode=new_worm["eradication_mode"],
                 )
             )
         if change_worm and not module.check_mode:


### PR DESCRIPTION
##### SUMMARY
We're seeing errors trying to set `block_new_public_policies`, `block_public_access` and `eradication_delay` via `purestorage.flashblade.purefb_bucket`.

Fix enclosed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_bucket

##### ADDITIONAL INFORMATION
Given a task like
```
- name: "{{ datacenter }} - {{ account_name }} - Ensure buckets exist"
  purestorage.flashblade.purefb_bucket:
    fb_url: "{{ fb_url }}"
    api_token: "{{ api_token }}"
    name: "{{ item.name }}"
    account: "{{ account_name }}"
    block_new_public_policies: true
    block_public_access: true
    eradication_delay: 2
  loop: "{{ buckets }}"
  register: bucket_creation
```
we're seeing this error:
```
  File "/var/folders/f1/_00jhynx1x59dkrpk2g2f4mc0000gn/T/ansible_purestorage.flashblade.purefb_bucket_payload_tjsaatjo/ansible_purestorage.flashblade.purefb_bucket_payload.zip/ansible_collections/purestorage/flashblade/plugins/modules/purefb_bucket.py", line 622, in update_bucket
AttributeError: 'dict' object has no attribute 'block_new_public_policies'
```
and we see the same issue for `eradication_delay`.