### PR TITLE
Fix info default when no SMB DS

### DIFF
--- a/changelogs/fragments/377_info_smb_ds.yaml
+++ b/changelogs/fragments/377_info_smb_ds.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_info - Fixed error when ``default`` subset fails if SMD has been disabled on the FLashBlade

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -392,12 +392,15 @@ def generate_config_dict(module, blade):
         .items[0]
         .to_dict()
     )
-    if SERVERS_API_VERSION not in api_version:
-        config_info["smb_directory_service"] = (
-            blade.directory_services.list_directory_services(names=["smb"])
-            .items[0]
-            .to_dict()
-        )
+    try:
+        if SERVERS_API_VERSION not in api_version:
+            config_info["smb_directory_service"] = (
+                blade.directory_services.list_directory_services(names=["smb"])
+                .items[0]
+                .to_dict()
+            )
+    except Exception:
+        config_info["smb_directory_service"] = {}
     config_info["ntp"] = blade.arrays.list_arrays().items[0].ntp_servers
     config_info["ssl_certs"] = blade.certificates.list_certificates().items[0].to_dict()
     if CERT_GROUPS_API_VERSION in api_version:


### PR DESCRIPTION
##### SUMMARY
After SMB was removed from parts of Purity, this fix ensures that the default info suset doesn't fail when looking for SMB directory services that no longer exist.
Fixes #370 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_info.py