### PR TITLE
Remove prefix req for updating subnet

### DIFF
--- a/changelogs/fragments/360_subnet_prefix.yaml
+++ b/changelogs/fragments/360_subnet_prefix.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_subnet - ``prefix`` removed as a required parameter for updating an existing subnet

--- a/plugins/modules/purefb_subnet.py
+++ b/plugins/modules/purefb_subnet.py
@@ -275,11 +275,7 @@ def main():
         )
     )
 
-    required_if = [["state", "present", ["prefix"]]]
-
-    module = AnsibleModule(
-        argument_spec, required_if=required_if, supports_check_mode=True
-    )
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
 
     if not HAS_PURITY_FB:
         module.fail_json(msg="purity_fb sdk is required for this module")


### PR DESCRIPTION
##### SUMMARY
Previously when amending an existing subnet, `prefix` was a required parameter, when actually it isn't necessarily required.
This patch removes the requirement for `prefix` when updating an existing subnet.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_subnet.py