### PR TITLE
Fix typo in encryption type for Kerberos authentication

### DIFF
--- a/changelogs/fragments/526_encryption_typo.yml
+++ b/changelogs/fragments/526_encryption_typo.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_ad - Correct encryption type from ``arcfour-hma`` to ``arcfour-hmac``

--- a/plugins/modules/purefb_ad.py
+++ b/plugins/modules/purefb_ad.py
@@ -66,7 +66,7 @@ options:
     - The encryption types that will be supported for use by clients for Kerberos authentication
     type: list
     elements: str
-    choices: [ aes256-sha1, aes128-sha1, aes256-cts-hmac-sha1-96, aes128-cts-hmac-sha1-96, arcfour-hma ]
+    choices: [ aes256-sha1, aes128-sha1, aes256-cts-hmac-sha1-96, aes128-cts-hmac-sha1-96, arcfour-hmac ]
     default: aes256-sha1
   join_ou:
     description:
@@ -490,7 +490,7 @@ def main():
                     "aes128-sha1",
                     "aes256-cts-hmac-sha1-96",
                     "aes128-cts-hmac-sha1-96",
-                    "arcfour-hma",
+                    "arcfour-hmac",
                 ],
                 default=["aes256-sha1"],
             ),


### PR DESCRIPTION
##### SUMMARY
Fix typo that references `arcfour-hma` when it should be `arcfour-hmac`.
Closes #525 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_ad.py