### PR TITLE
Rebrand Pure Storage to Everpure in module documentation

### DIFF
--- a/plugins/modules/purefb_ad.py
+++ b/plugins/modules/purefb_ad.py
@@ -24,7 +24,7 @@ description:
 - FlashBlade allows the creation of one AD computer account, or joining of an
   existing AD computer account.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_admin.py
+++ b/plugins/modules/purefb_admin.py
@@ -18,11 +18,11 @@ DOCUMENTATION = r"""
 ---
 module: purefb_admin
 version_added: '1.8.0'
-short_description: Configure Pure Storage FlashBlade Global Admin settings
+short_description: Configure Everpure FlashBlade Global Admin settings
 description:
 - Set global admin settings for the FlashBlade
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   max_login:
     description:

--- a/plugins/modules/purefb_alert.py
+++ b/plugins/modules/purefb_alert.py
@@ -18,13 +18,13 @@ DOCUMENTATION = r"""
 ---
 module: purefb_alert
 version_added: '1.0.0'
-short_description: Configure Pure Storage FlashBlade alert email settings
+short_description: Configure Everpure FlashBlade alert email settings
 description:
-- Configure alert email configuration for Pure Storage FlashArrays.
+- Configure alert email configuration for Everpure FlashArrays.
 - Add or delete an individual syslog server to the existing
   list of serves.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     type: str

--- a/plugins/modules/purefb_apiclient.py
+++ b/plugins/modules/purefb_apiclient.py
@@ -22,7 +22,7 @@ short_description: Manage FlashBlade API Clients
 description:
 - Enable or disable FlashBlade API Clients
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_banner.py
+++ b/plugins/modules/purefb_banner.py
@@ -18,13 +18,13 @@ DOCUMENTATION = r"""
 ---
 module: purefb_banner
 version_added: '1.4.0'
-short_description: Configure Pure Storage FlashBlade GUI and SSH MOTD message
+short_description: Configure Everpure FlashBlade GUI and SSH MOTD message
 description:
-- Configure MOTD for Pure Storage FlashBlades.
+- Configure MOTD for Everpure FlashBlades.
 - This will be shown during an SSH or GUI login to the system.
 - Multiple line messages can be achieved using \\n.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_bladename.py
+++ b/plugins/modules/purefb_bladename.py
@@ -18,12 +18,12 @@ DOCUMENTATION = r"""
 ---
 module: purefb_bladename
 version_added: '1.0.0'
-short_description: Configure Pure Storage FlashBlade name
+short_description: Configure Everpure FlashBlade name
 description:
-- Configure name of Pure Storage FlashBlades.
+- Configure name of Everpure FlashBlades.
 - Ideal for Day 0 initial configuration.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_bucket.py
+++ b/plugins/modules/purefb_bucket.py
@@ -20,10 +20,10 @@ DOCUMENTATION = """
 ---
 module: purefb_bucket
 version_added: "1.0.0"
-short_description:  Manage Object Store Buckets on a  Pure Storage FlashBlade.
+short_description:  Manage Object Store Buckets on a  Everpure FlashBlade.
 description:
-    - This module managess object store (s3) buckets on Pure Storage FlashBlade.
-author: Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+    - This module managess object store (s3) buckets on Everpure FlashBlade.
+author: Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_bucket_access.py
+++ b/plugins/modules/purefb_bucket_access.py
@@ -24,7 +24,7 @@ description:
 - This modules allows the management of both bucket access and cross-origin
   resource sharing policies and their associated rules.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_bucket_replica.py
+++ b/plugins/modules/purefb_bucket_replica.py
@@ -20,10 +20,10 @@ DOCUMENTATION = """
 ---
 module: purefb_bucket_replica
 version_added: '1.0.0'
-short_description:  Manage bucket replica links between Pure Storage FlashBlades
+short_description:  Manage bucket replica links between Everpure FlashBlades
 description:
-    - This module manages bucket replica links between Pure Storage FlashBlades.
-author: Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+    - This module manages bucket replica links between Everpure FlashBlades.
+author: Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_certgrp.py
+++ b/plugins/modules/purefb_certgrp.py
@@ -22,7 +22,7 @@ short_description: Manage FlashBlade Certifcate Groups
 description:
 - Manage certifcate groups for FlashBlades
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -22,7 +22,7 @@ short_description: Manage FlashBlade SSL Certificates
 description:
 - Create, delete, import and export FlashBlade SSL Certificates
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_connect.py
+++ b/plugins/modules/purefb_connect.py
@@ -22,7 +22,7 @@ short_description: Manage replication connections between two FlashBlades
 description:
 - Manage replication connections to specified remote FlashBlade system
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_dns.py
+++ b/plugins/modules/purefb_dns.py
@@ -23,7 +23,7 @@ description:
 - Set or erase configuration for the DNS settings.
 - Nameservers provided will overwrite any existing nameservers.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_ds.py
+++ b/plugins/modules/purefb_ds.py
@@ -27,7 +27,7 @@ description:
   will always cause a change, even if the password given isn't different from
   the current. This makes this part of the module non-idempotent..
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_dsrole.py
+++ b/plugins/modules/purefb_dsrole.py
@@ -22,7 +22,7 @@ short_description: Configure FlashBlade  Management Directory Service Roles
 description:
 - Set or erase directory services role configurations.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_eula.py
+++ b/plugins/modules/purefb_eula.py
@@ -18,11 +18,11 @@ DOCUMENTATION = r"""
 ---
 module: purefb_eula
 version_added: '1.6.0'
-short_description: Sign Pure Storage FlashBlade EULA
+short_description: Sign Everpure FlashBlade EULA
 description:
 - Sign the FlashBlade EULA for Day 0 config, or change signatory.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   company:
     description:

--- a/plugins/modules/purefb_export.py
+++ b/plugins/modules/purefb_export.py
@@ -20,10 +20,10 @@ DOCUMENTATION = """
 ---
 module: purefb_export
 version_added: "1.25.0"
-short_description:  Manage filesystem exports on Pure Storage FlashBlade`
+short_description:  Manage filesystem exports on Everpure FlashBlade`
 description:
-    - This module manages filesystem exports on Pure Storage FlashBlade.
-author: Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+    - This module manages filesystem exports on Everpure FlashBlade.
+author: Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_fleet.py
+++ b/plugins/modules/purefb_fleet.py
@@ -22,7 +22,7 @@ short_description: Manage Fusion Fleet
 description:
 - Create/Modify/Delete Fusion fleet and members
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_fs.py
+++ b/plugins/modules/purefb_fs.py
@@ -20,10 +20,10 @@ DOCUMENTATION = """
 ---
 module: purefb_fs
 version_added: "1.0.0"
-short_description:  Manage filesystemon Pure Storage FlashBlade`
+short_description:  Manage filesystemon Everpure FlashBlade`
 description:
-    - This module manages filesystems on Pure Storage FlashBlade.
-author: Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+    - This module manages filesystems on Everpure FlashBlade.
+author: Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_fs_replica.py
+++ b/plugins/modules/purefb_fs_replica.py
@@ -20,10 +20,10 @@ DOCUMENTATION = """
 ---
 module: purefb_fs_replica
 version_added: '1.0.0'
-short_description:  Manage filesystem replica links between Pure Storage FlashBlades
+short_description:  Manage filesystem replica links between Everpure FlashBlades
 description:
-    - This module manages filesystem replica links between Pure Storage FlashBlades.
-author: Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+    - This module manages filesystem replica links between Everpure FlashBlades.
+author: Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_groupquota.py
+++ b/plugins/modules/purefb_groupquota.py
@@ -22,8 +22,8 @@ module: purefb_groupquota
 version_added: "1.7.0"
 short_description:  Manage filesystem group quotas
 description:
-    - This module manages group quotas for filesystems on Pure Storage FlashBlade.
-author: Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+    - This module manages group quotas for filesystems on Everpure FlashBlade.
+author: Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_hardware.py
+++ b/plugins/modules/purefb_hardware.py
@@ -22,7 +22,7 @@ short_description: Manage FlashBlade Hardware
 description:
 - Enable or disable FlashBlade visual identification lights and set connector parameters
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -19,15 +19,15 @@ DOCUMENTATION = r"""
 ---
 module: purefb_info
 version_added: '1.0.0'
-short_description: Collect information from Pure Storage FlashBlade
+short_description: Collect information from Everpure FlashBlade
 description:
-  - Collect information from a Pure Storage FlashBlade running the
+  - Collect information from a Everpure FlashBlade running the
     Purity//FB operating system. By default, the module will collect basic
     information including hosts, host groups, protection
     groups and volume counts. Additional information can be collected
     based on the configured set of arguements.
 author:
-  - Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+  - Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   gather_subset:
     description:

--- a/plugins/modules/purefb_inventory.py
+++ b/plugins/modules/purefb_inventory.py
@@ -18,15 +18,15 @@ DOCUMENTATION = r"""
 ---
 module: purefb_inventory
 version_added: '1.0.0'
-short_description: Collect information from Pure Storage FlashBlade
+short_description: Collect information from Everpure FlashBlade
 description:
-  - Collect information from a Pure Storage FlashBlade running the
+  - Collect information from a Everpure FlashBlade running the
     Purity//FB operating system. By default, the module will collect basic
     information including hosts, host groups, protection
     groups and volume counts. Additional information can be collected
     based on the configured set of arguements.
 author:
-  - Pure Storage ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+  - Everpure ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 extends_documentation_fragment:
   - purestorage.flashblade.purestorage.fb
 """

--- a/plugins/modules/purefb_keytabs.py
+++ b/plugins/modules/purefb_keytabs.py
@@ -16,7 +16,7 @@ short_description: Manage FlashBlade Kerberos Keytabs
 description:
 - Manage Kerberos Keytabs for FlashBlades
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_kmip.py
+++ b/plugins/modules/purefb_kmip.py
@@ -22,7 +22,7 @@ short_description: Manage FlashBlade KMIP server objects
 description:
 - Manage FlashBlade KMIP Server objects
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_lag.py
+++ b/plugins/modules/purefb_lag.py
@@ -22,7 +22,7 @@ short_description: Manage FlashBlade Link Aggregation Groups
 description:
 - Maintain FlashBlade Link Aggregation Groups
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_lifecycle.py
+++ b/plugins/modules/purefb_lifecycle.py
@@ -22,7 +22,7 @@ short_description: Manage FlashBlade object lifecycles
 description:
 - Manage lifecycles for object buckets
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_messages.py
+++ b/plugins/modules/purefb_messages.py
@@ -22,7 +22,7 @@ short_description: List FlashBlade Alert Messages
 description:
 - List Alert messages based on filters provided
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   severity:
     description:

--- a/plugins/modules/purefb_network.py
+++ b/plugins/modules/purefb_network.py
@@ -20,13 +20,13 @@ DOCUMENTATION = """
 ---
 module: purefb_network
 version_added: "1.0.0"
-short_description:  Manage network interfaces in a Pure Storage FlashBlade
+short_description:  Manage network interfaces in a Everpure FlashBlade
 description:
-    - This module manages network interfaces on Pure Storage FlashBlade.
+    - This module manages network interfaces on Everpure FlashBlade.
     - When creating a network interface a subnet must already exist with
       a network prefix that covers the IP address of the interface being
       created.
-author: Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+author: Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_ntp.py
+++ b/plugins/modules/purefb_ntp.py
@@ -18,11 +18,11 @@ DOCUMENTATION = r"""
 ---
 module: purefb_ntp
 version_added: '1.0.0'
-short_description: Configure Pure Storage FlashBlade NTP settings
+short_description: Configure Everpure FlashBlade NTP settings
 description:
-- Set or erase NTP configuration for Pure Storage FlashBlades.
+- Set or erase NTP configuration for Everpure FlashBlades.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_phonehome.py
+++ b/plugins/modules/purefb_phonehome.py
@@ -18,11 +18,11 @@ DOCUMENTATION = r"""
 ---
 module: purefb_phonehome
 version_added: '1.0.0'
-short_description: Enable or Disable Pure Storage FlashBlade Phone Home
+short_description: Enable or Disable Everpure FlashBlade Phone Home
 description:
-- Enablke or Disable Remote Phone Home for a Pure Storage FlashBlade.
+- Enablke or Disable Remote Phone Home for a Everpure FlashBlade.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_pingtrace.py
+++ b/plugins/modules/purefb_pingtrace.py
@@ -22,7 +22,7 @@ short_description: Employ the internal FlashBlade ping and trace mechanisms
 description:
 - Ping or trace a destination
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   action:
     description:

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -27,7 +27,7 @@ description:
   the first rule will be recovered as long replacement rule is added before
   the snapshot eradication period is exceeded (usuually 24 hours).
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:
@@ -382,7 +382,7 @@ options:
       - If set to I(locked) then values of the policy attributes are not allowed to change.
       - If set to I(locked) then values of the policy attributes can be changed.
       - Changing from I(unlocked) to I(locked) is allowed, but to change from I(locked) to I(unlocked)
-        will require support from Pure Storage Technical Services.
+        will require support from Everpure Technical Services.
     type: str
     choices: [ locked, unlocked ]
     version_added: '1.19.0'

--- a/plugins/modules/purefb_proxy.py
+++ b/plugins/modules/purefb_proxy.py
@@ -19,7 +19,7 @@ DOCUMENTATION = r"""
 module: purefb_proxy
 version_added: '1.0.0'
 author:
-  - Pure Storage ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+  - Everpure ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 short_description: Configure FlashBlade phonehome HTTPs proxy settings
 description:
 - Set or erase configuration for the phonehome proxy settings.

--- a/plugins/modules/purefb_ra.py
+++ b/plugins/modules/purefb_ra.py
@@ -18,11 +18,11 @@ DOCUMENTATION = r"""
 ---
 module: purefb_ra
 version_added: '1.0.0'
-short_description: Enable or Disable Pure Storage FlashBlade Remote Assist
+short_description: Enable or Disable Everpure FlashBlade Remote Assist
 description:
-- Enablke or Disable Remote Assist for a Pure Storage FlashBlade.
+- Enablke or Disable Remote Assist for a Everpure FlashBlade.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_remote_cred.py
+++ b/plugins/modules/purefb_remote_cred.py
@@ -24,7 +24,7 @@ description:
 - You must have a correctly configured remote array or target
 - This module is B(not) idempotent when updating existing remote credentials
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_s3acc.py
+++ b/plugins/modules/purefb_s3acc.py
@@ -22,7 +22,7 @@ short_description: Create or delete FlashBlade Object Store accounts
 description:
 - Create or delete object store accounts on a Pure Stoage FlashBlade.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_s3user.py
+++ b/plugins/modules/purefb_s3user.py
@@ -22,7 +22,7 @@ short_description: Create or delete FlashBlade Object Store account users
 description:
 - Create or delete object store account users on a Pure Stoage FlashBlade.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_saml.py
+++ b/plugins/modules/purefb_saml.py
@@ -22,7 +22,7 @@ short_description: Manage FlashBlade SAML2 service and identity providers
 description:
 - Enable or disable FlashBlade SAML2 providers
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_server.py
+++ b/plugins/modules/purefb_server.py
@@ -22,7 +22,7 @@ short_description: Manage FlashBlade servers
 description:
 - Add, update or delete FlashBlade servers
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_smtp.py
+++ b/plugins/modules/purefb_smtp.py
@@ -18,12 +18,12 @@ DOCUMENTATION = r"""
 ---
 module: purefb_smtp
 version_added: '1.0.0'
-short_description: Configure SMTP for Pure Storage FlashBlade
+short_description: Configure SMTP for Everpure FlashBlade
 description:
-- Configure SMTP for a Pure Storage FlashBlade.
+- Configure SMTP for a Everpure FlashBlade.
 - Whilst there can be no relay host, a sender domain must be configured.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   host:
     description:

--- a/plugins/modules/purefb_snap.py
+++ b/plugins/modules/purefb_snap.py
@@ -18,13 +18,13 @@ DOCUMENTATION = r"""
 ---
 module: purefb_snap
 version_added: '1.0.0'
-short_description: Manage filesystem snapshots on Pure Storage FlashBlades
+short_description: Manage filesystem snapshots on Everpure FlashBlades
 description:
-- Create or delete volumes and filesystem snapshots on Pure Storage FlashBlades.
+- Create or delete volumes and filesystem snapshots on Everpure FlashBlades.
 - Restoring a filesystem from a snapshot is only supported using
   the latest snapshot.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_snmp_agent.py
+++ b/plugins/modules/purefb_snmp_agent.py
@@ -20,12 +20,12 @@ module: purefb_snmp_agent
 version_added: '1.0.0'
 short_description: Configure the FlashBlade SNMP Agent
 description:
-- Configure the management SNMP Agent on a Pure Storage FlashBlade.
+- Configure the management SNMP Agent on a Everpure FlashBlade.
 - This module is not idempotent and will always modify the
   existing management SNMP agent due to hidden parameters that cannot
   be compared to the play parameters.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   auth_passphrase:
     type: str

--- a/plugins/modules/purefb_snmp_mgr.py
+++ b/plugins/modules/purefb_snmp_mgr.py
@@ -20,12 +20,12 @@ module: purefb_snmp_mgr
 version_added: '1.0.0'
 short_description: Configure FlashBlade SNMP Managers
 description:
-- Manage SNMP managers on a Pure Storage FlashBlade.
+- Manage SNMP managers on a Everpure FlashBlade.
 - This module is not idempotent and will always modify an
   existing SNMP manager due to hidden parameters that cannot
   be compared to the play parameters.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_subnet.py
+++ b/plugins/modules/purefb_subnet.py
@@ -20,10 +20,10 @@ DOCUMENTATION = """
 ---
 module: purefb_subnet
 version_added: "1.0.0"
-short_description:  Manage network subnets in a Pure Storage FlashBlade
+short_description:  Manage network subnets in a Everpure FlashBlade
 description:
-    - This module manages network subnets on Pure Storage FlashBlade.
-author: Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+    - This module manages network subnets on Everpure FlashBlade.
+author: Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_syslog.py
+++ b/plugins/modules/purefb_syslog.py
@@ -18,13 +18,13 @@ DOCUMENTATION = r"""
 ---
 module: purefb_syslog
 version_added: '1.4.0'
-short_description: Configure Pure Storage FlashBlade syslog settings
+short_description: Configure Everpure FlashBlade syslog settings
 description:
-- Configure syslog configuration for Pure Storage FlashBlades.
+- Configure syslog configuration for Everpure FlashBlades.
 - Add or delete an individual syslog server to the existing
   list of serves.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_target.py
+++ b/plugins/modules/purefb_target.py
@@ -24,7 +24,7 @@ description:
 - Use this for non-FlashBlade targets.
 - Use I(purestorage.flashblade.purefb_connect) for FlashBlade targets.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_timeout.py
+++ b/plugins/modules/purefb_timeout.py
@@ -18,12 +18,12 @@ DOCUMENTATION = r"""
 ---
 module: purefb_timeout
 version_added: '1.6.0'
-short_description: Configure Pure Storage FlashBlade GUI idle timeout
+short_description: Configure Everpure FlashBlade GUI idle timeout
 description:
-- Configure GUI idle timeout for Pure Storage FlashBlade.
+- Configure GUI idle timeout for Everpure FlashBlade.
 - This does not affect existing GUI sessions.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_tz.py
+++ b/plugins/modules/purefb_tz.py
@@ -18,11 +18,11 @@ DOCUMENTATION = r"""
 ---
 module: purefb_tz
 version_added: '1.10.0'
-short_description: Configure Pure Storage FlashBlade timezone
+short_description: Configure Everpure FlashBlade timezone
 description:
-- Configure the timezone for a Pure Storage FlashBlade.
+- Configure the timezone for a Everpure FlashBlade.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   timezone:
     description:

--- a/plugins/modules/purefb_user.py
+++ b/plugins/modules/purefb_user.py
@@ -22,7 +22,7 @@ short_description: Create, modify or delete FlashBlade user accounts
 description:
 - Modify user on a Pure Stoage FlashBlade.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   state:
     description:

--- a/plugins/modules/purefb_userpolicy.py
+++ b/plugins/modules/purefb_userpolicy.py
@@ -22,7 +22,7 @@ short_description: Manage FlashBlade Object Store User Access Policies
 description:
 - Add or Remove FlashBlade Object Store Access Policies for Account User
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_userquota.py
+++ b/plugins/modules/purefb_userquota.py
@@ -22,8 +22,8 @@ module: purefb_userquota
 version_added: "1.7.0"
 short_description:  Manage filesystem user quotas
 description:
-    - This module manages user hard quotas for filesystems on Pure Storage FlashBlade.
-author: Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+    - This module manages user hard quotas for filesystems on Everpure FlashBlade.
+author: Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:

--- a/plugins/modules/purefb_virtualhost.py
+++ b/plugins/modules/purefb_virtualhost.py
@@ -22,7 +22,7 @@ short_description: Manage FlashBlade Object Store Virtual Hosts
 description:
 - Add or delete FlashBlade Object Store Virtual Hosts
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
+- Everpure Ansible Team (@sdodsley) <pure-ansible-team@purestorage.com>
 options:
   name:
     description:


### PR DESCRIPTION
##### SUMMARY
- Updated all module DOCUMENTATION sections to replace Pure Storage with Everpure
- Changed author fields from "Pure Storage Ansible Team" to "Everpure Ansible Team"
- Updated short descriptions and module descriptions to use Everpure branding
- Affects 53 module files in plugins/modules/

##### ISSUE TYPE
- Docs Pull Request
