### PR TITLE
purefb_info: fix AttributeError on gather_subset=policies

### DIFF
--- a/changelogs/fragments/547_fix_policies_info_attribute_error.yaml
+++ b/changelogs/fragments/547_fix_policies_info_attribute_error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_info - Fix AttributeError in `generate_policies_dict` where the loop variable was overwritten with `policy.name`, causing `gather_subset=policies` (or `all`) to crash on any array with existing policies (#547)

--- a/changelogs/fragments/547_fix_policies_info_attribute_error.yaml
+++ b/changelogs/fragments/547_fix_policies_info_attribute_error.yaml
@@ -1,2 +1,2 @@
 bugfixes:
- - purefb_info - Fix AttributeError in `generate_policies_dict` where the loop variable was overwritten with `policy.name`, causing `gather_subset=policies` (or `all`) to crash on any array with existing policies (#547)
+ - purefb_info - Fix AttributeError where the policy loop variable was overwritten with `policy.name`, breaking `gather_subset=policies` (#547)

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -795,15 +795,15 @@ def generate_policies_dict(blade):
     policies_info = {}
     policies = list(blade.get_policies_all().items)
     for policy in policies:
-        policy = policy.name
-        policies_info[policy] = {
+        policy_name = policy.name
+        policies_info[policy_name] = {
             "enabled": policy.enabled,
             "retention_lock": getattr(policy, "retention_lock", None),
             "policy_type": policy.policy_type,
             "rules": {},
         }
         if policy.rules:
-            policies_info[policy]["rules"] = {
+            policies_info[policy_name]["rules"] = {
                 "at": getattr(policy.rules[0], "at", None),
                 "every": getattr(policy.rules[0], "every", None),
                 "keep_for": getattr(policy.rules[0], "keep_for", None),


### PR DESCRIPTION
##### SUMMARY
Fix issue where the loop variable in `generate_policies_dict` is reassigned to `policy.name`, shadowing the policy object and causing an AttributeError ('str' object has no attribute 'enabled') on any call with `gather_subset=policies` or `all` against an array with existing policies.
Closes #547

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
purefb_info.py


