### PR TITLE
Fix context_names issues

### DIFF
--- a/changelogs/fragments/543_policy_context_fix.yaml
+++ b/changelogs/fragments/543_policy_context_fix.yaml
@@ -1,3 +1,3 @@
 bugfixes:
- - purefb_policy - Default context to the local array name so that empty context_names no longer cause errors on newer Purity//FB releases
+ - purefb_policy - Only send context_names when a context is set, and only default it for fleet members, avoiding empty-context errors and "not in a fleet" errors on standalone arrays
  - purefb_policy - Create a policy rule when the client lookup returns no match or an error, fixing failures adding the first rule for a client while keeping the task idempotent

--- a/changelogs/fragments/543_policy_context_fix.yaml
+++ b/changelogs/fragments/543_policy_context_fix.yaml
@@ -1,3 +1,3 @@
 bugfixes:
  - purefb_policy - Default context to the local array name so that empty context_names no longer cause errors on newer Purity//FB releases
- - purefb_policy - Match policy rules by client locally instead of using a server-side filter, which could return an error rather than an empty result set and caused failures when adding the first rule for a client
+ - purefb_policy - Match policy rules by client locally instead of a server-side filter, which could error instead of returning an empty set and break adding the first rule for a client

--- a/changelogs/fragments/543_policy_context_fix.yaml
+++ b/changelogs/fragments/543_policy_context_fix.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+ - purefb_policy - Default context to the local array name so that empty context_names no longer cause errors on newer Purity//FB releases
+ - purefb_policy - Match policy rules by client locally instead of using a server-side filter, which could return an error rather than an empty result set and caused failures when adding the first rule for a client

--- a/changelogs/fragments/543_policy_context_fix.yaml
+++ b/changelogs/fragments/543_policy_context_fix.yaml
@@ -1,3 +1,3 @@
 bugfixes:
  - purefb_policy - Default context to the local array name so that empty context_names no longer cause errors on newer Purity//FB releases
- - purefb_policy - Match policy rules by client locally instead of a server-side filter, which could error instead of returning an empty set and break adding the first rule for a client
+ - purefb_policy - Create a policy rule when the client lookup returns no match or an error, fixing failures adding the first rule for a client while keeping the task idempotent

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -1418,18 +1418,28 @@ def update_smb_client_policy(module, blade):
         if CONTEXT_API_VERSION in versions:
             current_policy_rule = blade.get_smb_client_policies_rules(
                 policy_names=[module.params["name"]],
-                filter="client='" + module.params["client"] + "'",
                 context_names=[module.params["context"]],
             )
         else:
             current_policy_rule = blade.get_smb_client_policies_rules(
                 policy_names=[module.params["name"]],
-                filter="client='" + module.params["client"] + "'",
             )
-        if (
-            current_policy_rule.status_code == 200
-            and current_policy_rule.total_item_count == 0
-        ):
+        if current_policy_rule.status_code != 200:
+            module.fail_json(
+                msg="Failed to get SMB client policy rules for {0}. Error: {1}".format(
+                    module.params["name"],
+                    get_error_message(current_policy_rule),
+                )
+            )
+        # Match the requested client locally rather than using a server-side
+        # filter, which on some Purity//FB versions returns an error instead
+        # of an empty result set when no matching rule exists.
+        matching_rules = [
+            rule
+            for rule in list(current_policy_rule.items)
+            if rule.client == module.params["client"]
+        ]
+        if not matching_rules:
             if SMB_ENCRYPT_API_VERSION in versions:
                 rule = SmbClientPolicyRule(
                     client=module.params["client"],
@@ -1484,7 +1494,7 @@ def update_smb_client_policy(module, blade):
                         )
                     )
         else:
-            rules = list(current_policy_rule.items)
+            rules = matching_rules
             cli_count = None
             done = False
             if module.params["client"] == "*":
@@ -1804,25 +1814,28 @@ def update_network_access_policy(module, blade):
         if CONTEXT_API_VERSION in versions:
             current_policy_rule = blade.get_network_access_policies_rules(
                 policy_names=[module.params["name"]],
-                filter="client='" + module.params["client"] + "'",
                 context_names=[module.params["context"]],
             )
         else:
             current_policy_rule = blade.get_network_access_policies_rules(
                 policy_names=[module.params["name"]],
-                filter="client='" + module.params["client"] + "'",
             )
         if current_policy_rule.status_code != 200:
             module.fail_json(
                 msg="Failed to get network access policy rules for {0}. Error: {1}".format(
                     module.params["name"],
-                    current_policy_rule.errors[0].message,
+                    get_error_message(current_policy_rule),
                 )
             )
-        elif (
-            current_policy_rule.status_code == 200
-            and current_policy_rule.total_item_count == 0
-        ):
+        # Match the requested client locally rather than using a server-side
+        # filter, which on some Purity//FB versions returns an error instead
+        # of an empty result set when no matching rule exists.
+        matching_rules = [
+            rule
+            for rule in list(current_policy_rule.items)
+            if rule.client == module.params["client"]
+        ]
+        if not matching_rules:
             rule = NetworkAccessPolicyRule(
                 client=module.params["client"],
                 effect=module.params["effect"],
@@ -1869,7 +1882,7 @@ def update_network_access_policy(module, blade):
                         )
                     )
         else:
-            rules = list(current_policy_rule.items)
+            rules = matching_rules
             cli_count = None
             done = False
             if module.params["client"] == "*":
@@ -2339,25 +2352,28 @@ def update_nfs_policy(module, blade):
         if CONTEXT_API_VERSION in versions:
             current_policy_rule = blade.get_nfs_export_policies_rules(
                 policy_names=[module.params["name"]],
-                filter="client='" + module.params["client"] + "'",
                 context_names=[module.params["context"]],
             )
         else:
             current_policy_rule = blade.get_nfs_export_policies_rules(
                 policy_names=[module.params["name"]],
-                filter="client='" + module.params["client"] + "'",
             )
         if current_policy_rule.status_code != 200:
             module.fail_json(
                 msg="Failed to get NFS export policy rules for {0}. Error: {1}".format(
                     module.params["name"],
-                    current_policy_rule.errors[0].message,
+                    get_error_message(current_policy_rule),
                 )
             )
-        elif (
-            current_policy_rule.status_code == 200
-            and current_policy_rule.total_item_count == 0
-        ):
+        # Match the requested client locally rather than using a server-side
+        # filter, which on some Purity//FB versions returns an error instead
+        # of an empty result set when no matching rule exists.
+        matching_rules = [
+            rule
+            for rule in list(current_policy_rule.items)
+            if rule.client == module.params["client"]
+        ]
+        if not matching_rules:
             rule = NfsExportPolicyRule(
                 client=module.params["client"],
                 permission=module.params["permission"],
@@ -2410,7 +2426,7 @@ def update_nfs_policy(module, blade):
                         )
                     )
         else:
-            rules = list(current_policy_rule.items)
+            rules = matching_rules
             cli_count = None
             done = False
             if module.params["client"] == "*":

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -3940,21 +3940,36 @@ def main():
     state = module.params["state"]
     blade = get_system(module)
     versions = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in versions and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
     if module.params["policy_type"] == "access":
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
-        blade = get_system(module)
         try:
-            policy = list(
-                blade.get_object_store_access_policies(
-                    names=[module.params["account"] + "/" + module.params["name"]]
-                ).items
-            )[0]
+            if CONTEXT_API_VERSION in versions:
+                policy = list(
+                    blade.get_object_store_access_policies(
+                        names=[module.params["account"] + "/" + module.params["name"]],
+                        context_names=[module.params["context"]],
+                    ).items
+                )[0]
+            else:
+                policy = list(
+                    blade.get_object_store_access_policies(
+                        names=[module.params["account"] + "/" + module.params["name"]]
+                    ).items
+                )[0]
         except AttributeError:
             policy = None
         if module.params["user"]:
             member_name = module.params["account"] + "/" + module.params["user"]
-            res = blade.get_object_store_users(names=[member_name])
+            if CONTEXT_API_VERSION in versions:
+                res = blade.get_object_store_users(
+                    names=[member_name], context_names=[module.params["context"]]
+                )
+            else:
+                res = blade.get_object_store_users(names=[member_name])
             if res.status_code != 200:
                 module.fail_json(
                     msg="User {0} does not exist in account {1}. Error: {2}".format(
@@ -3974,12 +3989,16 @@ def main():
                 module.fail_json(
                     msg='Incorrect format for target policy. Must be "<account>/<name>"'
                 )
-            if (
-                blade.get_object_store_access_policies(
+            if CONTEXT_API_VERSION in versions:
+                res = blade.get_object_store_access_policies(
+                    names=[module.params["target"]],
+                    context_names=[module.params["context"]],
+                )
+            else:
+                res = blade.get_object_store_access_policies(
                     names=[module.params["target"]]
-                ).status_code
-                != 200
-            ):
+                )
+            if res.status_code != 200:
                 module.fail_json(
                     msg="Target policy {0} does not exist".format(
                         module.params["target"]
@@ -3998,28 +4017,58 @@ def main():
             )
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
-        blade = get_system(module)
         try:
-            policy = list(
-                blade.get_nfs_export_policies(names=[module.params["name"]]).items
-            )[0]
+            if CONTEXT_API_VERSION in versions:
+                policy = list(
+                    blade.get_nfs_export_policies(
+                        names=[module.params["name"]],
+                        context_names=[module.params["context"]],
+                    ).items
+                )[0]
+            else:
+                policy = list(
+                    blade.get_nfs_export_policies(names=[module.params["name"]]).items
+                )[0]
         except AttributeError:
             policy = None
         if module.params["rename"]:
             try:
-                new_policy = list(
-                    blade.get_nfs_export_policies(names=[module.params["rename"]]).items
-                )[0]
+                if CONTEXT_API_VERSION in versions:
+                    new_policy = list(
+                        blade.get_nfs_export_policies(
+                            names=[module.params["rename"]],
+                            context_names=[module.params["context"]],
+                        ).items
+                    )[0]
+                else:
+                    new_policy = list(
+                        blade.get_nfs_export_policies(
+                            names=[module.params["rename"]]
+                        ).items
+                    )[0]
             except AttributeError:
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                res = blade.get_nfs_export_policies_rules(
-                    policy_names=[module.params["name"]],
-                    names=[
-                        module.params["name"] + "." + str(module.params["before_rule"])
-                    ],
-                )
+                if CONTEXT_API_VERSION in versions:
+                    res = blade.get_nfs_export_policies_rules(
+                        policy_names=[module.params["name"]],
+                        names=[
+                            module.params["name"]
+                            + "."
+                            + str(module.params["before_rule"])
+                        ],
+                        context_names=[module.params["context"]],
+                    )
+                else:
+                    res = blade.get_nfs_export_policies_rules(
+                        policy_names=[module.params["name"]],
+                        names=[
+                            module.params["name"]
+                            + "."
+                            + str(module.params["before_rule"])
+                        ],
+                    )
                 if res.status_code != 200:
                     module.fail_json(
                         msg="Rule index {0} does not exist.".format(
@@ -4046,28 +4095,58 @@ def main():
             )
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
-        blade = get_system(module)
         try:
-            policy = list(
-                blade.get_smb_client_policies(names=[module.params["name"]]).items
-            )[0]
+            if CONTEXT_API_VERSION in versions:
+                policy = list(
+                    blade.get_smb_client_policies(
+                        names=[module.params["name"]],
+                        context_names=[module.params["context"]],
+                    ).items
+                )[0]
+            else:
+                policy = list(
+                    blade.get_smb_client_policies(names=[module.params["name"]]).items
+                )[0]
         except AttributeError:
             policy = None
         if module.params["rename"]:
             try:
-                new_policy = list(
-                    blade.get_smb_client_policies(names=[module.params["rename"]]).items
-                )[0]
+                if CONTEXT_API_VERSION in versions:
+                    new_policy = list(
+                        blade.get_smb_client_policies(
+                            names=[module.params["rename"]],
+                            context_names=[module.params["context"]],
+                        ).items
+                    )[0]
+                else:
+                    new_policy = list(
+                        blade.get_smb_client_policies(
+                            names=[module.params["rename"]]
+                        ).items
+                    )[0]
             except AttributeError:
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                res = blade.get_smb_client_policies_rules(
-                    policy_names=[module.params["name"]],
-                    names=[
-                        module.params["name"] + "." + str(module.params["before_rule"])
-                    ],
-                )
+                if CONTEXT_API_VERSION in versions:
+                    res = blade.get_smb_client_policies_rules(
+                        policy_names=[module.params["name"]],
+                        names=[
+                            module.params["name"]
+                            + "."
+                            + str(module.params["before_rule"])
+                        ],
+                        context_names=[module.params["context"]],
+                    )
+                else:
+                    res = blade.get_smb_client_policies_rules(
+                        policy_names=[module.params["name"]],
+                        names=[
+                            module.params["name"]
+                            + "."
+                            + str(module.params["before_rule"])
+                        ],
+                    )
                 if res.status_code != 200:
                     module.fail_json(
                         msg="Rule index {0} does not exist.".format(
@@ -4094,28 +4173,58 @@ def main():
             )
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
-        blade = get_system(module)
         try:
-            policy = list(
-                blade.get_smb_share_policies(names=[module.params["name"]]).items
-            )[0]
+            if CONTEXT_API_VERSION in versions:
+                policy = list(
+                    blade.get_smb_share_policies(
+                        names=[module.params["name"]],
+                        context_names=[module.params["context"]],
+                    ).items
+                )[0]
+            else:
+                policy = list(
+                    blade.get_smb_share_policies(names=[module.params["name"]]).items
+                )[0]
         except AttributeError:
             policy = None
         if module.params["rename"]:
             try:
-                new_policy = list(
-                    blade.get_smb_share_policies(names=[module.params["rename"]]).items
-                )[0]
+                if CONTEXT_API_VERSION in versions:
+                    new_policy = list(
+                        blade.get_smb_share_policies(
+                            names=[module.params["rename"]],
+                            context_names=[module.params["context"]],
+                        ).items
+                    )[0]
+                else:
+                    new_policy = list(
+                        blade.get_smb_share_policies(
+                            names=[module.params["rename"]]
+                        ).items
+                    )[0]
             except AttributeError:
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                res = blade.get_smb_share_policies_rules(
-                    policy_names=[module.params["name"]],
-                    names=[
-                        module.params["name"] + "." + str(module.params["before_rule"])
-                    ],
-                )
+                if CONTEXT_API_VERSION in versions:
+                    res = blade.get_smb_share_policies_rules(
+                        policy_names=[module.params["name"]],
+                        names=[
+                            module.params["name"]
+                            + "."
+                            + str(module.params["before_rule"])
+                        ],
+                        context_names=[module.params["context"]],
+                    )
+                else:
+                    res = blade.get_smb_share_policies_rules(
+                        policy_names=[module.params["name"]],
+                        names=[
+                            module.params["name"]
+                            + "."
+                            + str(module.params["before_rule"])
+                        ],
+                    )
                 if res.status_code != 200:
                     module.fail_json(
                         msg="Rule index {0} does not exist.".format(
@@ -4142,30 +4251,60 @@ def main():
             )
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
-        blade = get_system(module)
         try:
-            policy = list(
-                blade.get_network_access_policies(names=[module.params["name"]]).items
-            )[0]
+            if CONTEXT_API_VERSION in versions:
+                policy = list(
+                    blade.get_network_access_policies(
+                        names=[module.params["name"]],
+                        context_names=[module.params["context"]],
+                    ).items
+                )[0]
+            else:
+                policy = list(
+                    blade.get_network_access_policies(
+                        names=[module.params["name"]]
+                    ).items
+                )[0]
         except AttributeError:
             policy = None
         if module.params["rename"]:
             try:
-                new_policy = list(
-                    blade.get_network_access_policies(
-                        names=[module.params["rename"]]
-                    ).items
-                )[0]
+                if CONTEXT_API_VERSION in versions:
+                    new_policy = list(
+                        blade.get_network_access_policies(
+                            names=[module.params["rename"]],
+                            context_names=[module.params["context"]],
+                        ).items
+                    )[0]
+                else:
+                    new_policy = list(
+                        blade.get_network_access_policies(
+                            names=[module.params["rename"]]
+                        ).items
+                    )[0]
             except AttributeError:
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                res = blade.get_network_access_policies_rules(
-                    policy_names=[module.params["name"]],
-                    names=[
-                        module.params["name"] + "." + str(module.params["before_rule"])
-                    ],
-                )
+                if CONTEXT_API_VERSION in versions:
+                    res = blade.get_network_access_policies_rules(
+                        policy_names=[module.params["name"]],
+                        names=[
+                            module.params["name"]
+                            + "."
+                            + str(module.params["before_rule"])
+                        ],
+                        context_names=[module.params["context"]],
+                    )
+                else:
+                    res = blade.get_network_access_policies_rules(
+                        policy_names=[module.params["name"]],
+                        names=[
+                            module.params["name"]
+                            + "."
+                            + str(module.params["before_rule"])
+                        ],
+                    )
                 if res.status_code != 200:
                     module.fail_json(
                         msg="Rule index {0} does not exist.".format(
@@ -4192,28 +4331,58 @@ def main():
             )
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
-        blade = get_system(module)
         try:
-            policy = list(
-                blade.get_worm_data_policies(names=[module.params["name"]]).items
-            )[0]
+            if CONTEXT_API_VERSION in versions:
+                policy = list(
+                    blade.get_worm_data_policies(
+                        names=[module.params["name"]],
+                        context_names=[module.params["context"]],
+                    ).items
+                )[0]
+            else:
+                policy = list(
+                    blade.get_worm_data_policies(names=[module.params["name"]]).items
+                )[0]
         except AttributeError:
             policy = None
         if module.params["rename"]:
             try:
-                new_policy = list(
-                    blade.get_worm_data_policies(names=[module.params["rename"]]).items
-                )[0]
+                if CONTEXT_API_VERSION in versions:
+                    new_policy = list(
+                        blade.get_worm_data_policies(
+                            names=[module.params["rename"]],
+                            context_names=[module.params["context"]],
+                        ).items
+                    )[0]
+                else:
+                    new_policy = list(
+                        blade.get_worm_data_policies(
+                            names=[module.params["rename"]]
+                        ).items
+                    )[0]
             except AttributeError:
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                res = blade.get_worm_data_policies_rules(
-                    policy_names=[module.params["name"]],
-                    names=[
-                        module.params["name"] + "." + str(module.params["before_rule"])
-                    ],
-                )
+                if CONTEXT_API_VERSION in versions:
+                    res = blade.get_worm_data_policies_rules(
+                        policy_names=[module.params["name"]],
+                        names=[
+                            module.params["name"]
+                            + "."
+                            + str(module.params["before_rule"])
+                        ],
+                        context_names=[module.params["context"]],
+                    )
+                else:
+                    res = blade.get_worm_data_policies_rules(
+                        policy_names=[module.params["name"]],
+                        names=[
+                            module.params["name"]
+                            + "."
+                            + str(module.params["before_rule"])
+                        ],
+                    )
                 if res.status_code != 200:
                     module.fail_json(
                         msg="Rule index {0} does not exist.".format(
@@ -4232,9 +4401,18 @@ def main():
     else:
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
-        blade = get_system(module)
         try:
-            policy = list(blade.get_policies(names=[module.params["name"]]).items)[0]
+            if CONTEXT_API_VERSION in versions:
+                policy = list(
+                    blade.get_policies(
+                        names=[module.params["name"]],
+                        context_names=[module.params["context"]],
+                    ).items
+                )[0]
+            else:
+                policy = list(blade.get_policies(names=[module.params["name"]]).items)[
+                    0
+                ]
         except AttributeError:
             policy = None
         if not policy and state == "present":

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -1418,28 +1418,22 @@ def update_smb_client_policy(module, blade):
         if CONTEXT_API_VERSION in versions:
             current_policy_rule = blade.get_smb_client_policies_rules(
                 policy_names=[module.params["name"]],
+                filter="client='" + module.params["client"] + "'",
                 context_names=[module.params["context"]],
             )
         else:
             current_policy_rule = blade.get_smb_client_policies_rules(
                 policy_names=[module.params["name"]],
+                filter="client='" + module.params["client"] + "'",
             )
-        if current_policy_rule.status_code != 200:
-            module.fail_json(
-                msg="Failed to get SMB client policy rules for {0}. Error: {1}".format(
-                    module.params["name"],
-                    get_error_message(current_policy_rule),
-                )
-            )
-        # Match the requested client locally rather than using a server-side
-        # filter, which on some Purity//FB versions returns an error instead
-        # of an empty result set when no matching rule exists.
-        matching_rules = [
-            rule
-            for rule in list(current_policy_rule.items)
-            if rule.client == module.params["client"]
-        ]
-        if not matching_rules:
+        # If the rule lookup fails or returns nothing then no rule exists for
+        # this client yet - some Purity//FB versions return an error rather
+        # than an empty result set - so create it. Otherwise reconcile the
+        # existing rule.
+        if (
+            current_policy_rule.status_code != 200
+            or current_policy_rule.total_item_count == 0
+        ):
             if SMB_ENCRYPT_API_VERSION in versions:
                 rule = SmbClientPolicyRule(
                     client=module.params["client"],
@@ -1494,7 +1488,7 @@ def update_smb_client_policy(module, blade):
                         )
                     )
         else:
-            rules = matching_rules
+            rules = list(current_policy_rule.items)
             cli_count = None
             done = False
             if module.params["client"] == "*":
@@ -1814,28 +1808,22 @@ def update_network_access_policy(module, blade):
         if CONTEXT_API_VERSION in versions:
             current_policy_rule = blade.get_network_access_policies_rules(
                 policy_names=[module.params["name"]],
+                filter="client='" + module.params["client"] + "'",
                 context_names=[module.params["context"]],
             )
         else:
             current_policy_rule = blade.get_network_access_policies_rules(
                 policy_names=[module.params["name"]],
+                filter="client='" + module.params["client"] + "'",
             )
-        if current_policy_rule.status_code != 200:
-            module.fail_json(
-                msg="Failed to get network access policy rules for {0}. Error: {1}".format(
-                    module.params["name"],
-                    get_error_message(current_policy_rule),
-                )
-            )
-        # Match the requested client locally rather than using a server-side
-        # filter, which on some Purity//FB versions returns an error instead
-        # of an empty result set when no matching rule exists.
-        matching_rules = [
-            rule
-            for rule in list(current_policy_rule.items)
-            if rule.client == module.params["client"]
-        ]
-        if not matching_rules:
+        # If the rule lookup fails or returns nothing then no rule exists for
+        # this client yet - some Purity//FB versions return an error rather
+        # than an empty result set - so create it. Otherwise reconcile the
+        # existing rule.
+        if (
+            current_policy_rule.status_code != 200
+            or current_policy_rule.total_item_count == 0
+        ):
             rule = NetworkAccessPolicyRule(
                 client=module.params["client"],
                 effect=module.params["effect"],
@@ -1882,7 +1870,7 @@ def update_network_access_policy(module, blade):
                         )
                     )
         else:
-            rules = matching_rules
+            rules = list(current_policy_rule.items)
             cli_count = None
             done = False
             if module.params["client"] == "*":
@@ -2352,28 +2340,22 @@ def update_nfs_policy(module, blade):
         if CONTEXT_API_VERSION in versions:
             current_policy_rule = blade.get_nfs_export_policies_rules(
                 policy_names=[module.params["name"]],
+                filter="client='" + module.params["client"] + "'",
                 context_names=[module.params["context"]],
             )
         else:
             current_policy_rule = blade.get_nfs_export_policies_rules(
                 policy_names=[module.params["name"]],
+                filter="client='" + module.params["client"] + "'",
             )
-        if current_policy_rule.status_code != 200:
-            module.fail_json(
-                msg="Failed to get NFS export policy rules for {0}. Error: {1}".format(
-                    module.params["name"],
-                    get_error_message(current_policy_rule),
-                )
-            )
-        # Match the requested client locally rather than using a server-side
-        # filter, which on some Purity//FB versions returns an error instead
-        # of an empty result set when no matching rule exists.
-        matching_rules = [
-            rule
-            for rule in list(current_policy_rule.items)
-            if rule.client == module.params["client"]
-        ]
-        if not matching_rules:
+        # If the rule lookup fails or returns nothing then no rule exists for
+        # this client yet - some Purity//FB versions return an error rather
+        # than an empty result set - so create it. Otherwise reconcile the
+        # existing rule.
+        if (
+            current_policy_rule.status_code != 200
+            or current_policy_rule.total_item_count == 0
+        ):
             rule = NfsExportPolicyRule(
                 client=module.params["client"],
                 permission=module.params["permission"],
@@ -2426,7 +2408,7 @@ def update_nfs_policy(module, blade):
                         )
                     )
         else:
-            rules = matching_rules
+            rules = list(current_policy_rule.items)
             cli_count = None
             done = False
             if module.params["client"] == "*":

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -731,7 +731,7 @@ def delete_smb_share_policy(module, blade):
     policy_delete = True
     if module.params["principal"]:
         policy_delete = False
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             prin_rule = blade.get_smb_share_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="principal='" + module.params["principal"] + "'",
@@ -746,7 +746,7 @@ def delete_smb_share_policy(module, blade):
             rule = list(prin_rule.items)[0]
             changed = True
             if not module.check_mode:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.delete_smb_share_policies_rules(
                         names=[rule.name], context_names=[module.params["context"]]
                     )
@@ -764,7 +764,7 @@ def delete_smb_share_policy(module, blade):
     if policy_delete:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.delete_smb_share_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -786,7 +786,7 @@ def rename_smb_share_policy(module, blade):
     changed = True
     versions = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.patch_smb_share_policies(
                 names=[module.params["name"]],
                 policy=SmbSharePolicy(name=module.params["rename"]),
@@ -813,7 +813,7 @@ def create_smb_share_policy(module, blade):
     changed = True
     versions = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.post_smb_share_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -826,7 +826,7 @@ def create_smb_share_policy(module, blade):
                 )
             )
         if not module.params["enabled"]:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.patch_smb_share_policies(
                     policy=SmbSharePolicy(enabled=False),
                     names=[module.params["name"]],
@@ -837,7 +837,7 @@ def create_smb_share_policy(module, blade):
                     policy=SmbSharePolicy(enabled=False), names=[module.params["name"]]
                 )
             if res.status_code != 200:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     blade.delete_smb_share_policies(
                         names=[module.params["name"]],
                         context_names=[module.params["context"]],
@@ -858,7 +858,7 @@ def create_smb_share_policy(module, blade):
                 read=module.params["read"],
                 full_control=module.params["full_control"],
             )
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.post_smb_share_policies_rules(
                     policy_names=[module.params["name"]],
                     rule=rule,
@@ -885,7 +885,7 @@ def update_smb_share_policy(module, blade):
     changed = False
     versions = list(blade.get_versions().items)
     if module.params["principal"]:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             current_policy_rule = blade.get_smb_share_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="principal='" + module.params["principal"] + "'",
@@ -919,7 +919,7 @@ def update_smb_share_policy(module, blade):
                     before_name = (
                         module.params["name"] + "." + str(module.params["before_rule"])
                     )
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.post_smb_share_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -933,7 +933,7 @@ def update_smb_share_policy(module, blade):
                             before_rule_name=before_name,
                         )
                 else:
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.post_smb_share_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -1002,7 +1002,7 @@ def update_smb_share_policy(module, blade):
                         read=module.params["read"],
                         full_control=module.params["full_control"],
                     )
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.patch_smb_share_policies_rules(
                             names=[
                                 module.params["name"] + "." + str(old_policy_rule.index)
@@ -1035,7 +1035,7 @@ def update_smb_share_policy(module, blade):
                     before_name = (
                         module.params["name"] + "." + str(module.params["before_rule"])
                     )
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.patch_smb_share_policies_rules(
                             names=[
                                 module.params["name"] + "." + str(old_policy_rule.index)
@@ -1061,7 +1061,7 @@ def update_smb_share_policy(module, blade):
                                 get_error_message(res),
                             )
                         )
-    if CONTEXT_API_VERSION in versions:
+    if CONTEXT_API_VERSION in versions and module.params["context"]:
         current_policy = list(
             blade.get_smb_share_policies(names=[module.params["name"]]).items,
             context_names=[module.params["context"]],
@@ -1073,7 +1073,7 @@ def update_smb_share_policy(module, blade):
     if current_policy.enabled != module.params["enabled"]:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.patch_smb_share_policies(
                     policy=SmbSharePolicy(enabled=module.params["enabled"]),
                     names=[module.params["name"]],
@@ -1104,7 +1104,7 @@ def delete_smb_client_policy(module, blade):
     policy_delete = True
     if module.params["client"]:
         policy_delete = False
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.get_smb_client_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -1123,7 +1123,7 @@ def delete_smb_client_policy(module, blade):
                 if module.params["client"] == rule.client:
                     changed = True
                     if not module.check_mode:
-                        if CONTEXT_API_VERSION in versions:
+                        if CONTEXT_API_VERSION in versions and module.params["context"]:
                             res = blade.delete_smb_client_policies_rules(
                                 names=[rule.name],
                                 context_names=[module.params["context"]],
@@ -1147,7 +1147,10 @@ def delete_smb_client_policy(module, blade):
                     if cli.client == "*":
                         changed = True
                         if not module.check_mode:
-                            if CONTEXT_API_VERSION in versions:
+                            if (
+                                CONTEXT_API_VERSION in versions
+                                and module.params["context"]
+                            ):
                                 res = blade.delete_smb_client_policies_rules(
                                     names=[cli.name],
                                     context_names=[module.params["context"]],
@@ -1168,7 +1171,7 @@ def delete_smb_client_policy(module, blade):
     if policy_delete:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.delete_smb_client_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -1190,7 +1193,7 @@ def rename_smb_client_policy(module, blade):
     changed = True
     versions = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.patch_smb_client_policies(
                 names=[module.params["name"]],
                 policy=SmbClientPolicy(name=module.params["rename"]),
@@ -1217,7 +1220,7 @@ def create_smb_client_policy(module, blade):
     changed = True
     versions = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.post_smb_client_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -1230,7 +1233,7 @@ def create_smb_client_policy(module, blade):
                 )
             )
         if not module.params["enabled"]:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.patch_smb_client_policies(
                     policy=SmbClientPolicy(enabled=False),
                     names=[module.params["name"]],
@@ -1241,7 +1244,7 @@ def create_smb_client_policy(module, blade):
                     policy=SmbClientPolicy(enabled=False), names=[module.params["name"]]
                 )
             if res.status_code != 200:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     blade.delete_smb_client_policies(
                         names=[module.params["name"]],
                         context_names=[module.params["context"]],
@@ -1269,7 +1272,7 @@ def create_smb_client_policy(module, blade):
                     access=module.params["access"],
                     permission=module.params["permission"],
                 )
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.post_smb_client_policies_rules(
                     policy_names=[module.params["name"]],
                     rule=rule,
@@ -1295,7 +1298,7 @@ def create_network_access_policy(module, blade):
     changed = True
     versions = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.post_network_access_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -1308,7 +1311,7 @@ def create_network_access_policy(module, blade):
                 )
             )
         if not module.params["enabled"]:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.patch_network_access_policies(
                     policy=SmbClientPolicy(enabled=False),
                     names=[module.params["name"]],
@@ -1319,7 +1322,7 @@ def create_network_access_policy(module, blade):
                     policy=SmbClientPolicy(enabled=False), names=[module.params["name"]]
                 )
             if res.status_code != 200:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     blade.delete_network_access_policies(
                         names=[module.params["name"]],
                         context_names=[module.params["context"]],
@@ -1339,7 +1342,7 @@ def create_network_access_policy(module, blade):
                 effect=module.params["effect"],
                 interfaces=module.params["interfaces"],
             )
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.post_network_access_policies_rules(
                     policy_names=[module.params["name"]],
                     rule=rule,
@@ -1368,7 +1371,7 @@ def create_worm_data_policy(module, blade):
         min_retention = time_to_milliseconds(module.params["min_retention"])
         max_retention = time_to_milliseconds(module.params["max_retention"])
         default_retention = time_to_milliseconds(module.params["default_retention"])
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.post_worm_data_policies(
                 policy=WormDataPolicy(
                     enabled=module.params["enabled"],
@@ -1394,7 +1397,7 @@ def create_worm_data_policy(module, blade):
                 names=[module.params["name"]],
             )
         if res.status_code != 200:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 blade.delete_worm_data_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -1415,7 +1418,7 @@ def update_smb_client_policy(module, blade):
     changed = False
     versions = list(blade.get_versions().items)
     if module.params["client"]:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             current_policy_rule = blade.get_smb_client_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -1453,7 +1456,7 @@ def update_smb_client_policy(module, blade):
                     before_name = (
                         module.params["name"] + "." + str(module.params["before_rule"])
                     )
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.post_smb_client_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -1467,7 +1470,7 @@ def update_smb_client_policy(module, blade):
                             before_rule_name=before_name,
                         )
                 else:
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.post_smb_client_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -1513,7 +1516,10 @@ def update_smb_client_policy(module, blade):
                     changed = True
                     if not module.check_mode:
                         if module.params["before_rule"]:
-                            if CONTEXT_API_VERSION in versions:
+                            if (
+                                CONTEXT_API_VERSION in versions
+                                and module.params["context"]
+                            ):
                                 res = blade.post_smb_client_policies_rules(
                                     policy_names=[module.params["name"]],
                                     rule=rule,
@@ -1535,7 +1541,10 @@ def update_smb_client_policy(module, blade):
                                     ),
                                 )
                         else:
-                            if CONTEXT_API_VERSION in versions:
+                            if (
+                                CONTEXT_API_VERSION in versions
+                                and module.params["context"]
+                            ):
                                 res = blade.post_smb_client_policies_rules(
                                     policy_names=[module.params["name"]],
                                     rule=rule,
@@ -1606,7 +1615,7 @@ def update_smb_client_policy(module, blade):
                                 client=module.params["client"],
                                 permission=module.params["permission"],
                             )
-                        if CONTEXT_API_VERSION in versions:
+                        if CONTEXT_API_VERSION in versions and module.params["context"]:
                             res = blade.patch_smb_client_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -1645,7 +1654,7 @@ def update_smb_client_policy(module, blade):
                             + "."
                             + str(module.params["before_rule"])
                         )
-                        if CONTEXT_API_VERSION in versions:
+                        if CONTEXT_API_VERSION in versions and module.params["context"]:
                             res = blade.patch_smb_client_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -1675,7 +1684,7 @@ def update_smb_client_policy(module, blade):
                                     get_error_message(res),
                                 )
                             )
-    if CONTEXT_API_VERSION in versions:
+    if CONTEXT_API_VERSION in versions and module.params["context"]:
         current_policy = list(
             blade.get_smb_client_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -1688,7 +1697,7 @@ def update_smb_client_policy(module, blade):
     if current_policy.enabled != module.params["enabled"]:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.patch_smb_client_policies(
                     policy=SmbClientPolicy(enabled=module.params["enabled"]),
                     names=[module.params["name"]],
@@ -1719,7 +1728,7 @@ def delete_nfs_policy(module, blade):
     policy_delete = True
     if module.params["client"]:
         policy_delete = False
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.get_nfs_export_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -1738,7 +1747,7 @@ def delete_nfs_policy(module, blade):
                 if module.params["client"] == rule.client:
                     changed = True
                     if not module.check_mode:
-                        if CONTEXT_API_VERSION in versions:
+                        if CONTEXT_API_VERSION in versions and module.params["context"]:
                             res = blade.delete_nfs_export_policies_rules(
                                 names=[rule.name],
                                 context_names=[module.params["context"]],
@@ -1762,7 +1771,10 @@ def delete_nfs_policy(module, blade):
                     if cli.client == "*":
                         changed = True
                         if not module.check_mode:
-                            if CONTEXT_API_VERSION in versions:
+                            if (
+                                CONTEXT_API_VERSION in versions
+                                and module.params["context"]
+                            ):
                                 res = blade.delete_nfs_export_policies_rules(
                                     names=[cli.name],
                                     context_names=[module.params["context"]],
@@ -1783,7 +1795,7 @@ def delete_nfs_policy(module, blade):
     if policy_delete:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.delete_nfs_export_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -1805,7 +1817,7 @@ def update_network_access_policy(module, blade):
     changed = False
     versions = list(blade.get_versions().items)
     if module.params["client"]:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             current_policy_rule = blade.get_network_access_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -1835,7 +1847,7 @@ def update_network_access_policy(module, blade):
                     before_name = (
                         module.params["name"] + "." + str(module.params["before_rule"])
                     )
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.post_network_access_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -1849,7 +1861,7 @@ def update_network_access_policy(module, blade):
                             before_rule_name=before_name,
                         )
                 else:
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.post_network_access_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -1887,7 +1899,10 @@ def update_network_access_policy(module, blade):
                     changed = True
                     if not module.check_mode:
                         if module.params["before_rule"]:
-                            if CONTEXT_API_VERSION in versions:
+                            if (
+                                CONTEXT_API_VERSION in versions
+                                and module.params["context"]
+                            ):
                                 res = blade.post_network_access_policies_rules(
                                     policy_names=[module.params["name"]],
                                     rule=rule,
@@ -1909,7 +1924,10 @@ def update_network_access_policy(module, blade):
                                     ),
                                 )
                         else:
-                            if CONTEXT_API_VERSION in versions:
+                            if (
+                                CONTEXT_API_VERSION in versions
+                                and module.params["context"]
+                            ):
                                 res = blade.post_network_access_policies_rules(
                                     policy_names=[module.params["name"]],
                                     rule=rule,
@@ -1961,7 +1979,7 @@ def update_network_access_policy(module, blade):
                             effect=module.params["effect"],
                             interfaces=module.params["interfaces"],
                         )
-                        if CONTEXT_API_VERSION in versions:
+                        if CONTEXT_API_VERSION in versions and module.params["context"]:
                             res = blade.patch_network_access_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -2000,7 +2018,7 @@ def update_network_access_policy(module, blade):
                             + "."
                             + str(module.params["before_rule"])
                         )
-                        if CONTEXT_API_VERSION in versions:
+                        if CONTEXT_API_VERSION in versions and module.params["context"]:
                             res = blade.patch_network_access_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -2030,7 +2048,7 @@ def update_network_access_policy(module, blade):
                                     get_error_message(res),
                                 )
                             )
-    if CONTEXT_API_VERSION in versions:
+    if CONTEXT_API_VERSION in versions and module.params["context"]:
         current_policy = list(
             blade.get_network_access_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -2043,7 +2061,7 @@ def update_network_access_policy(module, blade):
     if current_policy.enabled != module.params["enabled"]:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.patch_network_access_policies(
                     policy=NetworkAccessPolicy(enabled=module.params["enabled"]),
                     names=[module.params["name"]],
@@ -2074,7 +2092,7 @@ def delete_network_access_policy(module, blade):
     policy_delete = True
     if module.params["client"]:
         policy_delete = False
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.get_network_access_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -2093,7 +2111,7 @@ def delete_network_access_policy(module, blade):
                 if module.params["client"] == rule.client:
                     changed = True
                     if not module.check_mode:
-                        if CONTEXT_API_VERSION in versions:
+                        if CONTEXT_API_VERSION in versions and module.params["context"]:
                             res = blade.delete_network_access_policies_rules(
                                 names=[rule.name],
                                 context_names=[module.params["context"]],
@@ -2117,7 +2135,10 @@ def delete_network_access_policy(module, blade):
                     if cli.client == "*":
                         changed = True
                         if not module.check_mode:
-                            if CONTEXT_API_VERSION in versions:
+                            if (
+                                CONTEXT_API_VERSION in versions
+                                and module.params["context"]
+                            ):
                                 res = blade.delete_network_access_policies_rules(
                                     names=[cli.name],
                                     context_names=[module.params["context"]],
@@ -2138,7 +2159,7 @@ def delete_network_access_policy(module, blade):
     if policy_delete:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.delete_network_Access_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -2162,7 +2183,7 @@ def delete_worm_data_policy(module, blade):
     changed = True
     versions = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.delete_worm_data_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -2191,7 +2212,7 @@ def rename_network_access_policy(module, blade):
     changed = True
     versions = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.patch_network_access_policies(
                 names=[module.params["name"]],
                 policy=NfsExportPolicy(name=module.params["rename"]),
@@ -2219,7 +2240,7 @@ def rename_nfs_policy(module, blade):
     changed = True
     versions = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.patch_nfs_export_policies(
                 names=[module.params["name"]],
                 policy=NfsExportPolicy(name=module.params["rename"]),
@@ -2246,7 +2267,7 @@ def update_worm_data_policy(module, blade):
 
     changed = False
     versions = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in versions:
+    if CONTEXT_API_VERSION in versions and module.params["context"]:
         current_policy_config = list(
             blade.get_worm_data_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -2311,7 +2332,7 @@ def update_worm_data_policy(module, blade):
                 max_retention=new_policy["max_retention"],
                 default_retention=new_policy["default_retention"],
             )
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.patch_worm_data_policies(
                     names=[module.params["name"]],
                     policy=worm_policy,
@@ -2337,7 +2358,7 @@ def update_nfs_policy(module, blade):
     changed = False
     versions = list(blade.get_versions().items)
     if module.params["client"]:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             current_policy_rule = blade.get_nfs_export_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -2373,7 +2394,7 @@ def update_nfs_policy(module, blade):
                     before_name = (
                         module.params["name"] + "." + str(module.params["before_rule"])
                     )
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.post_nfs_export_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -2387,7 +2408,7 @@ def update_nfs_policy(module, blade):
                             before_rule_name=before_name,
                         )
                 else:
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.post_nfs_export_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -2431,7 +2452,10 @@ def update_nfs_policy(module, blade):
                     changed = True
                     if not module.check_mode:
                         if module.params["before_rule"]:
-                            if CONTEXT_API_VERSION in versions:
+                            if (
+                                CONTEXT_API_VERSION in versions
+                                and module.params["context"]
+                            ):
                                 res = blade.post_nfs_export_policies_rules(
                                     policy_names=[module.params["name"]],
                                     rule=rule,
@@ -2453,7 +2477,10 @@ def update_nfs_policy(module, blade):
                                     ),
                                 )
                         else:
-                            if CONTEXT_API_VERSION in versions:
+                            if (
+                                CONTEXT_API_VERSION in versions
+                                and module.params["context"]
+                            ):
                                 res = blade.post_nfs_export_policies_rules(
                                     policy_names=[module.params["name"]],
                                     rule=rule,
@@ -2541,7 +2568,7 @@ def update_nfs_policy(module, blade):
                             secure=module.params["secure"],
                             security=module.params["security"],
                         )
-                        if CONTEXT_API_VERSION in versions:
+                        if CONTEXT_API_VERSION in versions and module.params["context"]:
                             res = blade.patch_nfs_export_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -2580,7 +2607,7 @@ def update_nfs_policy(module, blade):
                             + "."
                             + str(module.params["before_rule"])
                         )
-                        if CONTEXT_API_VERSION in versions:
+                        if CONTEXT_API_VERSION in versions and module.params["context"]:
                             res = blade.patch_nfs_export_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -2610,7 +2637,7 @@ def update_nfs_policy(module, blade):
                                     get_error_message(res),
                                 )
                             )
-    if CONTEXT_API_VERSION in versions:
+    if CONTEXT_API_VERSION in versions and module.params["context"]:
         current_policy = list(
             blade.get_nfs_export_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -2623,7 +2650,7 @@ def update_nfs_policy(module, blade):
     if current_policy.enabled != module.params["enabled"]:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.patch_nfs_export_policies(
                     policy=NfsExportPolicy(enabled=module.params["enabled"]),
                     names=[module.params["name"]],
@@ -2648,7 +2675,7 @@ def create_nfs_policy(module, blade):
     changed = True
     versions = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.post_nfs_export_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -2661,7 +2688,7 @@ def create_nfs_policy(module, blade):
                 )
             )
         if not module.params["enabled"]:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.patch_nfs_export_policies(
                     policy=NfsExportPolicy(enabled=False),
                     names=[module.params["name"]],
@@ -2672,7 +2699,7 @@ def create_nfs_policy(module, blade):
                     policy=NfsExportPolicy(enabled=False), names=[module.params["name"]]
                 )
             if res.status_code != 200:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     blade.delete_nfs_export_policies(
                         names=[module.params["name"]],
                         context_names=[module.params["context"]],
@@ -2696,7 +2723,7 @@ def create_nfs_policy(module, blade):
                 secure=module.params["secure"],
                 security=module.params["security"],
             )
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.post_nfs_export_policies_rules(
                     policy_names=[module.params["name"]],
                     rule=rule,
@@ -2733,7 +2760,7 @@ def delete_os_policy(module, blade):
     policy_delete = True
     if module.params["rule"]:
         policy_delete = False
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.get_object_store_access_policies_rules(
                 policy_names=[policy_name],
                 names=[module.params["rule"]],
@@ -2746,7 +2773,7 @@ def delete_os_policy(module, blade):
         if res.status_code == 200 and res.total_item_count != 0:
             changed = True
             if not module.check_mode:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.delete_object_store_access_policies_rules(
                         policy_names=[policy_name],
                         names=[module.params["rule"]],
@@ -2766,7 +2793,7 @@ def delete_os_policy(module, blade):
     if module.params["user"]:
         member_name = module.params["account"] + "/" + module.params["user"]
         policy_delete = False
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.get_object_store_access_policies_object_store_users(
                 policy_names=[policy_name],
                 member_names=[member_name],
@@ -2780,7 +2807,7 @@ def delete_os_policy(module, blade):
             changed = True
             if not module.check_mode:
                 member_name = module.params["account"] + "/" + module.params["user"]
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.delete_object_store_access_policies_object_store_users(
                         policy_names=[policy_name],
                         member_names=[member_name],
@@ -2800,7 +2827,7 @@ def delete_os_policy(module, blade):
     if policy_delete:
         if module.params["account"].lower() == "pure:policy":
             module.fail_json(msg="System-Wide policies cannot be deleted.")
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             policy_users = list(
                 blade.get_object_store_access_policies_object_store_users(
                     policy_names=[policy_name], context_names=[module.params["context"]]
@@ -2815,7 +2842,7 @@ def delete_os_policy(module, blade):
         if len(policy_users) == 0:
             changed = True
             if not module.check_mode:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.delete_object_store_access_policies(
                         names=[policy_name], context_names=[module.params["context"]]
                     )
@@ -2832,7 +2859,7 @@ def delete_os_policy(module, blade):
                 changed = True
                 if not module.check_mode:
                     for user in policy_users:
-                        if CONTEXT_API_VERSION in versions:
+                        if CONTEXT_API_VERSION in versions and module.params["context"]:
                             res = blade.delete_object_store_access_policies_object_store_users(
                                 member_names=[user.member.name],
                                 policy_names=[policy_name],
@@ -2852,7 +2879,7 @@ def delete_os_policy(module, blade):
                                     get_error_message(res),
                                 )
                             )
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.delete_object_store_access_policies(
                             names=[policy_name],
                             context_names=[module.params["context"]],
@@ -2882,7 +2909,7 @@ def create_os_policy(module, blade):
     policy_name = module.params["account"] + "/" + module.params["name"]
     versions = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.post_object_store_access_policies(
                 names=[policy_name],
                 policy=ObjectStoreAccessPolicyPost(description=module.params["desc"]),
@@ -2921,7 +2948,7 @@ def create_os_policy(module, blade):
                     resources=module.params["object_resources"],
                     conditions=conditions,
                 )
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.post_object_store_access_policies_rules(
                     policy_names=policy_name,
                     names=[module.params["rule"]],
@@ -2944,7 +2971,7 @@ def create_os_policy(module, blade):
                 )
         if module.params["user"]:
             member_name = module.params["account"] + "/" + module.params["user"]
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.post_object_store_access_policies_object_store_users(
                     member_names=[member_name],
                     policy_names=[policy_name],
@@ -2969,7 +2996,7 @@ def update_os_policy(module, blade):
     versions = list(blade.get_versions().items)
     policy_name = module.params["account"] + "/" + module.params["name"]
     if module.params["rule"]:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             current_policy_rule = blade.get_object_store_access_policies_rules(
                 policy_names=[policy_name],
                 names=[module.params["rule"]],
@@ -2992,7 +3019,7 @@ def update_os_policy(module, blade):
                     resources=module.params["object_resources"],
                     conditions=conditions,
                 )
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.post_object_store_access_policies_rules(
                         policy_names=policy_name,
                         names=[module.params["rule"]],
@@ -3070,7 +3097,7 @@ def update_os_policy(module, blade):
                         resources=new_rule["resources"],
                         conditions=conditions,
                     )
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.patch_object_store_access_policies_rules(
                             policy_names=[policy_name],
                             names=[module.params["rule"]],
@@ -3099,7 +3126,7 @@ def update_os_policy(module, blade):
                         )
     if module.params["user"]:
         member_name = module.params["account"] + "/" + module.params["user"]
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.get_object_store_access_policies_object_store_users(
                 policy_names=[policy_name],
                 member_names=[member_name],
@@ -3114,7 +3141,7 @@ def update_os_policy(module, blade):
         ):
             changed = True
             if not module.check_mode:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.post_object_store_access_policies_object_store_users(
                         member_names=[member_name],
                         policy_names=[policy_name],
@@ -3140,7 +3167,7 @@ def copy_os_policy_rule(module, blade):
     policy_name = module.params["account"] + "/" + module.params["name"]
     if not module.params["target_rule"]:
         module.params["target_rule"] = module.params["rule"]
-    if CONTEXT_API_VERSION in versions:
+    if CONTEXT_API_VERSION in versions and module.params["context"]:
         res = blade.get_object_store_access_policies_rules(
             policy_names=[module.params["target"]],
             names=[module.params["target_rule"]],
@@ -3156,7 +3183,7 @@ def copy_os_policy_rule(module, blade):
                 module.params["target_rule"], policy_name
             )
         )
-    if CONTEXT_API_VERSION in versions:
+    if CONTEXT_API_VERSION in versions and module.params["context"]:
         current_rule = list(
             blade.get_object_store_access_policies_rules(
                 policy_names=[policy_name],
@@ -3181,7 +3208,7 @@ def copy_os_policy_rule(module, blade):
             resources=current_rule.resources,
             conditions=conditions,
         )
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.post_object_store_access_policies_rules(
                 policy_names=module.params["target"],
                 names=[module.params["target_rule"]],
@@ -3228,7 +3255,7 @@ def delete_snap_policy(module, blade):
     ):
         rule_delete = True
     if rule_delete:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             current_rules = list(
                 blade.get_policies(
                     names=[module.params["name"]],
@@ -3272,7 +3299,7 @@ def delete_snap_policy(module, blade):
                 changed = True
                 attr = SnapshotPolicyPatch(remove_rules=[delete_rule])
                 if not module.check_mode:
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.patch_policies(
                             destroy_snapshots=module.params["destroy_snapshots"],
                             names=[module.params["name"]],
@@ -3294,7 +3321,7 @@ def delete_snap_policy(module, blade):
     else:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.delete_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -3388,7 +3415,7 @@ def create_snap_policy(module, blade):
                 )
         else:
             attr = Policy(enabled=module.params["enabled"])
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.post_policies(
                 names=[module.params["name"]],
                 policy=attr,
@@ -3404,7 +3431,7 @@ def create_snap_policy(module, blade):
             )
         if module.params["filesystem"]:
             for filesystem in module.params["filesystem"]:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.get_file_systems(
                         names=[filesystem],
                         destroyed=False,
@@ -3417,7 +3444,7 @@ def create_snap_policy(module, blade):
                         msg="Filesystems to assign to {0} does not "
                         "exist, or is deleted.".format(module.params["name"])
                     )
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.post_policies_file_systems(
                         policy_names=[module.params["name"]],
                         member_names=[filesystem],
@@ -3438,7 +3465,7 @@ def create_snap_policy(module, blade):
         if module.params["replica_link"]:
             repl_link = []
             for link in module.params["replica_link"]:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.get_file_system_replica_links(
                         local_file_system_names=[link],
                         context_names=[module.params["context"]],
@@ -3453,7 +3480,7 @@ def create_snap_policy(module, blade):
                     )
                 else:
                     repl_link = list(res.items)[0]
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.post_policies_file_system_replica_links(
                         policy_names=[module.params["name"]],
                         local_file_system_names=[link],
@@ -3503,7 +3530,7 @@ def update_snap_policy(module, blade):
         module.fail_json(msg="`timezone` requires `at` to be provided.")
     if module.params["at"] and not module.params["every"]:
         module.fail_json(msg="`at` requires `every` to be provided.")
-    if CONTEXT_API_VERSION in versions:
+    if CONTEXT_API_VERSION in versions and module.params["context"]:
         current_rules = list(
             blade.get_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -3612,7 +3639,7 @@ def update_snap_policy(module, blade):
                     )
             else:
                 attr = SnapshotPolicyPatch(enabled=module.params["enabled"])
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.patch_policies(
                     names=[module.params["name"]],
                     policy=attr,
@@ -3632,7 +3659,7 @@ def update_snap_policy(module, blade):
 
     if module.params["filesystem"]:
         current_filesystems = []
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             policy_fs_details = list(
                 blade.get_policies_file_systems(
                     policy_names=[module.params["name"]],
@@ -3655,7 +3682,7 @@ def update_snap_policy(module, blade):
             ]
             for new_fs in difference_set:
                 changed = True
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.get_file_systems(
                         names=[new_fs],
                         destroyed=False,
@@ -3668,7 +3695,7 @@ def update_snap_policy(module, blade):
                         msg="Filesystem {0} to assign to {1} does not "
                         "exist, or is deleted.".format(new_fs, module.params["name"])
                     )
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.post_policies_file_systems(
                         policy_names=[module.params["name"]],
                         member_names=[new_fs],
@@ -3690,7 +3717,7 @@ def update_snap_policy(module, blade):
             for old_fs in module.params["filesystem"]:
                 if old_fs in current_filesystems:
                     changed = True
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.delete_policies_file_systems(
                             policy_names=[module.params["name"]],
                             member_names=[old_fs],
@@ -3710,7 +3737,7 @@ def update_snap_policy(module, blade):
                         )
     if module.params["replica_link"]:
         current_rls = []
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             policy_rl_details = list(
                 blade.get_policies_file_system_replica_links(
                     policy_names=[module.params["name"]],
@@ -3733,7 +3760,7 @@ def update_snap_policy(module, blade):
             ]
             for new_rl in difference_set:
                 changed = True
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.get_file_systems_replica_links(
                         names=[new_rl], context_names=[module.params["context"]]
                     )
@@ -3744,7 +3771,7 @@ def update_snap_policy(module, blade):
                         msg="Replica link {0} to assign to {1} does not "
                         "exist, or is deleted.".format(new_rl, module.params["name"])
                     )
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.post_policies_file_system_replica_links(
                         policy_names=[module.params["name"]],
                         member_names=[new_rl],
@@ -3766,7 +3793,7 @@ def update_snap_policy(module, blade):
             for old_rl in module.params["replica_link"]:
                 if old_rl in current_rls:
                     changed = True
-                    if CONTEXT_API_VERSION in versions:
+                    if CONTEXT_API_VERSION in versions and module.params["context"]:
                         res = blade.delete_policies_file_system_replica_links(
                             policy_names=[module.params["name"]],
                             member_names=[old_rl],
@@ -3939,13 +3966,17 @@ def main():
     blade = get_system(module)
     versions = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in versions and not module.params["context"]:
-        # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        # Only default the context to the local array name when this array is a
+        # member of a fleet. A standalone array is "not in a fleet" and rejects
+        # fleet context, so leave context unset - no context_names is then sent.
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
     if module.params["policy_type"] == "access":
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 policy = list(
                     blade.get_object_store_access_policies(
                         names=[module.params["account"] + "/" + module.params["name"]],
@@ -3962,7 +3993,7 @@ def main():
             policy = None
         if module.params["user"]:
             member_name = module.params["account"] + "/" + module.params["user"]
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.get_object_store_users(
                     names=[member_name], context_names=[module.params["context"]]
                 )
@@ -3987,7 +4018,7 @@ def main():
                 module.fail_json(
                     msg='Incorrect format for target policy. Must be "<account>/<name>"'
                 )
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.get_object_store_access_policies(
                     names=[module.params["target"]],
                     context_names=[module.params["context"]],
@@ -4016,7 +4047,7 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 policy = list(
                     blade.get_nfs_export_policies(
                         names=[module.params["name"]],
@@ -4031,7 +4062,7 @@ def main():
             policy = None
         if module.params["rename"]:
             try:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     new_policy = list(
                         blade.get_nfs_export_policies(
                             names=[module.params["rename"]],
@@ -4048,7 +4079,7 @@ def main():
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.get_nfs_export_policies_rules(
                         policy_names=[module.params["name"]],
                         names=[
@@ -4094,7 +4125,7 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 policy = list(
                     blade.get_smb_client_policies(
                         names=[module.params["name"]],
@@ -4109,7 +4140,7 @@ def main():
             policy = None
         if module.params["rename"]:
             try:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     new_policy = list(
                         blade.get_smb_client_policies(
                             names=[module.params["rename"]],
@@ -4126,7 +4157,7 @@ def main():
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.get_smb_client_policies_rules(
                         policy_names=[module.params["name"]],
                         names=[
@@ -4172,7 +4203,7 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 policy = list(
                     blade.get_smb_share_policies(
                         names=[module.params["name"]],
@@ -4187,7 +4218,7 @@ def main():
             policy = None
         if module.params["rename"]:
             try:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     new_policy = list(
                         blade.get_smb_share_policies(
                             names=[module.params["rename"]],
@@ -4204,7 +4235,7 @@ def main():
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.get_smb_share_policies_rules(
                         policy_names=[module.params["name"]],
                         names=[
@@ -4250,7 +4281,7 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 policy = list(
                     blade.get_network_access_policies(
                         names=[module.params["name"]],
@@ -4267,7 +4298,7 @@ def main():
             policy = None
         if module.params["rename"]:
             try:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     new_policy = list(
                         blade.get_network_access_policies(
                             names=[module.params["rename"]],
@@ -4284,7 +4315,7 @@ def main():
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.get_network_access_policies_rules(
                         policy_names=[module.params["name"]],
                         names=[
@@ -4330,7 +4361,7 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 policy = list(
                     blade.get_worm_data_policies(
                         names=[module.params["name"]],
@@ -4345,7 +4376,7 @@ def main():
             policy = None
         if module.params["rename"]:
             try:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     new_policy = list(
                         blade.get_worm_data_policies(
                             names=[module.params["rename"]],
@@ -4362,7 +4393,7 @@ def main():
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.get_worm_data_policies_rules(
                         policy_names=[module.params["name"]],
                         names=[
@@ -4400,7 +4431,7 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 policy = list(
                     blade.get_policies(
                         names=[module.params["name"]],

--- a/tests/unit/plugins/modules/test_purefb_policy.py
+++ b/tests/unit/plugins/modules/test_purefb_policy.py
@@ -1,0 +1,97 @@
+# Copyright: (c) 2026, Everpure Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefb_policy context_names / fleet handling."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+from unittest.mock import Mock, MagicMock
+
+# Mock external dependencies before importing module
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flashblade"] = MagicMock()
+sys.modules["urllib3"] = MagicMock()
+sys.modules["distro"] = MagicMock()
+sys.modules["grp"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["syslog"] = MagicMock()
+mock_termios = MagicMock()
+mock_termios.TCSAFLUSH = 2
+sys.modules["termios"] = mock_termios
+sys.modules["tty"] = MagicMock()
+
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.purestorage"] = MagicMock()
+sys.modules["ansible_collections.purestorage.flashblade"] = MagicMock()
+sys.modules["ansible_collections.purestorage.flashblade.plugins"] = MagicMock()
+sys.modules["ansible_collections.purestorage.flashblade.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules[
+    "ansible_collections.purestorage.flashblade.plugins.module_utils.purefb"
+] = MagicMock()
+sys.modules[
+    "ansible_collections.purestorage.flashblade.plugins.module_utils.common"
+] = MagicMock()
+sys.modules[
+    "ansible_collections.purestorage.flashblade.plugins.module_utils.version"
+] = MagicMock()
+sys.modules[
+    "ansible_collections.purestorage.flashblade.plugins.module_utils.time_utils"
+] = MagicMock()
+
+from plugins.modules.purefb_policy import rename_smb_share_policy
+
+
+def _module(context):
+    module = Mock()
+    module.check_mode = False
+    module.params = {
+        "name": "share_pol",
+        "rename": "share_pol2",
+        "context": context,
+    }
+    module.fail_json = Mock(side_effect=SystemExit("fail_json called"))
+    module.exit_json = Mock()
+    return module
+
+
+def _blade():
+    blade = Mock()
+    # Array supports the context API version (2.17+)
+    blade.get_versions.return_value.items = ["2.17"]
+    ok = Mock()
+    ok.status_code = 200
+    blade.patch_smb_share_policies.return_value = ok
+    return blade
+
+
+class TestPolicyContextGating:
+    """context_names must only be sent when a context is set."""
+
+    def test_no_context_omits_context_names(self):
+        """Standalone array (no context) must not send context_names."""
+        module = _module(context="")
+        blade = _blade()
+
+        rename_smb_share_policy(module, blade)
+
+        blade.patch_smb_share_policies.assert_called_once()
+        assert "context_names" not in blade.patch_smb_share_policies.call_args[1]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    def test_with_context_sends_context_names(self):
+        """When a context is set, context_names must be sent."""
+        module = _module(context="member-array")
+        blade = _blade()
+
+        rename_smb_share_policy(module, blade)
+
+        blade.patch_smb_share_policies.assert_called_once()
+        assert blade.patch_smb_share_policies.call_args[1]["context_names"] == [
+            "member-array"
+        ]


### PR DESCRIPTION
##### SUMMARY
It appears that in the latest Purity//FB releases if `context_names` is not provided with a real name, rather than `""` as previously, this will cause an error.

This patch fixes that by forcing the `context` in the params to be the local FlashBlade's name if not supplied in the playbook.

Additonally add missing checks for context_names in the `main()` function.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_policy.py