### PR TITLE
Remove old API version checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ The Pure Storage FlashBlade collection consists of the latest versions of the Fl
 ## Requirements
 
 - Ansible 2.15 or later
-- Pure Storage FlashBlade system running Purity//FB 2.1.2 or later
-    - some modules require higher versions of Purity//FB
-- purity-fb >=v1.12.2
+- Pure Storage FlashBlade system running Purity//FB 3.3.3 or later
 - py-pure-client >=v1.67.2
 - python >=3.9
 - netaddr

--- a/changelogs/fragments/416_api_remove.yaml
+++ b/changelogs/fragments/416_api_remove.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+ - purefb_admin - Remove references to unsupported API versions
+ - purefb_connect - Remove references to unsupported API versions
+ - purefb_policy - Remove references to unsupported API versions
+ - purefb_s3acc - Remove references to unsupported API versions

--- a/plugins/modules/purefb_admin.py
+++ b/plugins/modules/purefb_admin.py
@@ -69,8 +69,6 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb impo
     purefb_argument_spec,
 )
 
-MIN_API_VERSION = "2.3"
-
 
 def main():
     argument_spec = purefb_argument_spec()
@@ -93,43 +91,40 @@ def main():
     blade = get_system(module)
     api_version = list(blade.get_versions().items)
     changed = False
-    if MIN_API_VERSION in api_version:
-        current_settings = list(blade.get_admins_settings().items)[0]
-        lockout = getattr(current_settings, "lockout_duration", None)
-        max_login = getattr(current_settings, "max_login_attempts", None)
-        min_password = getattr(current_settings, "min_password_length", 1)
-        if min_password != module.params["min_password"]:
-            changed = True
-            min_password = module.params["min_password"]
-        if lockout and lockout != module.params["lockout"] * 1000:
-            changed = True
-            lockout = module.params["lockout"] * 1000
-        elif not lockout and module.params["lockout"]:
-            changed = True
-            lockout = module.params["lockout"] * 1000
-        if max_login and max_login != module.params["max_login"]:
-            changed = True
-            max_login = module.params["max_login"]
-        elif not max_login and module.params["max_login"]:
-            changed = True
-            max_login = module.params["max_login"]
+    current_settings = list(blade.get_admins_settings().items)[0]
+    lockout = getattr(current_settings, "lockout_duration", None)
+    max_login = getattr(current_settings, "max_login_attempts", None)
+    min_password = getattr(current_settings, "min_password_length", 1)
+    if min_password != module.params["min_password"]:
+        changed = True
+        min_password = module.params["min_password"]
+    if lockout and lockout != module.params["lockout"] * 1000:
+        changed = True
+        lockout = module.params["lockout"] * 1000
+    elif not lockout and module.params["lockout"]:
+        changed = True
+        lockout = module.params["lockout"] * 1000
+    if max_login and max_login != module.params["max_login"]:
+        changed = True
+        max_login = module.params["max_login"]
+    elif not max_login and module.params["max_login"]:
+        changed = True
+        max_login = module.params["max_login"]
 
-        if changed and not module.check_mode:
-            admin = AdminSetting(
-                min_password_length=min_password,
-                max_login_attempts=max_login,
-                lockout_duration=lockout,
-            )
+    if changed and not module.check_mode:
+        admin = AdminSetting(
+            min_password_length=min_password,
+            max_login_attempts=max_login,
+            lockout_duration=lockout,
+        )
 
-            res = blade.patch_admins_settings(admin_setting=admin)
-            if res.status_code != 200:
-                module.fail_json(
-                    msg="Failed to change Global Admin settings. Error: {0}".format(
-                        res.errors[0].message
-                    )
+        res = blade.patch_admins_settings(admin_setting=admin)
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to change Global Admin settings. Error: {0}".format(
+                    res.errors[0].message
                 )
-    else:
-        module.fail_json(msg="Purity version does not support Global Admin settings")
+            )
     module.exit_json(changed=changed)
 
 

--- a/plugins/modules/purefb_bucket.py
+++ b/plugins/modules/purefb_bucket.py
@@ -58,7 +58,6 @@ options:
   mode:
     description:
       - The type of bucket to be created. Also referred to a VSO Mode.
-      - Requires Purity//FB 3.3.3 or higher
       - I(multi-site-writable) type can only be used after feature is
         enabled by Pure Technical Support
     type: str

--- a/plugins/modules/purefb_fs.py
+++ b/plugins/modules/purefb_fs.py
@@ -160,7 +160,6 @@ options:
     description:
       - The access control style that is utilized for client actions such
         as setting file and directory ACLs.
-      - Only available from Purity//FB 3.1.1
     type: str
     default: shared
     choices: [ 'nfs', 'smb', 'shared', 'independent', 'mode-bits' ]
@@ -169,14 +168,12 @@ options:
       - Safeguards ACLs on a filesystem.
       - Performs different roles depending on the filesystem protocol enabled.
       - See Purity//FB documentation for detailed description.
-      - Only available from Purity//FB 3.1.1
     type: bool
     default: true
   export_policy:
     description:
     - Name of NFS export policy to assign to filesystem
     - Overrides I(nfs_rules)
-    - Only valid for Purity//FB 3.3.0 or higher
     type: str
     version_added: "1.9.0"
   share_policy:

--- a/plugins/modules/purefb_lifecycle.py
+++ b/plugins/modules/purefb_lifecycle.py
@@ -80,15 +80,7 @@ extends_documentation_fragment:
 """
 
 EXAMPLES = r"""
-- name: Create a lifecycle rule called bar for bucket foo (pre-Purity//FB 3.2.3)
-  purestorage.flashblade.purefb_lifecycle:
-    name: bar
-    bucket: foo
-    keep_previous_for: 2d
-    prefix: test
-    fb_url: 10.10.10.2
-    api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
-- name: Create a lifecycle rule called bar for bucket foo (post-Purity//FB 3.2.3)
+- name: Create a lifecycle rule called bar for bucket foo
   purestorage.flashblade.purefb_lifecycle:
     name: bar
     bucket: foo
@@ -98,7 +90,7 @@ EXAMPLES = r"""
     prefix: test
     fb_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
-- name: Modify a lifecycle rule (post-Purity//FB 3.2.3)
+- name: Modify a lifecycle rule
   purestorage.flashblade.purefb_lifecycle:
     name: bar
     bucket: foo

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -633,7 +633,6 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.common impo
     convert_time_to_millisecs,
 )
 
-ACCESS_POLICY_API_VERSION = "2.2"
 NFS_POLICY_API_VERSION = "2.3"
 NFS_RENAME_API_VERSION = "2.4"
 SMB_POLICY_API_VERSION = "2.10"
@@ -3937,14 +3936,6 @@ def main():
     blade = get_system(module)
     versions = list(blade.get_versions().items)
     if module.params["policy_type"] == "access":
-        if ACCESS_POLICY_API_VERSION not in versions:
-            module.fail_json(
-                msg=(
-                    "Minimum FlashBlade REST version required: {0}".format(
-                        ACCESS_POLICY_API_VERSION
-                    )
-                )
-            )
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         blade = get_system(module)

--- a/plugins/modules/purefb_s3acc.py
+++ b/plugins/modules/purefb_s3acc.py
@@ -123,7 +123,6 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb impo
 )
 
 
-QUOTA_API_VERSION = "2.1"
 PUBLIC_API_VERSION = "2.12"
 
 
@@ -366,12 +365,6 @@ def main():
     if module.params["quota"] or module.params["default_quota"]:
         if not HAS_PURESTORAGE:
             module.fail_json(msg="py-pure-client sdk is required for to set quotas")
-        if QUOTA_API_VERSION not in versions:
-            module.fail_json(
-                msg="Quotas require minimum FlashBlade REST version: {0}".format(
-                    QUOTA_API_VERSION
-                )
-            )
 
     upper = False
     for element in module.params["name"]:


### PR DESCRIPTION
##### SUMMARY
With the support of REST v2 the FlashBlade Collections will now only support Purity//FB versions 3.3.3 and higher.
This patch removes all references and checks for previous REST versions

##### ISSUE TYPE
- Feature Pull Request
- REST 2 Pull Request

##### COMPONENT NAME
purefb_admin.py
purefb_bucket.py
purefb_connect.py
purefb_fs.py
purefb_lifecycle.py
purefb_policy.py
purefb_s3acc.py
README.md