### PR TITLE
Allow deleting a bucket replica link without its buckets

### DIFF
--- a/changelogs/fragments/546_bucket_replica_delete.yaml
+++ b/changelogs/fragments/546_bucket_replica_delete.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefb_bucket_replica - Allow a replica link to be removed when its local bucket no longer exists (https://github.com/Everpure-Ansible/FlashBlade-Collection/issues/545)

--- a/plugins/modules/purefb_bucket_replica.py
+++ b/plugins/modules/purefb_bucket_replica.py
@@ -357,10 +357,19 @@ def main():
         # If no context is provided set the context to the local array name
         module.params["context"] = list(blade.get_arrays().items)[0].name
 
-    local_bucket = get_local_bucket(module, blade)
     local_replica_link = get_local_rl(module, blade)
 
-    if not module.params["target"] and state == "present" and not local_replica_link:
+    # Removing a replica link only requires the link itself. The local and
+    # remote buckets, the target connection and the remote credential may
+    # already have been deleted, so none of these are required when deleting.
+    if state == "absent":
+        if local_replica_link:
+            delete_rl_policy(module, blade, local_replica_link)
+        module.exit_json(changed=False)
+
+    local_bucket = get_local_bucket(module, blade)
+
+    if not module.params["target"] and not local_replica_link:
         module.fail_json(
             msg="target parameter is required when creating a new replica link"
         )
@@ -395,12 +404,10 @@ def main():
         if local_replica_link.status == "unhealthy":
             module.fail_json(msg="Replica Link unhealthy - please check target")
 
-    if state == "present" and not local_replica_link:
+    if not local_replica_link:
         create_rl(module, blade, remote_cred)
-    elif state == "present" and local_replica_link:
+    else:
         update_rl_policy(module, blade, local_replica_link)
-    elif state == "absent" and local_replica_link:
-        delete_rl_policy(module, blade, local_replica_link)
 
     module.exit_json(changed=False)
 


### PR DESCRIPTION
##### SUMMARY

When `state: absent` the module required the local bucket, remote credential and target connection to still exist before it would remove a replica link. If the buckets were deleted first, the link could no longer be removed ("Selected local bucket ... does not exist").

Handle `state:absent` immediately after looking up the replica link, before any create-oriented validation. Deletion works purely from the link object, so none of those resources are required. Also makes absent idempotent and able to remove an unhealthy link.

Closes #545

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_bucket_replica.py