### PR TITLE
purefb_fs - restore nfs_rules and deprecate in favour of export_policy

### DIFF
--- a/changelogs/fragments/550_fs_context_not_in_fleet.yaml
+++ b/changelogs/fragments/550_fs_context_not_in_fleet.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefb_fs - Fixed ``not in a fleet`` errors on standalone arrays by only sending ``context_names`` when a context is set, and only defaulting the context for arrays that are fleet members.

--- a/changelogs/fragments/550_restore_nfs_rules.yaml
+++ b/changelogs/fragments/550_restore_nfs_rules.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - purefb_fs - Restore the ``nfs_rules`` parameter, silently ignored since v1.25.0. Inline NFS export rules are applied again on create and update for non-realm filesystems.
+deprecated_features:
+  - purefb_fs - The ``nfs_rules`` parameter is deprecated in favour of ``export_policy`` and will be removed in 2.0.0. A deprecation notice is emitted when it is used.

--- a/plugins/modules/purefb_fs.py
+++ b/plugins/modules/purefb_fs.py
@@ -63,8 +63,12 @@ options:
     default: true
   nfs_rules:
     description:
-      - No longer valid
-      - Superceeded by I(export_policy)
+      - Define the NFS client export rules for the filesystem, for example
+        C(10.21.200.0/24(rw,no_root_squash)).
+      - Deprecated. Use I(export_policy) instead. This parameter will be
+        removed in 2.0.0.
+      - Only honoured when explicitly set, and only for non-realm
+        filesystems. It is ignored for filesystems in a realm.
     required: false
     type: str
   smb:
@@ -425,16 +429,34 @@ def create_fs(module, blade):
         elif "::" in module.params["name"]:
             realm_name = module.params["name"].split("::")[0]
 
+        # nfs_rules is deprecated in favour of export_policy. It is still
+        # honoured for non-realm filesystems for backwards compatibility, but
+        # only when explicitly supplied.
+        nfs_kwargs = {
+            "v3_enabled": module.params["nfsv3"],
+            "v4_1_enabled": module.params["nfsv4"],
+        }
+        if module.params["nfs_rules"] is not None:
+            module.deprecate(
+                "nfs_rules is deprecated. Use export_policy instead.",
+                version="2.0.0",
+                collection_name="purestorage.flashblade",
+            )
+            if realm_name:
+                module.warn(
+                    "nfs_rules is not supported for realm filesystems and "
+                    "will be ignored."
+                )
+            else:
+                nfs_kwargs["rules"] = module.params["nfs_rules"]
+
         # Build FileSystemPost object
         fs_obj = FileSystemPost(
             provisioned=size,
             fast_remove_directory_enabled=module.params["fastremove"],
             hard_limit_enabled=module.params["hard_limit"],
             snapshot_directory_enabled=module.params["snapshot"],
-            nfs=Nfs(
-                v3_enabled=module.params["nfsv3"],
-                v4_1_enabled=module.params["nfsv4"],
-            ),
+            nfs=Nfs(**nfs_kwargs),
             smb=SmbPost(enabled=module.params["smb"]),
             http=Http(enabled=module.params["http"]),
             multi_protocol=MultiProtocolPost(
@@ -648,6 +670,7 @@ def modify_fs(module, blade):
     change_ca = False
     change_go = False
     change_sc = False
+    change_rules = False
     mod_fs = False
     # Determine if this is a realm filesystem
     realm_name = None
@@ -971,6 +994,41 @@ def modify_fs(module, blade):
                         get_error_message(res),
                     )
                 )
+    if module.params["nfs_rules"] is not None:
+        module.deprecate(
+            "nfs_rules is deprecated. Use export_policy instead.",
+            version="2.0.0",
+            collection_name="purestorage.flashblade",
+        )
+        if realm_name:
+            module.warn(
+                "nfs_rules is not supported for realm filesystems and "
+                "will be ignored."
+            )
+        elif getattr(current_fs.nfs, "rules", None) != module.params["nfs_rules"]:
+            change_rules = True
+            if not module.check_mode:
+                rules_attr = FileSystemPatch(
+                    nfs=NfsPatch(rules=module.params["nfs_rules"])
+                )
+                if CONTEXT_API_VERSION in api_version:
+                    res = blade.patch_file_systems(
+                        names=[fs_name],
+                        file_system=rules_attr,
+                        context_names=[module.params["context"]],
+                    )
+                else:
+                    res = blade.patch_file_systems(
+                        names=[fs_name], file_system=rules_attr
+                    )
+                if res.status_code != 200:
+                    module.fail_json(
+                        msg="Failed to modify nfs_rules for "
+                        "filesystem {0}. Error: {1}".format(
+                            fs_name,
+                            get_error_message(res),
+                        )
+                    )
     if (
         SMB_POLICY_API_VERSION in api_version
         and module.params["client_policy"]
@@ -1111,6 +1169,7 @@ def modify_fs(module, blade):
             or change_go
             or change_sc
             or change_client
+            or change_rules
         )
     )
 

--- a/plugins/modules/purefb_fs.py
+++ b/plugins/modules/purefb_fs.py
@@ -478,7 +478,7 @@ def create_fs(module, blade):
         }
 
         # Add context if API supports it
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             post_kwargs["context_names"] = [module.params["context"]]
 
         # Add default_exports=[""] for realm filesystems (empty string)
@@ -493,7 +493,7 @@ def create_fs(module, blade):
                 )
             )
         if module.params["policy"]:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.get_policies(
                     names=[module.params["policy"]],
                     context_names=[module.params["context"]],
@@ -505,7 +505,7 @@ def create_fs(module, blade):
                 module.fail_json(
                     msg="Policy {0} doesn't exist.".format(module.params["policy"])
                 )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_policies_file_systems(
                     policy_names=[module.params["policy"]],
                     member_names=[fs_name],
@@ -535,7 +535,7 @@ def create_fs(module, blade):
                     export_policy=Reference(name=module.params["export_policy"])
                 )
             )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=export_attr,
@@ -559,7 +559,7 @@ def create_fs(module, blade):
                         client_policy=Reference(name=module.params["client_policy"])
                     )
                 )
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.patch_file_systems(
                         names=[fs_name],
                         file_system=export_attr,
@@ -582,7 +582,7 @@ def create_fs(module, blade):
                 export_attr = FileSystemPatch(
                     smb=Smb(share_policy=Reference(name=module.params["share_policy"]))
                 )
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.patch_file_systems(
                         names=[fs_name],
                         file_system=export_attr,
@@ -610,7 +610,7 @@ def create_fs(module, blade):
                         ]
                     )
                 )
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.patch_file_systems(
                         names=[fs_name],
                         file_system=ca_attr,
@@ -630,7 +630,7 @@ def create_fs(module, blade):
                 go_attr = FileSystemPatch(
                     group_ownership=module.params["group_ownership"]
                 )
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.patch_file_systems(
                         names=[fs_name],
                         file_system=go_attr,
@@ -647,16 +647,18 @@ def create_fs(module, blade):
                         )
                     )
             if CONTEXT_API_VERSION in api_version and module.params["storage_class"]:
-                res = blade.patch_file_systems(
-                    names=[fs_name],
-                    file_system=FileSystemPatch(
+                sc_patch = {
+                    "names": [fs_name],
+                    "file_system": FileSystemPatch(
                         storage_class=StorageClassInfo(
                             name=module.params["storage_class"]
                         )
                     ),
-                    cancel_in_progress_storage_class_transition=False,
-                    context_names=[module.params["context"]],
-                )
+                    "cancel_in_progress_storage_class_transition": False,
+                }
+                if module.params["context"]:
+                    sc_patch["context_names"] = [module.params["context"]]
+                res = blade.patch_file_systems(**sc_patch)
 
     module.exit_json(changed=changed)
 
@@ -684,7 +686,7 @@ def modify_fs(module, blade):
         fs_name = "{0}::{1}".format(realm_name, fs_name)
     api_version = list(blade.get_versions().items)
     if module.params["policy"] and module.params["policy_state"] == "present":
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_policies(
                 names=[module.params["policy"]],
                 context_names=[module.params["context"]],
@@ -695,7 +697,7 @@ def modify_fs(module, blade):
             module.fail_json(
                 msg="Policy {0} doesn't exist.".format(module.params["policy"])
             )
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_policies_file_systems(
                 policy_names=[module.params["policy"]],
                 member_names=[fs_name],
@@ -707,7 +709,7 @@ def modify_fs(module, blade):
                 member_names=[fs_name],
             )
         if res.status_code != 200 or getattr(res, "total_item_count", 0) == 0:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_policies_file_systems(
                     policy_names=[module.params["policy"]],
                     member_names=[fs_name],
@@ -728,7 +730,7 @@ def modify_fs(module, blade):
                     )
                 )
     if module.params["policy"] and module.params["policy_state"] == "absent":
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_policies(
                 names=[module.params["policy"]],
                 context_names=[module.params["context"]],
@@ -736,7 +738,7 @@ def modify_fs(module, blade):
         else:
             res = blade.get_policies(names=[module.params["policy"]])
         if res.status_code == 200:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.get_policies_file_systems(
                     policy_names=[module.params["policy"]],
                     member_names=[fs_name],
@@ -748,7 +750,7 @@ def modify_fs(module, blade):
                     member_names=[fs_name],
                 )
             if res.status_code == 200:
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.delete_policies_file_systems(
                         policy_names=[module.params["policy"]],
                         member_names=[fs_name],
@@ -847,7 +849,7 @@ def modify_fs(module, blade):
             mod_fs = True
         if not module.params["promote"] and fsys.promotion_status == "promoted":
             # Demotion only allowed on filesystems in a replica-link
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.get_file_system_replica_links(
                     local_file_system_names=[fs_name],
                     context_names=[module.params["context"]],
@@ -867,7 +869,7 @@ def modify_fs(module, blade):
     if mod_fs:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 if new_fsys["destroyed"] != fsys.destroyed:
                     delres = blade.patch_file_systems(
                         names=[fs_name],
@@ -947,7 +949,7 @@ def modify_fs(module, blade):
                         fs_name, get_error_message(res)
                     )
                 )
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         current_fs = list(
             blade.get_file_systems(
                 context_names=[module.params["context"]],
@@ -977,7 +979,7 @@ def modify_fs(module, blade):
                     export_policy=Reference(name=module.params["export_policy"])
                 )
             )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=export_attr,
@@ -1011,7 +1013,7 @@ def modify_fs(module, blade):
                 rules_attr = FileSystemPatch(
                     nfs=NfsPatch(rules=module.params["nfs_rules"])
                 )
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.patch_file_systems(
                         names=[fs_name],
                         file_system=rules_attr,
@@ -1045,7 +1047,7 @@ def modify_fs(module, blade):
             client_attr = FileSystemPatch(
                 smb=Smb(client_policy=Reference(name=module.params["client_policy"]))
             )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=client_attr,
@@ -1078,7 +1080,7 @@ def modify_fs(module, blade):
             share_attr = FileSystemPatch(
                 smb=Smb(share_policy=Reference(name=module.params["share_policy"]))
             )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=share_attr,
@@ -1109,7 +1111,7 @@ def modify_fs(module, blade):
                     ]
                 )
             )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=ca_attr,
@@ -1130,7 +1132,7 @@ def modify_fs(module, blade):
             change_go = True
         if not module.check_mode and change_go:
             go_attr = FileSystemPatch(group_ownership=module.params["group_ownership"])
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=go_attr,
@@ -1149,16 +1151,18 @@ def modify_fs(module, blade):
     if CONTEXT_API_VERSION in api_version and module.params["storage_class"]:
         if module.params["storage_class"] != current_fs.storage_class:
             change_sc = True
-        res = blade.patch_file_systems(
-            names=[fs_name],
-            file_system=FileSystemPatch(
+        sc_patch = {
+            "names": [fs_name],
+            "file_system": FileSystemPatch(
                 storage_class=StorageClassInfo(name=module.params["storage_class"])
             ),
-            cancel_in_progress_storage_class_transition=module.params[
+            "cancel_in_progress_storage_class_transition": module.params[
                 "cancel_in_progress"
             ],
-            context_names=[module.params["context"]],
-        )
+        }
+        if module.params["context"]:
+            sc_patch["context_names"] = [module.params["context"]]
+        res = blade.patch_file_systems(**sc_patch)
 
     module.exit_json(
         changed=(
@@ -1331,8 +1335,12 @@ def main():
     blade = get_system(module)
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
-        # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        # Only default the context to the local array name when this array is a
+        # member of a fleet. A standalone array is "not in a fleet" and rejects
+        # fleet context, so leave context unset - no context_names is then sent.
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
 
     # Check if filesystem exists
     # If realm is provided and filesystem name doesn't include realm prefix,

--- a/tests/unit/plugins/modules/test_purefb_fs.py
+++ b/tests/unit/plugins/modules/test_purefb_fs.py
@@ -426,6 +426,120 @@ class TestPurefbFs:
         mock_blade.post_file_systems.assert_called_once()
         mock_module.exit_json.assert_called_with(changed=True)
 
+    @patch("plugins.modules.purefb_fs.FileSystemPost")
+    @patch("plugins.modules.purefb_fs.Nfs")
+    @patch("plugins.modules.purefb_fs.SmbPost")
+    @patch("plugins.modules.purefb_fs.Http")
+    @patch("plugins.modules.purefb_fs.MultiProtocolPost")
+    @patch("plugins.modules.purefb_fs.human_to_bytes")
+    @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    def test_create_fs_no_context_omits_context_names(
+        self,
+        mock_human_to_bytes,
+        mock_multi_protocol,
+        mock_http,
+        mock_smb,
+        mock_nfs,
+        mock_fs_post,
+    ):
+        """On a context-capable array with no context set (e.g. standalone,
+        not in a fleet), context_names must NOT be sent."""
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.params = {
+            "name": "test-fs",
+            "size": "1T",
+            "nfsv3": True,
+            "nfsv4": True,
+            "nfs_rules": None,
+            "smb": False,
+            "http": False,
+            "snapshot": False,
+            "fastremove": False,
+            "hard_limit": False,
+            "user_quota": None,
+            "group_quota": None,
+            "policy": None,
+            "access_control": "shared",
+            "safeguard_acls": True,
+            "export_policy": None,
+            "share_policy": None,
+            "client_policy": None,
+            "continuous_availability": True,
+            "context": "",  # no context -> standalone / not in a fleet
+            "storage_class": None,
+            "group_ownership": None,
+        }
+        mock_blade = Mock()
+        # Array supports the context API version (2.17+)
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_human_to_bytes.return_value = 1099511627776
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_blade.post_file_systems.return_value = mock_response
+
+        create_fs(mock_module, mock_blade)
+
+        mock_blade.post_file_systems.assert_called_once()
+        call_kwargs = mock_blade.post_file_systems.call_args[1]
+        assert "context_names" not in call_kwargs
+
+    @patch("plugins.modules.purefb_fs.FileSystemPost")
+    @patch("plugins.modules.purefb_fs.Nfs")
+    @patch("plugins.modules.purefb_fs.SmbPost")
+    @patch("plugins.modules.purefb_fs.Http")
+    @patch("plugins.modules.purefb_fs.MultiProtocolPost")
+    @patch("plugins.modules.purefb_fs.human_to_bytes")
+    @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    def test_create_fs_with_context_sends_context_names(
+        self,
+        mock_human_to_bytes,
+        mock_multi_protocol,
+        mock_http,
+        mock_smb,
+        mock_nfs,
+        mock_fs_post,
+    ):
+        """When a context is explicitly set, context_names must be sent."""
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.params = {
+            "name": "test-fs",
+            "size": "1T",
+            "nfsv3": True,
+            "nfsv4": True,
+            "nfs_rules": None,
+            "smb": False,
+            "http": False,
+            "snapshot": False,
+            "fastremove": False,
+            "hard_limit": False,
+            "user_quota": None,
+            "group_quota": None,
+            "policy": None,
+            "access_control": "shared",
+            "safeguard_acls": True,
+            "export_policy": None,
+            "share_policy": None,
+            "client_policy": None,
+            "continuous_availability": True,
+            "context": "member-array",
+            "storage_class": None,
+            "group_ownership": None,
+        }
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_human_to_bytes.return_value = 1099511627776
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_blade.post_file_systems.return_value = mock_response
+
+        create_fs(mock_module, mock_blade)
+
+        mock_blade.post_file_systems.assert_called_once()
+        call_kwargs = mock_blade.post_file_systems.call_args[1]
+        assert call_kwargs["context_names"] == ["member-array"]
+
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
     def test_create_fs_check_mode(self):
         """Test creating filesystem in check mode"""

--- a/tests/unit/plugins/modules/test_purefb_fs.py
+++ b/tests/unit/plugins/modules/test_purefb_fs.py
@@ -356,6 +356,76 @@ class TestPurefbFs:
         mock_blade.post_file_systems.assert_called_once()
         mock_module.exit_json.assert_called_with(changed=True)
 
+    @patch("plugins.modules.purefb_fs.FileSystemPost")
+    @patch("plugins.modules.purefb_fs.Nfs")
+    @patch("plugins.modules.purefb_fs.SmbPost")
+    @patch("plugins.modules.purefb_fs.Http")
+    @patch("plugins.modules.purefb_fs.MultiProtocolPost")
+    @patch("plugins.modules.purefb_fs.human_to_bytes")
+    @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    def test_create_fs_with_nfs_rules(
+        self,
+        mock_human_to_bytes,
+        mock_multi_protocol,
+        mock_http,
+        mock_smb,
+        mock_nfs,
+        mock_fs_post,
+    ):
+        """Explicit nfs_rules must reach the SDK and emit a deprecation warning"""
+        mock_module = Mock()
+        mock_module.check_mode = False
+        mock_module.params = {
+            "name": "test-fs",
+            "size": "1T",
+            "nfsv3": True,
+            "nfsv4": True,
+            "nfs_rules": "10.21.200.0/24(rw,no_root_squash)",
+            "smb": False,
+            "http": False,
+            "snapshot": False,
+            "fastremove": False,
+            "hard_limit": False,
+            "user_quota": None,
+            "group_quota": None,
+            "policy": None,
+            "access_control": "shared",
+            "safeguard_acls": True,
+            "export_policy": None,
+            "share_policy": None,
+            "client_policy": None,
+            "continuous_availability": True,
+            "context": "",
+            "storage_class": None,
+            "group_ownership": None,
+        }
+
+        mock_blade = Mock()
+        mock_version = Mock()
+        mock_version.version = "2.0"
+        mock_blade.get_versions.return_value.items = [mock_version]
+        mock_human_to_bytes.return_value = 1099511627776
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_blade.post_file_systems.return_value = mock_response
+
+        create_fs(mock_module, mock_blade)
+
+        # The inline rules must be passed through to the Nfs SDK object
+        mock_nfs.assert_called_once_with(
+            v3_enabled=True,
+            v4_1_enabled=True,
+            rules="10.21.200.0/24(rw,no_root_squash)",
+        )
+        # And the deprecation notice must be emitted
+        mock_module.deprecate.assert_any_call(
+            "nfs_rules is deprecated. Use export_policy instead.",
+            version="2.0.0",
+            collection_name="purestorage.flashblade",
+        )
+        mock_blade.post_file_systems.assert_called_once()
+        mock_module.exit_json.assert_called_with(changed=True)
+
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
     def test_create_fs_check_mode(self):
         """Test creating filesystem in check mode"""
@@ -749,7 +819,7 @@ class TestPurefbFs:
             "size": "1T",
             "nfsv3": True,
             "nfsv4": True,
-            "nfs_rules": "*(rw,no_root_squash)",
+            "nfs_rules": None,
             "smb": False,
             "http": False,
             "snapshot": False,


### PR DESCRIPTION
##### SUMMARY
The 1.25.0 NFS rules refactor removed all nfs_rules create/update logic but left the parameter in the argument spec, so it was silently ignored.

Restore inline NFS export rules on create and update for non-realm filesystems, honouring nfs_rules only when explicitly supplied so export_policy users are unaffected. Emit a module.deprecate() notice (removal scheduled for 2.0.0) steering users to export_policy.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_fs.py