### PR TITLE
Default context to local array name across modules

### DIFF
--- a/changelogs/fragments/544_context_default.yaml
+++ b/changelogs/fragments/544_context_default.yaml
@@ -1,0 +1,16 @@
+bugfixes:
+  - purefb_bucket - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_bucket_access - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_bucket_replica - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_connect - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_export - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_fs - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_groupquota - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_lifecycle - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_remote_cred - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_s3acc - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_s3user - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_snap - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_userpolicy - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_userquota - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases
+  - purefb_virtualhost - Default context to the local array name to avoid errors from an empty context_names on newer Purity//FB releases

--- a/plugins/modules/purefb_bucket.py
+++ b/plugins/modules/purefb_bucket.py
@@ -949,6 +949,9 @@ def main():
     state = module.params["state"]
     blade = get_system(module)
     api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
 
     # From REST 2.12 classic is no longer the default mode
     if MODE_VERSION in api_version:

--- a/plugins/modules/purefb_bucket_access.py
+++ b/plugins/modules/purefb_bucket_access.py
@@ -616,6 +616,9 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
     blade = get_system(module)
     api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
     if MIN_API_VERSION not in api_version:
         module.fail_json(
             msg=(

--- a/plugins/modules/purefb_bucket_replica.py
+++ b/plugins/modules/purefb_bucket_replica.py
@@ -352,6 +352,10 @@ def main():
     state = module.params["state"]
     module.params["name"] = module.params["name"].lower()
     blade = get_system(module)
+    api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
 
     local_bucket = get_local_bucket(module, blade)
     local_replica_link = get_local_rl(module, blade)

--- a/plugins/modules/purefb_connect.py
+++ b/plugins/modules/purefb_connect.py
@@ -464,6 +464,10 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
+    api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
 
     if module.params["default_limit"]:
         if (

--- a/plugins/modules/purefb_export.py
+++ b/plugins/modules/purefb_export.py
@@ -331,6 +331,9 @@ def main():
     state = module.params["state"]
     blade = get_system(module)
     api_version = list(blade.get_versions().items)
+    if MIN_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
     server_exists = bool(
         blade.get_servers(names=[module.params["server"]]).status_code == 200
     )

--- a/plugins/modules/purefb_fs.py
+++ b/plugins/modules/purefb_fs.py
@@ -1270,6 +1270,10 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
+    api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
 
     # Check if filesystem exists
     # If realm is provided and filesystem name doesn't include realm prefix,

--- a/plugins/modules/purefb_groupquota.py
+++ b/plugins/modules/purefb_groupquota.py
@@ -368,6 +368,10 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
+    api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
     fsys = get_filesystem(module, blade)
     if not fsys:
         module.fail_json(

--- a/plugins/modules/purefb_lifecycle.py
+++ b/plugins/modules/purefb_lifecycle.py
@@ -397,6 +397,9 @@ def main():
     state = module.params["state"]
     blade = get_system(module)
     api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
 
     if module.params["keep_previous_for"] and not module.params["keep_previous_for"][
         -1:

--- a/plugins/modules/purefb_remote_cred.py
+++ b/plugins/modules/purefb_remote_cred.py
@@ -263,6 +263,10 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)
+    api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
     target = get_connected(module, blade)
 
     if not target:

--- a/plugins/modules/purefb_s3acc.py
+++ b/plugins/modules/purefb_s3acc.py
@@ -429,6 +429,10 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
+    api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
 
     if module.params["quota"] or module.params["default_quota"]:
         if not HAS_PYPURECLIENT:

--- a/plugins/modules/purefb_s3user.py
+++ b/plugins/modules/purefb_s3user.py
@@ -638,6 +638,10 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
+    api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
 
     upper = False
     for element in module.params["account"]:

--- a/plugins/modules/purefb_snap.py
+++ b/plugins/modules/purefb_snap.py
@@ -447,6 +447,9 @@ def main():
     state = module.params["state"]
     blade = get_system(module)
     api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
 
     if SNAP_NOW_API not in api_version and module.params["now"]:
         module.fail_json(

--- a/plugins/modules/purefb_userpolicy.py
+++ b/plugins/modules/purefb_userpolicy.py
@@ -313,6 +313,10 @@ def main():
     )
 
     blade = get_system(module)
+    api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
 
     state = module.params["state"]
     if (

--- a/plugins/modules/purefb_userquota.py
+++ b/plugins/modules/purefb_userquota.py
@@ -358,6 +358,10 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
+    versions = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in versions and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
     fsys = get_filesystem(module, blade)
     if not fsys:
         module.fail_json(

--- a/plugins/modules/purefb_virtualhost.py
+++ b/plugins/modules/purefb_virtualhost.py
@@ -138,6 +138,9 @@ def main():
 
     blade = get_system(module)
     api_version = list(blade.get_versions().items)
+    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        module.params["context"] = list(blade.get_arrays().items)[0].name
     state = module.params["state"]
 
     if CONTEXT_API_VERSION in api_version:

--- a/tests/unit/plugins/modules/test_purefb_fs.py
+++ b/tests/unit/plugins/modules/test_purefb_fs.py
@@ -224,6 +224,11 @@ class TestPurefbFs:
         mock_blade = Mock()
         mock_get_system.return_value = mock_blade
 
+        # Mock API version
+        mock_version = Mock()
+        mock_version.version = "2.0"
+        mock_blade.get_versions.return_value.items = [mock_version]
+
         # Mock existing filesystem
         mock_fs = Mock()
         mock_fs.destroyed = False
@@ -263,6 +268,11 @@ class TestPurefbFs:
 
         mock_blade = Mock()
         mock_get_system.return_value = mock_blade
+
+        # Mock API version
+        mock_version = Mock()
+        mock_version.version = "2.0"
+        mock_blade.get_versions.return_value.items = [mock_version]
 
         # Mock destroyed filesystem
         mock_fs = Mock()
@@ -480,6 +490,11 @@ class TestPurefbFs:
         mock_blade = Mock()
         mock_get_system.return_value = mock_blade
         mock_get_filesystem.return_value = None  # Filesystem doesn't exist
+
+        # Mock API version
+        mock_version = Mock()
+        mock_version.version = "2.0"
+        mock_blade.get_versions.return_value.items = [mock_version]
 
         # Call main
         main()


### PR DESCRIPTION

##### SUMMARY
Newer Purity//FB releases reject an empty context_names rather than treating it as the local array. Apply the same fix used in purefb_policy to every module that passes context_names: when the context parameter is not supplied, default it to the local array name. purefb_export gates on its MIN_API_VERSION constant since it has no CONTEXT_API_VERSION.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
multiple