### PR TITLE
update_s3user: fix imported_key reference error

### DIFF
--- a/plugins/modules/purefb_s3user.py
+++ b/plugins/modules/purefb_s3user.py
@@ -196,7 +196,7 @@ def update_s3user(module, blade):
         keys = list(blade.get_object_store_access_keys().items)
         for key in range(0, len(keys)):
             if module.params["imported_key"]:
-                if keys.items[key].name == module.params["imported_key"]:
+                if keys[key].name == module.params["imported_key"]:
                     module.warn("Imported key provided already belongs to a user")
                     exists = True
             if keys[key].user.name == user:


### PR DESCRIPTION
##### SUMMARY
Fixes a regression we're seeing in 1.20.0:

> File \"/var/folders/f1/_00jhynx1x59dkrpk2g2f4mc0000gn/T/ansible_purestorage.flashblade.purefb_s3user_payload_ex164yzk/ansible_purestorage.flashblade.purefb_s3user_payload.zip/ansible_collections/purestorage/flashblade/plugins/modules/purefb_s3user.py\", line 199, in update_s3user\nAttributeError: 'list' object has no attribute 'items'\n",

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`purefb_s3user`