### PR TITLE
Revert AD service parameter removal

### DIFF
--- a/changelogs/fragments/391_revert_ad_service.yaml
+++ b/changelogs/fragments/391_revert_ad_service.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - purefb_ad - Revert removal of ``service`` parameter (breaking change). Added more logic to use of ``service`` parameter and recommend use of ``service_principals`` with service incorporated.


### PR DESCRIPTION
##### SUMMARY
#369 contained a breaking change.
This reverts that change and adds more logic into the use of the `service` parameter and recommendation to use the `service_principals` parameter correctly as shown in the examples.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_ad.py