### PR TITLE
Handle error for policy rule retrieval failures

### DIFF
--- a/changelogs/fragments/536_empty_policy_rule.yml
+++ b/changelogs/fragments/536_empty_policy_rule.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_policy - Fixed AttributeError with empty policy rules

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -899,7 +899,7 @@ def update_smb_share_policy(module, blade):
         if current_policy_rule.status_code != 200:
             module.fail_json(
                 msg="Failed to get SMB export policy rules for {0}. Error: {1}".format(
-                i    module.params["name"],
+                    module.params["name"],
                     current_policy_rule.errors[0].message,
                     )
                 )

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -901,8 +901,8 @@ def update_smb_share_policy(module, blade):
                 msg="Failed to get SMB export policy rules for {0}. Error: {1}".format(
                     module.params["name"],
                     current_policy_rule.errors[0].message,
-                    )
                 )
+            )
         elif (
             current_policy_rule.status_code == 200
             and current_policy_rule.total_item_count == 0

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -896,7 +896,14 @@ def update_smb_share_policy(module, blade):
                 policy_names=[module.params["name"]],
                 filter="principal='" + module.params["principal"] + "'",
             )
-        if (
+        if current_policy_rule.status_code != 200:
+            module.fail_json(
+                msg="Failed to get SMB export policy rules for {0}. Error: {1}".format(
+                module.params["name"],
+                current_policy_rule.errors[0].message,
+                )
+            )
+        elif (
             current_policy_rule.status_code == 200
             and current_policy_rule.total_item_count == 0
         ):
@@ -1805,7 +1812,14 @@ def update_network_access_policy(module, blade):
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
             )
-        if (
+        if current_policy_rule.status_code != 200:
+            module.fail_json(
+                msg="Failed to get network access policy rules for {0}. Error: {1}".format(
+                    module.params["name"],
+                    current_policy_rule.errors[0].message,
+                )
+            )
+        elif (
             current_policy_rule.status_code == 200
             and current_policy_rule.total_item_count == 0
         ):
@@ -2333,7 +2347,14 @@ def update_nfs_policy(module, blade):
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
             )
-        if (
+        if current_policy_rule.status_code != 200:
+            module.fail_json(
+                msg="Failed to get NFS export policy rules for {0}. Error: {1}".format(
+                    module.params["name"],
+                    current_policy_rule.errors[0].message,
+                )
+            )
+        elif (
             current_policy_rule.status_code == 200
             and current_policy_rule.total_item_count == 0
         ):

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -899,10 +899,10 @@ def update_smb_share_policy(module, blade):
         if current_policy_rule.status_code != 200:
             module.fail_json(
                 msg="Failed to get SMB export policy rules for {0}. Error: {1}".format(
-                module.params["name"],
-                current_policy_rule.errors[0].message,
+                i    module.params["name"],
+                    current_policy_rule.errors[0].message,
+                    )
                 )
-            )
         elif (
             current_policy_rule.status_code == 200
             and current_policy_rule.total_item_count == 0


### PR DESCRIPTION
##### SUMMARY
Fix issue where non-existant policy rules causes an `AttributeError`
Closes #532 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_policy.py