### PR TITLE
Handle None input in _convert_to_millisecs function

### DIFF
--- a/plugins/modules/purefb_lifecycle.py
+++ b/plugins/modules/purefb_lifecycle.py
@@ -169,7 +169,6 @@ def _convert_to_millisecs(day):
     """Convert a string like '2w' or '3d' into milliseconds."""
     if not day:
         return 0
-        
     multipliers = {
         "w": 7 * 86400000,  # one week
         "d": 86400000,  # one day


### PR DESCRIPTION
##### SUMMARY
Fix issue where None is passed for conversion to milliseconds.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_lifecycle.py