### PR TITLE
Update DS module with test and support for internal NFS servers

### DIFF
--- a/changelogs/fragments/454_ds_test.yaml
+++ b/changelogs/fragments/454_ds_test.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+ - purefb_ds - Update test state to allow specific tests to be run
+ - purefb_ds - Allow directory services to be modified for internal NFS servers


### PR DESCRIPTION
##### SUMMARY
Update DS test function to allow specific internal server to be tested and configure the directory service for an internal server.
Adds new parameter `nfs_server` to specify which internal server NFS. Only applied when `dstype: nfs`.
If not provided, will default to the internal server `_array_server` 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefb_ds.py