### PR TITLE
Fix purefb_fs fails to apply policies to existing filesystems

### DIFF
--- a/changelogs/fragments/534_purefb_fs_policy.yaml
+++ b/changelogs/fragments/534_purefb_fs_policy.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefb_fs - Fixed failure to apply policies to existing filesystems due to incorrect API check and non-existent patch method

--- a/plugins/modules/purefb_fs.py
+++ b/plugins/modules/purefb_fs.py
@@ -683,15 +683,15 @@ def modify_fs(module, blade):
                 policy_names=[module.params["policy"]],
                 member_names=[fs_name],
             )
-        if res.status_code != 200:
+        if res.status_code != 200 or getattr(res, "total_item_count", 0) == 0:
             if CONTEXT_API_VERSION in api_version:
-                res = blade.patch_policies_file_systems(
+                res = blade.post_policies_file_systems(
                     policy_names=[module.params["policy"]],
                     member_names=[fs_name],
                     context_names=[module.params["context"]],
                 )
             else:
-                res = blade.patch_policies_file_systems(
+                res = blade.post_policies_file_systems(
                     policy_names=[module.params["policy"]],
                     member_names=[fs_name],
                 )

--- a/tests/unit/plugins/modules/test_purefb_fs.py
+++ b/tests/unit/plugins/modules/test_purefb_fs.py
@@ -1008,7 +1008,7 @@ class TestPurefbFs:
         # Mock successful policy attachment
         mock_patch_response = Mock()
         mock_patch_response.status_code = 200
-        mock_blade.patch_policies_file_systems.return_value = mock_patch_response
+        mock_blade.post_policies_file_systems.return_value = mock_patch_response
         mock_blade.patch_file_systems.return_value = mock_patch_response
         mock_blade.get_file_systems.return_value.items = [mock_fs]
 
@@ -1016,7 +1016,7 @@ class TestPurefbFs:
         modify_fs(mock_module, mock_blade)
 
         # Verify
-        mock_blade.patch_policies_file_systems.assert_called_once()
+        mock_blade.post_policies_file_systems.assert_called_once()
         mock_module.exit_json.assert_called()
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
@@ -2828,7 +2828,7 @@ class TestPurefbFs:
         # Mock failed attach
         mock_attach_response = Mock()
         mock_attach_response.status_code = 400
-        mock_blade.patch_policies_file_systems.return_value = mock_attach_response
+        mock_blade.post_policies_file_systems.return_value = mock_attach_response
 
         # Call function - should fail
         try:
@@ -2837,7 +2837,7 @@ class TestPurefbFs:
             assert str(e) == "fail_json"
 
         # Verify
-        mock_blade.patch_policies_file_systems.assert_called()
+        mock_blade.post_policies_file_systems.assert_called()
         mock_module.fail_json.assert_called()
 
     @patch("plugins.modules.purefb_fs.get_filesystem")


### PR DESCRIPTION
##### SUMMARY

Fixes #533

The `purefb_fs` module fails to apply a policy to an existing filesystem because of two bugs in `modify_fs()`:

1. `get_policies_file_systems()` returns **HTTP 200** with `total_item_count=0` when the association does not exist. The original code only checked `res.status_code != 200`, so the branch to add the policy was never entered.

2. The code called `blade.patch_policies_file_systems(...)`, but **`patch_policies_file_systems` does not exist in `pypureclient`**. The `/policies/file-systems` endpoint only supports `GET`, `POST`, and `DELETE` because the association is binary.

This fix:
- Updates the condition to also check `total_item_count == 0`.
- Replaces the non-existent `patch_policies_file_systems` with `post_policies_file_systems`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_fs

##### ADDITIONAL INFORMATION
