### PR TITLE
Remove references to FQDNs in service principal names

### DIFF
--- a/changelogs/fragments/450_ad_fqdn.yaml
+++ b/changelogs/fragments/450_ad_fqdn.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefb_ad - Remove doc references to FQDNs as SPNs are the required method.
+ - purefa_ad - Added support for local servers using the ``server`` parameter.


### PR DESCRIPTION
##### SUMMARY
Remove docs references to FQDNs as we should only use SPNs with service included.
If the `service` parameter is specified, ignore or send failure message, depending on the idempotency state.
Add `server` parameter to allow for local servers from REST 2.16. If not provided, will use the default server `_array_server`

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
purefb_ad.py