### PR TITLE
Fix nfs_rules if only SMB

### DIFF
--- a/changelogs/fragments/387_smb_no_nfs.yaml
+++ b/changelogs/fragments/387_smb_no_nfs.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_fs - Ensured that NFS rules are emprty if requested filesystem is SMB only

--- a/plugins/modules/purefb_fs.py
+++ b/plugins/modules/purefb_fs.py
@@ -376,6 +376,10 @@ def create_fs(module, blade):
                                 module.fail_json(
                                     msg="Cannot set access_control to smb or independent when SMB is not enabled."
                                 )
+                            if module.params["smb"] and not (
+                                module.params["nfsv3"] or module.params["nfsv4"]
+                            ):
+                                module.params["nfs_rules"] = ""
                             if module.params["safeguard_acls"] and (
                                 module.params["access_control"]
                                 in ["mode-bits", "independent"]


### PR DESCRIPTION
##### SUMMARY
Ensure that NFS rules are empty is the requested filesystem is SMB only.
Fixes #387 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_fs.py