### PR TITLE
Rename variable for clarity in generate_bucket_dict

### DIFF
--- a/changelogs/fragments/540_reassignment_fix.yaml
+++ b/changelogs/fragments/540_reassignment_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_info - Fixed bucket AttributeError

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -816,8 +816,8 @@ def generate_bucket_dict(blade):
     bucket_info = {}
     buckets = list(blade.get_buckets().items)
     for bucket in buckets:
-        bucket = bucket.name
-        bucket_info[bucket] = {
+        bucket_name = bucket.name
+        bucket_info[bucket_name] = {
             "versioning": bucket.versioning,
             "bucket_type": getattr(bucket, "bucket_type", None),
             "object_count": bucket.object_count,


### PR DESCRIPTION
##### SUMMARY
Fix issue where a varaible is being incorrectly reassigned, causing an AttributeError
Closes #538 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_info.py