### PR TITLE
Fix AD updating issues

### DIFF
--- a/changelogs/fragments/369_ad_fix.yaml
+++ b/changelogs/fragments/369_ad_fix.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+ - purefb_ad - ``service`` parameter removed to comply with underlying API structure. ``service`` should be included in the ``service_principals`` strings as shown in the documentation.
+bugfixes:
+ - purefb_ad - Fixed issue where updating an AD account required unnecessary parameters.


### PR DESCRIPTION
##### SUMMARY
Updating AD account is incorrectly asking for unnecessary parameters.
This patch fixes this.
As part of this patch we are removing the `service` parameter and enforcing the service to be included in the `service_principal` string as is required by the API structure.
Closed #368 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_ad.py