### PR TITLE
Fix a typo preventing policy creation

### DIFF
--- a/plugins/modules/purefb_bucket_access.py
+++ b/plugins/modules/purefb_bucket_access.py
@@ -324,7 +324,7 @@ def create_access_policy(module, blade):
                 resources=all_resources,
                 actions=module.params["actions"],
                 principals=BucketAccessPolicyRulePrincipal(
-                    all=module.params["pricipals"]
+                    all=module.params["principals"]
                 ),
             ),
         )


### PR DESCRIPTION
##### SUMMARY

Fixes this error:

> File \"/var/folders/f1/_00jhynx1x59dkrpk2g2f4mc0000gn/T/ansible_purestorage.flashblade.purefb_bucket_access_payload_6ntbx60w/ansible_purestorage.flashblade.purefb_bucket_access_payload.zip/ansible_collections/purestorage/flashblade/plugins/modules/purefb_bucket_access.py\", line 327, in create_access_policy\nKeyError: 'pricipals'\n"

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_bucket_access