### PR TITLE
purefb_cert changes for 4.6.x

### DIFF
--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -134,7 +134,7 @@ options:
     - Generate a new private key.
     - If not selected, the certificate will use the existing key
     - Required when changing key-size or key-algorithm
-  subject_alternative_names
+  subject_alternative_names:
     type: array of str
     description:
     - The alternative names that are secured by this certificate.

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -32,9 +32,9 @@ options:
   state:
     description:
     - Action for the module to perform
-    - I(present) will create or import an SSL certificate including self-signed certificates
+    - I(present) will create or import an SSL certificate including self signed certificates
     - I(absent) will delete an existing SSL certificate
-    - I(sign) will construct a Certificate Signing request (CSR) from an existing (self-signed-)certificate
+    - I(sign) will construct a Certificate Signing request (CSR) from an existing (self signed) certificate
     - I(export) will export the exisitng SSL certificate
     - I(import) will import or create a provided certificate.
     default: present
@@ -42,7 +42,7 @@ options:
     type: str
   certificate_type:
     description:
-    - Type can be "array" for FlashBlade as server or "external" for FlashBlade as client (e.g. access to AD).
+    - Type can be I(array) for FlashBlade as server or I(external) for FlashBlade as client (e.g. access to AD).
     type: str
     choices: [ external, array ]
   certificate:
@@ -62,7 +62,7 @@ options:
     aliases: [ private_key ]
     type: str
     description:
-    - Certificates of type "array" must have a private key
+    - Certificates of type I(array) must have a private key
     - If the Certificate Signed Request (CSR) was not constructed on the system
       or the private key has changed since construction of the CSR, provide
       a new private key here

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -35,7 +35,7 @@ options:
     - I(present) will create or import an SSL certificate including self signed certificates
     - I(absent) will delete an existing SSL certificate
     - I(sign) will construct a Certificate Signing request (CSR) from an existing (self signed) certificate
-    - I(export) will export the exisitng SSL certificate
+    - I(export) will export the existing SSL certificate
     - I(import) will import or create a provided certificate.
     default: present
     choices: [ absent, present, import, export, sign ]
@@ -54,10 +54,10 @@ options:
     - Includes the "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----" lines
     - Does not exceed 3000 characters in length
   intermediate_cert:
-    aliases: [ intermeadiate_cert ]
+    aliases: [ intermediate_cert ]
     type: str
     description:
-    - Intermeadiate certificate provided by the CA
+    - Intermediate certificate provided by the CA
   key:
     aliases: [ private_key ]
     type: str
@@ -266,10 +266,9 @@ def update_cert(module, blade):
             )
             if res.status_code != 200:
                 module.fail_json(
-                    msg="Updating existing SSL certificate {0} failed. Error: {1} {2}".format(
+                    msg="Updating existing SSL certificate {0} failed. Error: {1}".format(
                         module.params["name"],
                         get_error_message(res),
-                        module.params["generate"],
                     )
                 )
     else:
@@ -353,7 +352,7 @@ def delete_cert(module, blade):
         res = blade.delete_certificates(names=[module.params["name"]])
         if res.status_code != 200:
             module.fail_json(
-                msg="Failed to delete {0} SSL certifcate. Error: {1}".format(
+                msg="Failed to delete {0} SSL certificate. Error: {1}".format(
                     module.params["name"], get_error_message(res)
                 )
             )
@@ -430,7 +429,7 @@ def main():
             key_size=dict(type="int", choices=[1024, 2048, 4096]),
             certificate=dict(type="str", no_log=True, aliases=["contents"]),
             intermediate_cert=dict(
-                type="str", no_log=True, aliases=["intermeadiate_cert"]
+                type="str", no_log=True, aliases=["intermediate_cert"]
             ),
             key=dict(type="str", no_log=True, aliases=["private_key"]),
             export_file=dict(type="str"),

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -42,7 +42,7 @@ options:
     type: str
   certificate_type:
     description:
-    - Type can be I(array) for FlashBlade as server or I(external) for FlashBlade as client (e.g. access to AD).
+    - Type can be I(array) for FlashBlade as server or I(external) for FlashBlade as client (eg access to AD).
     type: str
     choices: [ external, array ]
   certificate:

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -269,7 +269,9 @@ def update_cert(module, blade):
             if res.status_code != 200:
                 module.fail_json(
                     msg="Updating existing SSL certificate {0} failed. Error: {1} {2}".format(
-                        module.params["name"], get_error_message(res), module.params["generate"]
+                        module.params["name"],
+                        get_error_message(res),
+                        module.params["generate"],
                     )
                 )
     else:
@@ -358,7 +360,6 @@ def delete_cert(module, blade):
                 )
             )
     module.exit_json(changed=changed)
-
 
 
 def export_cert(module, blade):

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -193,7 +193,7 @@ EXAMPLES = r"""
     state: import
     name: foo
     certificate: "{{lookup('file', 'example.crt') }}"
-    key: "{{lookup('file', 'example.key') }}
+    key: "{{lookup('file', 'example.key') }}"
     fb_url: 10.10.10.2
     api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
 """

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -28,18 +28,56 @@ options:
     description:
     - Name of the SSL Certificate
     type: str
-    default: management
+    required
   state:
     description:
     - Action for the module to perform
-    - I(present) will create or re-create an SSL certificate
+    - I(present) will create or import an SSL certificate including self-signed certificates
     - I(absent) will delete an existing SSL certificate
-    - I(sign) will construct a Certificate Signing request (CSR)
+    - I(sign) will construct a Certificate Signing request (CSR) from an existing (self-signed-)certificate
     - I(export) will export the exisitng SSL certificate
-    - I(import) will import a CA provided certificate.
+    - I(import) will import or create a provided certificate.
     default: present
     choices: [ absent, present, import, export, sign ]
     type: str
+    required
+  certificate_type:
+    description: Type can be "array" for FlashBlade as server or "external" for FlashBlade as client (e.g. access to AD).
+    default: external
+    type: str
+  certificate:
+    aliases: [ contents ]
+    type: str
+    description:
+    - Required for I(import)
+    - A valid signed certicate in PEM format (Base64 encoded)
+    - Includes the "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----" lines
+    - Does not exceed 3000 characters in length
+  intermediate_cert:
+    aliases: [ intermeadiate_cert ]
+    type: str
+    description:
+    - Intermeadiate certificate provided by the CA
+  key:
+    aliases: [ private_key ]
+    type: str
+    description:
+    - Certificates of type "array" must have a private key
+    - If the Certificate Signed Request (CSR) was not constructed on the system
+      or the private key has changed since construction of the CSR, provide
+      a new private key here
+  passphrase:
+    type: str
+    description:
+    - Passphrase if the private key is encrypted
+  export_file:
+    type: str
+    description:
+    - Name of file to contain Certificate Signing Request when `status sign`
+    - Name of file to export the current SSL Certificate when `status export`
+    - File will be overwritten if it already exists
+  
+  The below parameters are for self-signed certificates or changing the CSR
   country:
     type: str
     description:
@@ -80,10 +118,13 @@ options:
     type: int
     description:
     - The key size in bits if you generate a new private key
-    default: 2048
     choices: [ 1024, 2048, 4096 ]
+  key_algorithm:
+    type: str
+    description:
+    - The key algorithm used to generate the certificate.
+    choices: [ rsa, ec, ed448, ed25519 ]
   days:
-    default: 3650
     type: int
     description:
     - The number of valid days for the self-signed certificate being generated
@@ -94,49 +135,20 @@ options:
     description:
     - Generate a new private key.
     - If not selected, the certificate will use the existing key
-  certificate:
-    aliases: [ contents ]
-    type: str
+    - Required when changing key-size or key-algorithm
+  subject_alternative_names
+    type: array of str
     description:
-    - Required for I(import)
-    - A valid signed certicate in PEM format (Base64 encoded)
-    - Includes the "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----" lines
-    - Does not exceed 3000 characters in length
-  intermediate_cert:
-    aliases: [ intermeadiate_cert ]
-    type: str
-    description:
-    - Intermeadiate certificate provided by the CA
-  key:
-    aliases: [ private_key ]
-    type: str
-    description:
-    - If the Certificate Signed Request (CSR) was not constructed on the system
-      or the private key has changed since construction the CSR, provide
-      a new private key here
-  passphrase:
-    type: str
-    description:
-    - Passphrase if the private key is encrypted
-  export_file:
-    type: str
-    description:
-    - Name of file to contain Certificate Signing Request when `status sign`
-    - Name of file to export the current SSL Certificate when `status export`
-    - File will be overwritten if it already exists
-  key_algorithm:
-    type: str
-    description:
-    - The key algorithm used to generate the certificate.
-    - This field can only be specified when creating a new self-signed certificate
-    choices: [ rsa, ec, ed448, ed25519 ]
+    - The alternative names that are secured by this certificate.
+        Alternative names may be IP addresses, DNS names, or URIs.
+        
     version_added: "1.22.0"
 extends_documentation_fragment:
 - purestorage.flashblade.purestorage.fb
 """
 
 EXAMPLES = r"""
-- name: Create SSL certifcate foo
+- name: Create self-signed SSL certifcate foo
   purestorage.flashblade.purefb_certs:
     name: foo
     key_size: 4096
@@ -157,18 +169,22 @@ EXAMPLES = r"""
 
 - name: Request CSR
   purestorage.flashblade.purefb_certs:
+    name: foo
     state: sign
+    export_file: <filepath>
     fb_url: 10.10.10.2
     api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
 
 - name: Request CSR with updated fields
   purestorage.flashblade.purefb_certs:
+    name: foo
     state: sign
+    export_file: <filepath>
     org_unit: Development
     fb_url: 10.10.10.2
     api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
 
-- name: Regenerate key for SSL foo
+- name: Regenerate key for self-signed SSL foo
   purestorage.flashblade.purefb_certs:
     generate: true
     name: foo
@@ -180,6 +196,7 @@ EXAMPLES = r"""
     state: import
     name: foo
     certificate: "{{lookup('file', 'example.crt') }}"
+    key: "{{lookup('file', 'example.key') }}
     fb_url: 10.10.10.2
     api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
 """
@@ -222,104 +239,39 @@ CSR_API_VERSION = "2.20"
 def update_cert(module, blade):
     """Update existing SSL Certificate"""
     api_versions = list(blade.get_versions().items)
-    changed = False
+
     if CSR_API_VERSION in api_versions:
-        current_cert = list(
-            blade.get_certificates(names=[module.params["name"]]).items
-        )[0]
-        new_cert = current_cert.copy()
-        if module.params["certificate"] and module.params["certificate"] != getattr(
-            current_cert, "certificate", None
-        ):
-            new_cert.certificate = module.params["certificate"]
-        else:
-            new_cert.certificate = getattr(current_cert, "certificate", None)
-        if module.params["intermediate_cert"] and module.params[
-            "intermediate_cert"
-        ] != getattr(current_cert, "intermediate_certificate", None):
-            new_cert.intermediate_certificate = module.params["intermediate_cert"]
-        else:
-            new_cert.intermediate_certificate = getattr(
-                current_cert, "intermediate_certificate", None
+        changed = True
+        certificate = CertificatePatch(
+            certificate=module.params["certificate"],
+            intermediate_certificate=module.params["intermediate_cert"],
+            private_key=module.params["key"],
+            passphrase=module.params["passphrase"],
+            common_name=module.params["common_name"],
+            country=module.params["country"],
+            email=module.params["email"],
+            key_size=module.params["key_size"],
+            locality=module.params["locality"],
+            organization=module.params["organization"],
+            organizational_unit=module.params["org_unit"],
+            state=module.params["province"],
+            days=module.params["days"],
+            subject_alternative_names=module.params["subject_alternative_names"],
+    )            
+        if not module.check_mode:
+            if module.params["generate"]:
+                generate="True"
+            res = blade.patch_certificates(
+                names=[module.params["name"]],
+                generate_new_key=generate,
+                certificate=certificate,
             )
-        if module.params["common_name"] and module.params["common_name"] != getattr(
-            current_cert, "common_name", None
-        ):
-            new_cert.common_name = module.params["common_name"]
-        else:
-            new_cert.common_name = getattr(current_cert, "common_name", None)
-        if module.params["country"] and module.params["country"] != getattr(
-            current_cert, "country", None
-        ):
-            new_cert.country = module.params["country"]
-        else:
-            new_cert.country = getattr(current_cert, "country")
-        if module.params["email"] and module.params["email"] != getattr(
-            current_cert, "email", None
-        ):
-            new_cert.email = module.params["email"]
-        else:
-            new_cert.email = getattr(current_cert, "email", None)
-        if module.params["key_size"] and module.params["key_size"] != getattr(
-            current_cert, "key_size", None
-        ):
-            new_cert.key_size = module.params["key_size"]
-        else:
-            new_cert.key_size = getattr(current_cert, "key_size", None)
-        if module.params["locality"] and module.params["locality"] != getattr(
-            current_cert, "locality", None
-        ):
-            new_cert.locality = module.params["locality"]
-        else:
-            new_cert.locality = getattr(current_cert, "locality", None)
-        if module.params["province"] and module.params["province"] != getattr(
-            current_cert, "state", None
-        ):
-            new_cert.state = module.params["province"]
-        else:
-            new_cert.state = getattr(current_cert, "state", None)
-        if module.params["organization"] and module.params["organization"] != getattr(
-            current_cert, "organization", None
-        ):
-            new_cert.organization = module.params["organization"]
-        else:
-            new_cert.organization = getattr(current_cert, "organization", None)
-        if module.params["org_unit"] and module.params["org_unit"] != getattr(
-            current_cert, "organizational_unit", None
-        ):
-            new_cert.organizational_unit = module.params["org_unit"]
-        else:
-            new_cert.organizational_unit = getattr(
-                current_cert, "organizational_unit", None
-            )
-        if module.params["key_algorithm"] and module.params["key_algorithm"] != getattr(
-            current_cert, "key_algorithm", None
-        ):
-            new_cert.key_algorithm = module.params["key_algorithm"]
-        else:
-            new_cert.key_algorithm = getattr(current_cert, "key_algorithm", None)
-        if new_cert != current_cert:
-            changed = True
-            certificate = CertificatePatch(
-                certificate=new_cert.certificate,
-                intermediate_certificate=getattr(
-                    new_cert, "intermediate_certificate", None
-                ),
-                private_key=module.params["key"],
-                passphrase=module.params["passphrase"],
-            )
-            if not module.check_mode:
-                res = blade.patch_certificates(
-                    names=[module.params["name"]],
-                    certificate=certificate,
-                    generate_new_key=module.params["generate"],
-                )
-                if res.status_code != 200:
-                    module.fail_json(
-                        msg="Updating existing SSL certificate {0} failed. Error: {1}".format(
-                            module.params["name"], get_error_message(res)
-                        )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Updating existing SSL certificate {0} failed. Error: {1} {2}".format(
+                        module.params["name"], get_error_message(res), module.params["generate"]
                     )
+                )
     else:
         changed = True
         certificate = CertificatePatch(
@@ -328,26 +280,29 @@ def update_cert(module, blade):
             private_key=module.params["key"],
             passphrase=module.params["passphrase"],
         )
-        res = blade.patch_certificates(
-            names=[module.params["name"]], certificate=certificate
-        )
-        if res.status_code != 200:
-            module.fail_json(
-                msg="Updating existing SSL certificate {0} failed. Error: {1}".format(
-                    module.params["name"], get_error_message(res)
-                )
+    res = blade.patch_certificates(
+        names=[module.params["name"]], certificate=certificate
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg="Updating existing SSL certificate {0} failed. Error: {1}".format(
+                module.params["name"], get_error_message(res)
             )
+        )
     module.exit_json(changed=changed)
 
 
 def create_cert(module, blade):
+    # let the rest-api itself deal with errors
     changed = True
     api_versions = list(blade.get_versions().items)
-    if CERT_TYPE_VERSION in api_versions:
+    if CSR_API_VERSION in api_versions:
         certificate = CertificatePost(
+            certificate_type=module.params["certificate_type"],
             certificate=module.params["certificate"],
             intermediate_certificate=module.params["intermediate_cert"],
-            certificate_type="appliance",
+            private_key=module.params["key"],
+            passphrase=module.params["passphrase"],
             common_name=module.params["common_name"],
             country=module.params["country"],
             email=module.params["email"],
@@ -356,25 +311,26 @@ def create_cert(module, blade):
             organization=module.params["organization"],
             organizational_unit=module.params["org_unit"],
             state=module.params["province"],
-            status="self-signed",
             days=module.params["days"],
+            subject_alternative_names=module.params["subject_alternative_names"],
         )
     else:
-        certificate = CertificatePost(
-            certificate=module.params["certificate"],
-            intermediate_certificate=module.params["intermediate_cert"],
-            certificate_type="appliance",
-            common_name=module.params["common_name"],
-            country=module.params["country"],
-            email=module.params["email"],
-            key_size=module.params["key_size"],
-            locality=module.params["locality"],
-            organization=module.params["organization"],
-            organizational_unit=module.params["org_unit"],
-            state=module.params["province"],
-            status="self-signed",
-            days=module.params["days"],
-        )
+        if CERT_TYPE_VERSION in api_versions:
+            certificate = CertificatePost(
+                certificate_type=module.params["certificate_type"],
+                certificate=module.params["certificate"],
+                intermediate_certificate=module.params["intermediate_cert"],
+                private_key=module.params["key"],
+                passphrase=module.params["passphrase"],
+            )
+        else:
+            certificate = CertificatePost(
+                certificate=module.params["certificate"],
+                intermediate_certificate=module.params["intermediate_cert"],
+                private_key=module.params["key"],
+                passphrase=module.params["passphrase"],
+            )
+                    
     if not module.check_mode:
         res = blade.post_certificates(
             names=[module.params["name"]], certificate=certificate
@@ -391,8 +347,8 @@ def create_cert(module, blade):
 
 def delete_cert(module, blade):
     changed = True
-    if module.params["name"] == "management":
-        module.fail_json(msg="management SSL cannot be deleted")
+    if module.params["name"] == "global":
+        module.fail_json(msg="Global certificate cannot be deleted")
     if not module.check_mode:
         res = blade.delete_certificates(names=[module.params["name"]])
         if res.status_code != 200:
@@ -403,35 +359,6 @@ def delete_cert(module, blade):
             )
     module.exit_json(changed=changed)
 
-
-def import_cert(module, blade):
-    """Import a CA provided SSL certificate"""
-    changed = True
-    if not module.check_mode:
-        if CERT_TYPE_VERSION in list(blade.get_versions().items):
-            certificate = CertificatePost(
-                certificate_type="external",
-                certificate=module.params["certificate"],
-                status="imported",
-            )
-        else:
-            certificate = CertificatePost(
-                certificate=module.params["certificate"],
-                intermediate_certificate=module.params["intermediate_cert"],
-                key_size=module.params["key_size"],
-                passphrase=module.params["passphrase"],
-                status="imported",
-            )
-        res = blade.post_certificates(
-            names=[module.params["name"]], certificate=certificate
-        )
-        if res.status_code != 200:
-            module.fail_json(
-                msg="Importing Certificate failed. Error: {0}".format(
-                    get_error_message(res)
-                )
-            )
-    module.exit_json(changed=changed)
 
 
 def export_cert(module, blade):
@@ -456,48 +383,17 @@ def create_csr(module, blade):
     Output the result to a specified file
     """
     changed = True
-    current_attr = Certificate()
-    res = blade.get_certificates(names=[module.params["name"]])
-    if res.status_code == 200:
-        current_attr = list(res.items)[0]
-    if module.params["common_name"] and module.params["common_name"] != getattr(
-        current_attr, "common_name", None
-    ):
-        current_attr.common_name = module.params["common_name"]
-    if module.params["country"] and module.params["country"] != getattr(
-        current_attr, "country", None
-    ):
-        current_attr.country = module.params["country"]
-    if module.params["email"] and module.params["email"] != getattr(
-        current_attr, "email", None
-    ):
-        current_attr.email = module.params["email"]
-    if module.params["locality"] and module.params["locality"] != getattr(
-        current_attr, "locality", None
-    ):
-        current_attr.locality = module.params["locality"]
-    if module.params["province"] and module.params["province"] != getattr(
-        current_attr, "state", None
-    ):
-        current_attr.state = module.params["province"]
-    if module.params["organization"] and module.params["organization"] != getattr(
-        current_attr, "organization", None
-    ):
-        current_attr.organization = module.params["organization"]
-    if module.params["org_unit"] and module.params["org_unit"] != getattr(
-        current_attr, "organizational_unit", None
-    ):
-        current_attr.organizational_unit = module.params["org_unit"]
     if not module.check_mode:
         certificate = CertificateSigningRequestPost(
             certificate=Reference(name=module.params["name"]),
-            common_name=getattr(current_attr, "common_name", None),
-            country=getattr(current_attr, "country", None),
-            email=getattr(current_attr, "email", None),
-            locality=getattr(current_attr, "locality", None),
-            state=getattr(current_attr, "state", None),
-            organization=getattr(current_attr, "organization", None),
-            organizational_unit=getattr(current_attr, "organizational_unit", None),
+            common_name=module.params["common_name"],
+            country=module.params["country"],
+            email=module.params["email"],
+            locality=module.params["locality"],
+            organization=module.params["organization"],
+            organizational_unit=module.params["org_unit"],
+            state=module.params["province"],            
+            subject_alternative_names=module.params["subject_alternative_names"],
         )
         csr = list(
             blade.post_certificates_certificate_signing_requests(
@@ -510,6 +406,9 @@ def create_csr(module, blade):
 
 
 def main():
+    # Do not set defaults, if you do you will have to craft each call to make sure you are not trying to write values that are read-only given the other parameters
+    # Exceptions: state, you must want to do some action
+    #
     argument_spec = purefb_argument_spec()
     argument_spec.update(
         dict(
@@ -518,8 +417,9 @@ def main():
                 default="present",
                 choices=["absent", "present", "import", "export", "sign"],
             ),
-            generate=dict(type="bool", default=False),
-            name=dict(type="str", default="management"),
+            generate=dict(type="bool"),
+            name=dict(type="str"),
+            certificate_type=dict(type="str", choices=["external", "array"]),
             country=dict(type="str"),
             province=dict(type="str"),
             locality=dict(type="str"),
@@ -527,7 +427,7 @@ def main():
             org_unit=dict(type="str"),
             common_name=dict(type="str"),
             email=dict(type="str"),
-            key_size=dict(type="int", default=2048, choices=[1024, 2048, 4096]),
+            key_size=dict(type="int", choices=[1024, 2048, 4096]),
             certificate=dict(type="str", no_log=True, aliases=["contents"]),
             intermediate_cert=dict(
                 type="str", no_log=True, aliases=["intermeadiate_cert"]
@@ -535,8 +435,9 @@ def main():
             key=dict(type="str", no_log=True, aliases=["private_key"]),
             export_file=dict(type="str"),
             passphrase=dict(type="str", no_log=True),
-            days=dict(type="int", default=3650),
+            days=dict(type="int"),
             key_algorithm=dict(type="str", choices=["rsa", "ec", "ed448", "ed25519"]),
+            subject_alternative_names=dict(type="str"),
         )
     )
 
@@ -578,11 +479,16 @@ def main():
                     module.params["country"].upper()
                 )
             )
+            
+            
+    if not module.params["certificate_type"]:
+        if ( module.params["key"] or not module.params["certificate"] ):
+            module.params["certificate_type"] = "array"
+    else:
+        module.params["certificate_type"] = "external"
+            
     state = module.params["state"]
-    if state in ["present"]:
-        if not module.params["common_name"]:
-            module.params["common_name"] = list(blade.get_arrays().items)[0].name
-        module.params["common_name"] = module.params["common_name"][:64]
+    certificate_type = module.params["certificate_type"]
 
     exists = bool(
         blade.get_certificates(names=[module.params["name"]]).status_code == 200
@@ -597,9 +503,11 @@ def main():
             module.fail_json(msg="Purity//FB 4.6.3+ is required for CSRs")
         create_csr(module, blade)
     elif not exists and state == "import":
-        import_cert(module, blade)
-    elif exists and state == "import":
+        create_cert(module, blade)
+    elif exists and state == "import" and certificate_type == "external":
         module.fail_json(msg="External Certificates cannot be reimported")
+    elif exists and state == "import":
+        update_cert(module,blade)
     elif state == "export":
         export_cert(module, blade)
     elif exists and state == "absent":

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -135,10 +135,11 @@ options:
     - If not selected, the certificate will use the existing key
     - Required when changing key-size or key-algorithm
   subject_alternative_names:
-    type: array of str
+    type: list
+    elements: str
     description:
     - The alternative names that are secured by this certificate.
-        Alternative names may be IP addresses, DNS names, or URIs.
+    - Alternative names may be IP addresses, DNS names, or URIs.
     version_added: "1.22.0"
 extends_documentation_fragment:
 - purestorage.flashblade.purestorage.fb
@@ -416,7 +417,7 @@ def main():
                 default="present",
                 choices=["absent", "present", "import", "export", "sign"],
             ),
-            generate=dict(type="bool"),
+            generate=dict(type="bool", default=False),
             name=dict(type="str", required=True),
             certificate_type=dict(type="str", choices=["external", "array"]),
             country=dict(type="str"),
@@ -436,7 +437,7 @@ def main():
             passphrase=dict(type="str", no_log=True),
             days=dict(type="int"),
             key_algorithm=dict(type="str", choices=["rsa", "ec", "ed448", "ed25519"]),
-            subject_alternative_names=dict(type="str"),
+            subject_alternative_names=dict(type="list", elements="str"),
         )
     )
 

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -28,7 +28,7 @@ options:
     description:
     - Name of the SSL Certificate
     type: str
-    required
+    required: true
   state:
     description:
     - Action for the module to perform
@@ -40,11 +40,11 @@ options:
     default: present
     choices: [ absent, present, import, export, sign ]
     type: str
-    required
   certificate_type:
-    description: Type can be "array" for FlashBlade as server or "external" for FlashBlade as client (e.g. access to AD).
-    default: external
+    description:
+    - Type can be "array" for FlashBlade as server or "external" for FlashBlade as client (e.g. access to AD).
     type: str
+    choices: [ external, array ]
   certificate:
     aliases: [ contents ]
     type: str
@@ -76,7 +76,7 @@ options:
     - Name of file to contain Certificate Signing Request when `status sign`
     - Name of file to export the current SSL Certificate when `status export`
     - File will be overwritten if it already exists
-  
+
   The below parameters are for self-signed certificates or changing the CSR
   country:
     type: str
@@ -141,7 +141,7 @@ options:
     description:
     - The alternative names that are secured by this certificate.
         Alternative names may be IP addresses, DNS names, or URIs.
-        
+
     version_added: "1.22.0"
 extends_documentation_fragment:
 - purestorage.flashblade.purestorage.fb
@@ -210,7 +210,6 @@ try:
         CertificatePost,
         CertificateSigningRequestPost,
         Reference,
-        Certificate,
         CertificatePatch,
     )
 except ImportError:
@@ -257,10 +256,11 @@ def update_cert(module, blade):
             state=module.params["province"],
             days=module.params["days"],
             subject_alternative_names=module.params["subject_alternative_names"],
-    )            
+        )
         if not module.check_mode:
+            generate = None
             if module.params["generate"]:
-                generate="True"
+                generate = "True"
             res = blade.patch_certificates(
                 names=[module.params["name"]],
                 generate_new_key=generate,
@@ -330,7 +330,7 @@ def create_cert(module, blade):
                 private_key=module.params["key"],
                 passphrase=module.params["passphrase"],
             )
-                    
+
     if not module.check_mode:
         res = blade.post_certificates(
             names=[module.params["name"]], certificate=certificate
@@ -392,7 +392,7 @@ def create_csr(module, blade):
             locality=module.params["locality"],
             organization=module.params["organization"],
             organizational_unit=module.params["org_unit"],
-            state=module.params["province"],            
+            state=module.params["province"],
             subject_alternative_names=module.params["subject_alternative_names"],
         )
         csr = list(
@@ -406,7 +406,8 @@ def create_csr(module, blade):
 
 
 def main():
-    # Do not set defaults, if you do you will have to craft each call to make sure you are not trying to write values that are read-only given the other parameters
+    # Do not set defaults, if you do you will have to craft each call to make sure
+    # you are not trying to write values that are read-only given the other parameters
     # Exceptions: state, you must want to do some action
     #
     argument_spec = purefb_argument_spec()
@@ -479,14 +480,13 @@ def main():
                     module.params["country"].upper()
                 )
             )
-            
-            
+
     if not module.params["certificate_type"]:
-        if ( module.params["key"] or not module.params["certificate"] ):
+        if module.params["key"] or not module.params["certificate"]:
             module.params["certificate_type"] = "array"
-    else:
-        module.params["certificate_type"] = "external"
-            
+        else:
+            module.params["certificate_type"] = "external"
+
     state = module.params["state"]
     certificate_type = module.params["certificate_type"]
 
@@ -507,7 +507,7 @@ def main():
     elif exists and state == "import" and certificate_type == "external":
         module.fail_json(msg="External Certificates cannot be reimported")
     elif exists and state == "import":
-        update_cert(module,blade)
+        update_cert(module, blade)
     elif state == "export":
         export_cert(module, blade)
     elif exists and state == "absent":

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -54,10 +54,10 @@ options:
     - Includes the "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----" lines
     - Does not exceed 3000 characters in length
   intermediate_cert:
-    aliases: [ intermediate_cert ]
+    aliases: [ intermeadiate_cert ]
     type: str
     description:
-    - Intermediate certificate provided by the CA
+    - Intermeadiate certificate provided by the CA
   key:
     aliases: [ private_key ]
     type: str
@@ -429,7 +429,7 @@ def main():
             key_size=dict(type="int", choices=[1024, 2048, 4096]),
             certificate=dict(type="str", no_log=True, aliases=["contents"]),
             intermediate_cert=dict(
-                type="str", no_log=True, aliases=["intermediate_cert"]
+                type="str", no_log=True, aliases=["intermeadiate_cert"]
             ),
             key=dict(type="str", no_log=True, aliases=["private_key"]),
             export_file=dict(type="str"),

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -76,7 +76,6 @@ options:
     - Name of file to contain Certificate Signing Request when `status sign`
     - Name of file to export the current SSL Certificate when `status export`
     - File will be overwritten if it already exists
-  # The below parameters are for self-signed certificates or changing the CSR
   country:
     type: str
     description:

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -76,8 +76,7 @@ options:
     - Name of file to contain Certificate Signing Request when `status sign`
     - Name of file to export the current SSL Certificate when `status export`
     - File will be overwritten if it already exists
-
-  The below parameters are for self-signed certificates or changing the CSR
+  # The below parameters are for self-signed certificates or changing the CSR
   country:
     type: str
     description:
@@ -141,7 +140,6 @@ options:
     description:
     - The alternative names that are secured by this certificate.
         Alternative names may be IP addresses, DNS names, or URIs.
-
     version_added: "1.22.0"
 extends_documentation_fragment:
 - purestorage.flashblade.purestorage.fb
@@ -420,7 +418,7 @@ def main():
                 choices=["absent", "present", "import", "export", "sign"],
             ),
             generate=dict(type="bool"),
-            name=dict(type="str"),
+            name=dict(type="str", required=True),
             certificate_type=dict(type="str", choices=["external", "array"]),
             country=dict(type="str"),
             province=dict(type="str"),

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -279,15 +279,16 @@ def update_cert(module, blade):
             private_key=module.params["key"],
             passphrase=module.params["passphrase"],
         )
-    res = blade.patch_certificates(
-        names=[module.params["name"]], certificate=certificate
-    )
-    if res.status_code != 200:
-        module.fail_json(
-            msg="Updating existing SSL certificate {0} failed. Error: {1}".format(
-                module.params["name"], get_error_message(res)
+        if not module.check_mode:
+            res = blade.patch_certificates(
+                names=[module.params["name"]], certificate=certificate
             )
-        )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Updating existing SSL certificate {0} failed. Error: {1}".format(
+                        module.params["name"], get_error_message(res)
+                    )
+                )
     module.exit_json(changed=changed)
 
 

--- a/tests/unit/plugins/modules/test_purefb_certs.py
+++ b/tests/unit/plugins/modules/test_purefb_certs.py
@@ -427,3 +427,1096 @@ class TestPurefbCerts:
         mock_module.exit_json.assert_called_once()
         call_args = mock_module.exit_json.call_args[1]
         assert call_args["changed"] is True
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_export_cert_success(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test export_cert successfully exports certificate"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "export",
+            "name": "test-cert",
+            "export_file": "test_cert.pem",
+            "common_name": None,
+            "country": None,
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": None,
+            "intermediate_cert": None,
+            "key": None,
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade
+        mock_blade = Mock()
+        mock_version = Mock()
+        mock_version.version = "2.15"
+        mock_blade.get_versions.return_value.items = [mock_version]
+
+        # Certificate exists
+        mock_cert_response = Mock()
+        mock_cert_response.status_code = 200
+        mock_cert = Mock()
+        mock_cert.certificate = "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----"
+        mock_cert_response.items = [mock_cert]
+        mock_blade.get_certificates.return_value = mock_cert_response
+
+        mock_get_system.return_value = mock_blade
+
+        # Mock file operations
+        with patch("builtins.open", create=True) as mock_open:
+            mock_file = Mock()
+            mock_open.return_value.__enter__.return_value = mock_file
+
+            # Call main
+            try:
+                main()
+            except SystemExit:
+                pass
+
+            # Verify file was written
+            mock_open.assert_called_once_with("test_cert.pem", "w", encoding="utf-8")
+            mock_file.write.assert_called_once_with(
+                "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----"
+            )
+
+        # Verify exit_json was called with changed=True
+        mock_module.exit_json.assert_called_once()
+        call_args = mock_module.exit_json.call_args[1]
+        assert call_args["changed"] is True
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_export_cert_failure(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test export_cert fails when certificate doesn't exist"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "export",
+            "name": "nonexistent-cert",
+            "export_file": "test_cert.pem",
+            "common_name": None,
+            "country": None,
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": None,
+            "intermediate_cert": None,
+            "key": None,
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade
+        mock_blade = Mock()
+        mock_version = Mock()
+        mock_version.version = "2.15"
+        mock_blade.get_versions.return_value.items = [mock_version]
+
+        # Certificate doesn't exist
+        mock_cert_response = Mock()
+        mock_cert_response.status_code = 400
+        mock_error = Mock()
+        mock_error.message = "Certificate not found"
+        mock_cert_response.errors = [mock_error]
+        mock_blade.get_certificates.return_value = mock_cert_response
+
+        mock_get_system.return_value = mock_blade
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "Exporting Certificate failed" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_create_csr_success(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test create_csr successfully creates CSR"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "sign",
+            "name": "test-cert",
+            "export_file": "test_csr.pem",
+            "common_name": "test.example.com",
+            "country": "US",
+            "province": "CA",
+            "locality": "SF",
+            "organization": "Test Org",
+            "org_unit": "IT",
+            "email": "test@example.com",
+            "key_size": None,
+            "certificate": None,
+            "intermediate_cert": None,
+            "key": None,
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": ["alt.example.com"],
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade with CSR API support
+        mock_blade = Mock()
+        mock_version = Mock()
+        mock_version.version = "2.20"
+        mock_blade.get_versions.return_value.items = ["2.20"]
+
+        # Certificate exists
+        mock_blade.get_certificates.return_value.status_code = 200
+
+        # Mock CSR response
+        mock_csr_item = Mock()
+        mock_csr_item.certificate_signing_request = [
+            "-----BEGIN CERTIFICATE REQUEST-----\n",
+            "CSR_CONTENT\n",
+            "-----END CERTIFICATE REQUEST-----\n",
+        ]
+        mock_csr_response = Mock()
+        mock_csr_response.items = [mock_csr_item]
+        mock_blade.post_certificates_certificate_signing_requests.return_value = (
+            mock_csr_response
+        )
+
+        mock_get_system.return_value = mock_blade
+
+        # Mock pycountry
+        mock_country = Mock()
+        mock_pycountry.countries.get.return_value = mock_country
+
+        # Mock file operations
+        with patch("builtins.open", create=True) as mock_open:
+            mock_file = Mock()
+            mock_open.return_value.__enter__.return_value = mock_file
+
+            # Call main
+            try:
+                main()
+            except SystemExit:
+                pass
+
+            # Verify file was written
+            mock_open.assert_called_once_with("test_csr.pem", "w", encoding="utf-8")
+            mock_file.writelines.assert_called_once()
+
+        # Verify exit_json was called with changed=True
+        mock_module.exit_json.assert_called_once()
+        call_args = mock_module.exit_json.call_args[1]
+        assert call_args["changed"] is True
+
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_create_csr_old_api_fails(
+        self, mock_ansible_module, mock_get_system
+    ):
+        """Test create_csr fails on old API version"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "sign",
+            "name": "test-cert",
+            "export_file": "test_csr.pem",
+            "common_name": None,
+            "country": None,
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": None,
+            "intermediate_cert": None,
+            "key": None,
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade with old API version
+        mock_blade = Mock()
+        mock_version = Mock()
+        mock_version.version = "2.15"
+        mock_blade.get_versions.return_value.items = ["2.15"]
+
+        mock_get_system.return_value = mock_blade
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "Purity//FB 4.6.3+ is required for CSRs" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_invalid_email(self, mock_ansible_module, mock_get_system):
+        """Test validation fails for invalid email"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "sign",
+            "name": "test-cert",
+            "export_file": "test_csr.pem",
+            "common_name": "test.example.com",
+            "country": None,
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": "invalid-email",  # Invalid email
+            "key_size": None,
+            "certificate": None,
+            "intermediate_cert": None,
+            "key": None,
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.20"]
+        mock_get_system.return_value = mock_blade
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "is not valid" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_invalid_country_length(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test validation fails for invalid country code length"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "sign",
+            "name": "test-cert",
+            "export_file": "test_csr.pem",
+            "common_name": "test.example.com",
+            "country": "USA",  # Invalid - should be 2 letters
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": None,
+            "intermediate_cert": None,
+            "key": None,
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.20"]
+        mock_get_system.return_value = mock_blade
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "two-letter country" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_invalid_country_code(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test validation fails for invalid country code"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "sign",
+            "name": "test-cert",
+            "export_file": "test_csr.pem",
+            "common_name": "test.example.com",
+            "country": "XX",  # Invalid ISO code
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": None,
+            "intermediate_cert": None,
+            "key": None,
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.20"]
+        mock_get_system.return_value = mock_blade
+
+        # Mock pycountry - return None for invalid code
+        mock_pycountry.countries.get.return_value = None
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "ISO 3166-1 code" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", False)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_no_pypureclient(self, mock_ansible_module):
+        """Test module fails when pypureclient is not installed"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "present",
+            "name": "test-cert",
+            "export_file": None,
+            "common_name": None,
+            "country": None,
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": "cert_content",
+            "intermediate_cert": None,
+            "key": "key_content",
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "py-pure-client sdk is required" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", False)
+    def test_main_no_pycountry(self, mock_ansible_module):
+        """Test module fails when pycountry is not installed"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "present",
+            "name": "test-cert",
+            "export_file": None,
+            "common_name": None,
+            "country": None,
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": "cert_content",
+            "intermediate_cert": None,
+            "key": "key_content",
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "pycountry sdk is required" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_update_cert_old_api(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test update_cert with old API version (< 2.20)"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "present",
+            "name": "existing-cert",
+            "export_file": None,
+            "common_name": None,
+            "country": None,
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": "new_cert_content",
+            "intermediate_cert": "intermediate_content",
+            "key": "new_key_content",
+            "passphrase": "secret",
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade with old API version
+        mock_blade = Mock()
+        mock_version = Mock()
+        mock_version.version = "2.15"
+        mock_blade.get_versions.return_value.items = ["2.15"]
+
+        # Certificate exists
+        mock_blade.get_certificates.return_value.status_code = 200
+
+        # Mock successful patch
+        mock_patch_response = Mock()
+        mock_patch_response.status_code = 200
+        mock_blade.patch_certificates.return_value = mock_patch_response
+
+        mock_get_system.return_value = mock_blade
+
+        # Call main
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify patch_certificates was called (old API path)
+        mock_blade.patch_certificates.assert_called_once()
+        call_args = mock_blade.patch_certificates.call_args
+
+        # Verify it was called with basic parameters (not extended)
+        assert "names" in call_args[1]
+        assert "certificate" in call_args[1]
+        # Should NOT have generate_new_key (that's only for new API)
+        assert "generate_new_key" not in call_args[1]
+
+        # Verify exit_json was called with changed=True
+        mock_module.exit_json.assert_called_once()
+        call_args = mock_module.exit_json.call_args[1]
+        assert call_args["changed"] is True
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_update_cert_new_api(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test update_cert with new API version (>= 2.20)"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "present",
+            "name": "existing-cert",
+            "export_file": None,
+            "common_name": "test.example.com",
+            "country": "US",
+            "province": "CA",
+            "locality": "SF",
+            "organization": "Test Org",
+            "org_unit": "IT",
+            "email": "test@example.com",
+            "key_size": 2048,
+            "certificate": "new_cert_content",
+            "intermediate_cert": "intermediate_content",
+            "key": "new_key_content",
+            "passphrase": "secret",
+            "generate": True,
+            "days": 365,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": ["alt.example.com"],
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade with new API version
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.20"]
+
+        # Certificate exists
+        mock_blade.get_certificates.return_value.status_code = 200
+
+        # Mock successful patch
+        mock_patch_response = Mock()
+        mock_patch_response.status_code = 200
+        mock_blade.patch_certificates.return_value = mock_patch_response
+
+        mock_get_system.return_value = mock_blade
+
+        # Mock pycountry
+        mock_country = Mock()
+        mock_pycountry.countries.get.return_value = mock_country
+
+        # Call main
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify patch_certificates was called (new API path)
+        mock_blade.patch_certificates.assert_called_once()
+        call_args = mock_blade.patch_certificates.call_args
+
+        # Verify it was called with extended parameters
+        assert "names" in call_args[1]
+        assert "certificate" in call_args[1]
+        assert "generate_new_key" in call_args[1]
+        assert call_args[1]["generate_new_key"] == "True"
+
+        # Verify exit_json was called with changed=True
+        mock_module.exit_json.assert_called_once()
+        call_args = mock_module.exit_json.call_args[1]
+        assert call_args["changed"] is True
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_update_cert_new_api_fails(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test update_cert fails with new API version"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "present",
+            "name": "existing-cert",
+            "export_file": None,
+            "common_name": "test.example.com",
+            "country": "US",
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": "test@example.com",
+            "key_size": None,
+            "certificate": "new_cert_content",
+            "intermediate_cert": None,
+            "key": "new_key_content",
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade with new API version
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.20"]
+
+        # Certificate exists
+        mock_blade.get_certificates.return_value.status_code = 200
+
+        # Mock failed patch
+        mock_patch_response = Mock()
+        mock_patch_response.status_code = 400
+        mock_error = Mock()
+        mock_error.message = "Invalid certificate"
+        mock_patch_response.errors = [mock_error]
+        mock_blade.patch_certificates.return_value = mock_patch_response
+
+        mock_get_system.return_value = mock_blade
+
+        # Mock pycountry
+        mock_country = Mock()
+        mock_pycountry.countries.get.return_value = mock_country
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "Updating existing SSL certificate" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_update_cert_old_api_fails(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test update_cert fails with old API version"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "present",
+            "name": "existing-cert",
+            "export_file": None,
+            "common_name": None,
+            "country": None,
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": "new_cert_content",
+            "intermediate_cert": None,
+            "key": "new_key_content",
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade with old API version
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.15"]
+
+        # Certificate exists
+        mock_blade.get_certificates.return_value.status_code = 200
+
+        # Mock failed patch
+        mock_patch_response = Mock()
+        mock_patch_response.status_code = 400
+        mock_error = Mock()
+        mock_error.message = "Invalid certificate"
+        mock_patch_response.errors = [mock_error]
+        mock_blade.patch_certificates.return_value = mock_patch_response
+
+        mock_get_system.return_value = mock_blade
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "Updating existing SSL certificate" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_create_cert_new_api_fails(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test create_cert fails with new API version"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "present",
+            "name": "new-cert",
+            "export_file": None,
+            "common_name": "test.example.com",
+            "country": "US",
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": "test@example.com",
+            "key_size": None,
+            "certificate": "cert_content",
+            "intermediate_cert": None,
+            "key": "key_content",
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": "self-signed",
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade with new API version
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.20"]
+
+        # Certificate doesn't exist
+        mock_blade.get_certificates.return_value.status_code = 400
+
+        # Mock failed post
+        mock_post_response = Mock()
+        mock_post_response.status_code = 400
+        mock_error = Mock()
+        mock_error.message = "Invalid certificate"
+        mock_post_response.errors = [mock_error]
+        mock_blade.post_certificates.return_value = mock_post_response
+
+        mock_get_system.return_value = mock_blade
+
+        # Mock pycountry
+        mock_country = Mock()
+        mock_pycountry.countries.get.return_value = mock_country
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "Creating SSL certificate" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_delete_cert_fails(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test delete_cert fails"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "absent",
+            "name": "test-cert",
+            "export_file": None,
+            "common_name": None,
+            "country": None,
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": None,
+            "intermediate_cert": None,
+            "key": None,
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.15"]
+
+        # Certificate exists
+        mock_blade.get_certificates.return_value.status_code = 200
+
+        # Mock failed delete
+        mock_delete_response = Mock()
+        mock_delete_response.status_code = 400
+        mock_error = Mock()
+        mock_error.message = "Cannot delete certificate"
+        mock_delete_response.errors = [mock_error]
+        mock_blade.delete_certificates.return_value = mock_delete_response
+
+        mock_get_system.return_value = mock_blade
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "Failed to delete" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_reimport_external_cert_fails(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test reimporting external certificate fails"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "import",
+            "name": "external-cert",
+            "export_file": None,
+            "common_name": None,
+            "country": None,
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": "cert_content",
+            "intermediate_cert": None,
+            "key": None,  # No key - will be auto-detected as external
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.15"]
+
+        # Certificate exists and is external
+        mock_cert_response = Mock()
+        mock_cert_response.status_code = 200
+        mock_cert = Mock()
+        mock_cert.certificate_type = "external"
+        mock_cert_response.items = [mock_cert]
+        mock_blade.get_certificates.return_value = mock_cert_response
+
+        mock_get_system.return_value = mock_blade
+
+        # Call main - expect failure
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify fail_json was called
+        mock_module.fail_json.assert_called_once()
+        call_args = mock_module.fail_json.call_args[1]
+        assert "External Certificates cannot be reimported" in call_args["msg"]
+
+    @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.get_system")
+    @patch("plugins.modules.purefb_certs.AnsibleModule")
+    @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
+    def test_main_import_existing_cert(
+        self, mock_ansible_module, mock_get_system, mock_pycountry
+    ):
+        """Test importing over existing non-external certificate"""
+        # Setup mock module
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "state": "import",
+            "name": "existing-cert",
+            "export_file": None,
+            "common_name": None,
+            "country": None,
+            "province": None,
+            "locality": None,
+            "organization": None,
+            "org_unit": None,
+            "email": None,
+            "key_size": None,
+            "certificate": "cert_content",
+            "intermediate_cert": None,
+            "key": "key_content",
+            "passphrase": None,
+            "generate": False,
+            "days": None,
+            "key_algorithm": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        # Mock blade
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.15"]
+
+        # Certificate exists and is NOT external
+        mock_cert_response = Mock()
+        mock_cert_response.status_code = 200
+        mock_cert = Mock()
+        mock_cert.certificate_type = "self-signed"
+        mock_cert_response.items = [mock_cert]
+        mock_blade.get_certificates.return_value = mock_cert_response
+
+        # Mock successful patch
+        mock_patch_response = Mock()
+        mock_patch_response.status_code = 200
+        mock_blade.patch_certificates.return_value = mock_patch_response
+
+        mock_get_system.return_value = mock_blade
+
+        # Call main
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify patch_certificates was called (update path)
+        mock_blade.patch_certificates.assert_called_once()
+
+        # Verify exit_json was called with changed=True
+        mock_module.exit_json.assert_called_once()
+        call_args = mock_module.exit_json.call_args[1]
+        assert call_args["changed"] is True

--- a/tests/unit/plugins/modules/test_purefb_certs.py
+++ b/tests/unit/plugins/modules/test_purefb_certs.py
@@ -94,6 +94,8 @@ class TestPurefbCerts:
             "days": 3650,
             "key_algorithm": None,
             "export_file": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
         }
         mock_module.check_mode = False
         mock_ansible_module.return_value = mock_module
@@ -168,6 +170,8 @@ class TestPurefbCerts:
             "days": 3650,
             "key_algorithm": None,
             "export_file": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
         }
         mock_module.check_mode = False
         mock_ansible_module.return_value = mock_module
@@ -269,6 +273,8 @@ class TestPurefbCerts:
             "days": 3650,
             "key_algorithm": None,
             "export_file": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
         }
         mock_module.check_mode = True  # This is the key - check_mode enabled
         mock_ansible_module.return_value = mock_module
@@ -302,10 +308,8 @@ class TestPurefbCerts:
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
-    def test_main_delete_cert_management_fails(
-        self, mock_ansible_module, mock_get_system
-    ):
-        """Test delete_cert fails when trying to delete management certificate"""
+    def test_main_delete_cert_global_fails(self, mock_ansible_module, mock_get_system):
+        """Test delete_cert fails when trying to delete global certificate"""
         # Setup mock module
         mock_module = Mock()
         # Make exit_json and fail_json raise exceptions to stop execution
@@ -313,7 +317,7 @@ class TestPurefbCerts:
         mock_module.fail_json = Mock(side_effect=SystemExit)
         mock_module.params = {
             "state": "absent",
-            "name": "management",
+            "name": "global",
             "common_name": None,
             "country": None,
             "province": None,
@@ -330,6 +334,8 @@ class TestPurefbCerts:
             "days": 3650,
             "key_algorithm": None,
             "export_file": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
         }
         mock_module.check_mode = False
         mock_ansible_module.return_value = mock_module
@@ -354,7 +360,7 @@ class TestPurefbCerts:
         # Verify fail_json was called
         mock_module.fail_json.assert_called_once()
         call_args = mock_module.fail_json.call_args[1]
-        assert "management SSL cannot be deleted" in call_args["msg"]
+        assert "Global certificate cannot be deleted" in call_args["msg"]
 
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
@@ -386,6 +392,8 @@ class TestPurefbCerts:
             "days": 3650,
             "key_algorithm": None,
             "export_file": None,
+            "certificate_type": None,
+            "subject_alternative_names": None,
         }
         mock_module.check_mode = False
         mock_ansible_module.return_value = mock_module

--- a/tests/unit/plugins/modules/test_purefb_certs.py
+++ b/tests/unit/plugins/modules/test_purefb_certs.py
@@ -476,7 +476,9 @@ class TestPurefbCerts:
         mock_cert_response = Mock()
         mock_cert_response.status_code = 200
         mock_cert = Mock()
-        mock_cert.certificate = "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----"
+        mock_cert.certificate = (
+            "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----"
+        )
         mock_cert_response.items = [mock_cert]
         mock_blade.get_certificates.return_value = mock_cert_response
 
@@ -659,9 +661,7 @@ class TestPurefbCerts:
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
-    def test_main_create_csr_old_api_fails(
-        self, mock_ansible_module, mock_get_system
-    ):
+    def test_main_create_csr_old_api_fails(self, mock_ansible_module, mock_get_system):
         """Test create_csr fails on old API version"""
         # Setup mock module
         mock_module = Mock()


### PR DESCRIPTION
##### SUMMARY
Setting defaults causes issues because the defaults always get send even if they make no sense. This causes errors along the long line of "trying to change read-only parameter".
Simplified the module.
Let FB do it's (error-)logic. Do not try to re-implement (with some trivial exceptions)
It's up to the user to use a valid set of parameters.

##### Known issues
- There is an problem with new-key/generate_new_key/generate which is still under
investigation. This impacts key-size/key-algorithm changes to self-signed certificates.
- Nothing done for realm support yet.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_certs.py