### PR TITLE
Standardize import name chacks

### DIFF
--- a/changelogs/fragments/495_import_standard.yaml
+++ b/changelogs/fragments/495_import_standard.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - Standardize all import checks of Pure SDK to use the same variable name

--- a/plugins/modules/purefb_ad.py
+++ b/plugins/modules/purefb_ad.py
@@ -223,7 +223,7 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import (
         ActiveDirectoryPost,
@@ -232,7 +232,7 @@ try:
         KeytabPost,
     )
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -496,7 +496,7 @@ def main():
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
 
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)

--- a/plugins/modules/purefb_admin.py
+++ b/plugins/modules/purefb_admin.py
@@ -56,11 +56,11 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import AdminSetting
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 
 from ansible.module_utils.basic import AnsibleModule
@@ -82,7 +82,7 @@ def main():
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
 
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
     if module.params["lockout"] and not 1 <= module.params["lockout"] <= 7776000:
         module.fail_json(msg="Lockout must be between 1 and 7776000 seconds")

--- a/plugins/modules/purefb_apiclient.py
+++ b/plugins/modules/purefb_apiclient.py
@@ -101,11 +101,11 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import ApiClient, ApiClientsPost, ReferenceWritable
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 import re
 from ansible.module_utils.basic import AnsibleModule
@@ -216,7 +216,7 @@ def main():
                 module.params["name"]
             )
         )
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -187,7 +187,7 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import (
         CertificatePost,
@@ -197,7 +197,7 @@ try:
         CertificatePatch,
     )
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 HAS_PYCOUNTRY = True
 try:
@@ -545,7 +545,7 @@ def main():
         supports_check_mode=True,
     )
 
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     if not HAS_PYCOUNTRY:

--- a/plugins/modules/purefb_dns.py
+++ b/plugins/modules/purefb_dns.py
@@ -93,11 +93,11 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import Dns, DnsPatch, DnsPost, Reference
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (

--- a/plugins/modules/purefb_ds.py
+++ b/plugins/modules/purefb_ds.py
@@ -194,11 +194,11 @@ RETURN = r"""
 
 NO_SMB_VERSION = "2.16"
 
-HAS_PURITY_FB = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import DirectoryService
 except ImportError:
-    HAS_PURITY_FB = False
+    HAS_PYPURECLIENT = False
 
 
 from ansible.module_utils.basic import AnsibleModule
@@ -497,7 +497,7 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True,
     )
-    if not HAS_PURITY_FB:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     state = module.params["state"]

--- a/plugins/modules/purefb_dsrole.py
+++ b/plugins/modules/purefb_dsrole.py
@@ -87,11 +87,11 @@ RETURN = r"""
 """
 
 
-HAS_PURITY_FB = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import DirectoryServiceRole
 except ImportError:
-    HAS_PURITY_FB = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -189,7 +189,7 @@ def main():
         argument_spec, required_together=required_together, supports_check_mode=True
     )
 
-    if not HAS_PURITY_FB:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     state = module.params["state"]

--- a/plugins/modules/purefb_fleet.py
+++ b/plugins/modules/purefb_fleet.py
@@ -103,7 +103,7 @@ try:
 except ImportError:
     HAS_DISTRO = False
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient import flashblade
     from pypureclient import flasharray
@@ -114,7 +114,7 @@ try:
         FleetPatch,
     )
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -337,7 +337,7 @@ def main():
         argument_spec, required_together=required_together, supports_check_mode=True
     )
 
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)

--- a/plugins/modules/purefb_fs_replica.py
+++ b/plugins/modules/purefb_fs_replica.py
@@ -93,11 +93,11 @@ EXAMPLES = """
 RETURN = """
 """
 
-HAS_PURITY_FB = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import FileSystemReplicaLink, LocationReference
 except ImportError:
-    HAS_PURITY_FB = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -289,7 +289,7 @@ def main():
         argument_spec, required_if=required_if, supports_check_mode=True
     )
 
-    if not HAS_PURITY_FB:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     state = module.params["state"]

--- a/plugins/modules/purefb_groupquota.py
+++ b/plugins/modules/purefb_groupquota.py
@@ -121,11 +121,11 @@ EXAMPLES = """
 RETURN = """
 """
 
-HAS_PURITY_FB = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import GroupQuotaPost, GroupQuotaPatch
 except ImportError:
-    HAS_PURITY_FB = False
+    HAS_PYPURECLIENT = False
 
 CONTEXT_API_VERSION = "2.17"
 
@@ -362,7 +362,7 @@ def main():
         supports_check_mode=True,
     )
 
-    if not HAS_PURITY_FB:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     state = module.params["state"]

--- a/plugins/modules/purefb_hardware.py
+++ b/plugins/modules/purefb_hardware.py
@@ -76,11 +76,11 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient import flashblade
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -107,7 +107,7 @@ def main():
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)

--- a/plugins/modules/purefb_keytabs.py
+++ b/plugins/modules/purefb_keytabs.py
@@ -106,11 +106,11 @@ download_file:
   sample: "/tmp/pure_krb8939478070214877726.keytab"
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import KeytabPost, Reference
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -218,7 +218,7 @@ def main():
         argument_spec, required_if=required_if, supports_check_mode=True
     )
 
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     state = module.params["state"]

--- a/plugins/modules/purefb_kmip.py
+++ b/plugins/modules/purefb_kmip.py
@@ -89,11 +89,11 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import KmipServer, Reference
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -245,7 +245,7 @@ def main():
         supports_check_mode=True,
     )
 
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)

--- a/plugins/modules/purefb_lag.py
+++ b/plugins/modules/purefb_lag.py
@@ -97,11 +97,11 @@ lag:
             type: str
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import Reference, FixedReference, LinkAggregationGroup
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -259,7 +259,7 @@ def main():
         argument_spec, required_if=required_if, supports_check_mode=True
     )
 
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)

--- a/plugins/modules/purefb_network.py
+++ b/plugins/modules/purefb_network.py
@@ -91,11 +91,11 @@ EXAMPLES = """
 RETURN = """
 """
 
-HAS_PURITY_FB = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import NetworkInterface, NetworkInterfacePatch
 except ImportError:
-    HAS_PURITY_FB = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -187,7 +187,7 @@ def main():
         argument_spec, required_if=required_if, supports_check_mode=True
     )
 
-    if not HAS_PURITY_FB:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     state = module.params["state"]

--- a/plugins/modules/purefb_ntp.py
+++ b/plugins/modules/purefb_ntp.py
@@ -66,11 +66,11 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURITY_FB = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import Array
 except ImportError:
-    HAS_PURITY_FB = False
+    HAS_PYPURECLIENT = False
 
 
 from ansible.module_utils.basic import AnsibleModule
@@ -131,7 +131,7 @@ def main():
         argument_spec, required_if=required_if, supports_check_mode=True
     )
 
-    if not HAS_PURITY_FB:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)

--- a/plugins/modules/purefb_phonehome.py
+++ b/plugins/modules/purefb_phonehome.py
@@ -49,11 +49,11 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURITY_FB = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import Support
 except ImportError:
-    HAS_PURITY_FB = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -132,7 +132,7 @@ def main():
 
     blade = get_system(module)
 
-    if not HAS_PURITY_FB:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client SDK is required for this module")
     support = list(blade.get_support().items)[0].phonehome_enabled
     if module.params["state"] == "present" and not support:

--- a/plugins/modules/purefb_remote_cred.py
+++ b/plugins/modules/purefb_remote_cred.py
@@ -84,14 +84,14 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURITY_FB = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import (
         ObjectStoreRemoteCredentialsPost,
         ObjectStoreRemoteCredentialsPatch,
     )
 except ImportError:
-    HAS_PURITY_FB = False
+    HAS_PYPURECLIENT = False
 
 
 from ansible.module_utils.basic import AnsibleModule
@@ -253,7 +253,7 @@ def main():
         argument_spec, required_if=required_if, supports_check_mode=True
     )
 
-    if not HAS_PURITY_FB:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)

--- a/plugins/modules/purefb_s3acc.py
+++ b/plugins/modules/purefb_s3acc.py
@@ -114,7 +114,7 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import (
         ObjectStoreAccountPatch,
@@ -122,7 +122,7 @@ try:
         PublicAccessConfig,
     )
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule, human_to_bytes
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -425,7 +425,7 @@ def main():
     blade = get_system(module)
 
     if module.params["quota"] or module.params["default_quota"]:
-        if not HAS_PURESTORAGE:
+        if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for to set quotas")
 
     upper = False

--- a/plugins/modules/purefb_saml.py
+++ b/plugins/modules/purefb_saml.py
@@ -112,7 +112,7 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import (
         Saml2Sso,
@@ -122,7 +122,7 @@ try:
         ReferenceWriteable,
     )
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -363,7 +363,7 @@ def main():
         argument_spec, supports_check_mode=True, required_if=required_if
     )
 
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)

--- a/plugins/modules/purefb_snmp_agent.py
+++ b/plugins/modules/purefb_snmp_agent.py
@@ -83,11 +83,11 @@ RETURN = r"""
 """
 
 
-HAS_PURITY_FB = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import SnmpAgent, SnmpV2c, SnmpV3
 except ImportError:
-    HAS_PURITY_FB = False
+    HAS_PYPURECLIENT = False
 
 
 from ansible.module_utils.basic import AnsibleModule
@@ -184,7 +184,7 @@ def main():
 
     blade = get_system(module)
 
-    if not HAS_PURITY_FB:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client SDK is required for this module")
 
     if module.params["version"] == "v3":

--- a/plugins/modules/purefb_snmp_mgr.py
+++ b/plugins/modules/purefb_snmp_mgr.py
@@ -120,11 +120,11 @@ RETURN = r"""
 """
 
 
-HAS_PURITY_FB = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import SnmpManager, SnmpV2c, SnmpV3
 except ImportError:
-    HAS_PURITY_FB = False
+    HAS_PYPURECLIENT = False
 
 
 from ansible.module_utils.basic import AnsibleModule
@@ -346,7 +346,7 @@ def main():
     state = module.params["state"]
     blade = get_system(module)
 
-    if not HAS_PURITY_FB:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client SDK is required for this module")
 
     mgr_configured = False

--- a/plugins/modules/purefb_subnet.py
+++ b/plugins/modules/purefb_subnet.py
@@ -106,11 +106,11 @@ EXAMPLES = """
 RETURN = """
 """
 
-HAS_PURITY_FB = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import Subnet, Reference
 except ImportError:
-    HAS_PURITY_FB = False
+    HAS_PYPURECLIENT = False
 
 try:
     import netaddr
@@ -274,7 +274,7 @@ def main():
         argument_spec, required_if=required_if, supports_check_mode=True
     )
 
-    if not HAS_PURITY_FB:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     if not HAS_NETADDR:

--- a/plugins/modules/purefb_syslog.py
+++ b/plugins/modules/purefb_syslog.py
@@ -89,11 +89,11 @@ RETURN = r"""
 """
 
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import SyslogServerPost, SyslogServerPatch
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/purefb_timeout.py
+++ b/plugins/modules/purefb_timeout.py
@@ -58,11 +58,11 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient import flashblade
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb import (
@@ -105,7 +105,7 @@ def main():
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
 
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)

--- a/plugins/modules/purefb_tz.py
+++ b/plugins/modules/purefb_tz.py
@@ -43,11 +43,11 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient import flashblade
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 HAS_PYTZ = True
 try:
@@ -167,7 +167,7 @@ def main():
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
 
-    if not HAS_PURESTORAGE:
+    if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
     if not HAS_PYTZ:
         module.fail_json(msg="pytz is required for this module")

--- a/plugins/modules/purefb_user.py
+++ b/plugins/modules/purefb_user.py
@@ -125,7 +125,7 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-HAS_PURESTORAGE = True
+HAS_PYPURECLIENT = True
 try:
     from pypureclient.flashblade import (
         AdminPatch,
@@ -134,7 +134,7 @@ try:
         ReferenceWritable,
     )
 except ImportError:
-    HAS_PURESTORAGE = False
+    HAS_PYPURECLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purestorage.flashblade.plugins.module_utils.time_utils import (


### PR DESCRIPTION
##### SUMMARY
Standadize all `pypureclient` import checks to use the same name across all modules

##### ISSUE TYPE
- Refactor Pull Request

##### COMPONENT NAME
purefb_ad.py
purefb_admin.py
purefb_apiclient.py
purefb_certs.py
purefb_dns.py
purefb_ds.py
purefb_dsrole.py
purefb_fleet.py
purefb_fs_replica.py
purefb_groupquota.py
purefb_hardware.py
purefb_keytabs.py
purefb_kmip.py
purefb_lag.py
purefb_network.py
purefb_ntp.py
purefb_phonehome.py
purefb_remote_cred.py
purefb_s3acc.py
purefb_saml.py
purefb_snmp_agent.py
purefb_snmp_mgr.py
purefb_subnet.py
purefb_syslog.py
purefb_timeout.py
purefb_tz.py
purefb_user.py