### PR TITLE
purefb - add API-client token authentication alongside api_token

### DIFF
--- a/changelogs/fragments/551_apiclient_token_auth.yaml
+++ b/changelogs/fragments/551_apiclient_token_auth.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefb - Add API-client token authentication as an alternative to ``api_token``, via a pre-signed ``id_token`` or a ``private_key_file`` (with ``client_id``, ``key_id``, ``issuer``, ``username``).

--- a/plugins/doc_fragments/purestorage.py
+++ b/plugins/doc_fragments/purestorage.py
@@ -30,6 +30,50 @@ options:
     description:
       - FlashBlade API token for admin privileged user.
     type: str
+  id_token:
+    description:
+      - A pre-signed JWT to authenticate with, as an alternative to I(api_token).
+      - The token is exchanged by the array for a short-lived access token.
+      - Requires a matching API Client to be registered on the array
+        (see M(purestorage.flashblade.purefb_apiclient)).
+    type: str
+    version_added: '1.26.0'
+  private_key_file:
+    description:
+      - Path to the PEM RSA private key used to sign an identity token,
+        as an alternative to I(api_token).
+      - Requires I(client_id), I(key_id), I(issuer) and I(username).
+    type: str
+    version_added: '1.26.0'
+  private_key_password:
+    description:
+      - Password protecting I(private_key_file), if encrypted.
+    type: str
+    version_added: '1.26.0'
+  username:
+    description:
+      - Username the issued token should be granted to.
+      - Must be a valid user on the array. Used with I(private_key_file).
+    type: str
+    version_added: '1.26.0'
+  client_id:
+    description:
+      - ID of the API Client that issues the identity token.
+      - Used with I(private_key_file).
+    type: str
+    version_added: '1.26.0'
+  key_id:
+    description:
+      - Key ID of the API Client that issues the identity token.
+      - Used with I(private_key_file).
+    type: str
+    version_added: '1.26.0'
+  issuer:
+    description:
+      - The API Client's trusted identity issuer registered on the array.
+      - Used with I(private_key_file).
+    type: str
+    version_added: '1.26.0'
   disable_warnings:
     description:
     - Disable insecure certificate warnings
@@ -39,6 +83,10 @@ options:
 notes:
   - You must set C(PUREFB_URL) and C(PUREFB_API) environment variables
     if I(fb_url) and I(api_token) arguments are not passed to the module directly
+  - Token-based authentication (I(id_token), or I(private_key_file) with
+    I(client_id), I(key_id), I(issuer) and I(username)) may be used as an
+    alternative to I(api_token), and requires a matching API Client registered
+    on the array via M(purestorage.flashblade.purefb_apiclient)
 requirements:
   - python >= 3.9
   - py-pure-client

--- a/plugins/module_utils/purefb.py
+++ b/plugins/module_utils/purefb.py
@@ -83,10 +83,23 @@ def get_system(module):
     Environment Variables:
         PUREFB_URL: FlashBlade URL (alternative to fb_url parameter)
         PUREFB_API: API token (alternative to api_token parameter)
+        PUREFB_ID_TOKEN: Pre-signed JWT (alternative to id_token parameter)
+        PUREFB_PRIVATE_KEY_FILE / PUREFB_PRIVATE_KEY_PASSWORD
+        PUREFB_USERNAME / PUREFB_CLIENT_ID / PUREFB_KEY_ID / PUREFB_ISSUER
 
     Note:
         Module parameters take precedence over environment variables.
+        Three mutually-exclusive authentication modes are supported:
+          1. api_token - static API token (default, backwards compatible).
+          2. id_token - a pre-signed JWT, exchanged by the array for an
+             access token at /oauth2/1.0/token.
+          3. private_key_file with client_id, key_id, issuer and username -
+             the SDK signs the JWT locally before exchange.
+        Modes 2 and 3 require a matching API Client registered on the array
+        (see the purefb_apiclient module).
     """
+    if not HAS_PYPURECLIENT:
+        module.fail_json(msg="pypureclient SDK not installed.")
     if module.params["disable_warnings"]:
         urllib3.disable_warnings()
     if HAS_DISTRO:
@@ -103,36 +116,53 @@ def get_system(module):
             "version": VERSION,
             "platform": platform.platform(),
         }
-    blade_name = module.params["fb_url"]
-    api = module.params["api_token"]
 
-    if HAS_PYPURECLIENT:
-        if blade_name and api:
-            system = flashblade.Client(
-                target=blade_name,
-                api_token=api,
-                user_agent=user_agent,
-            )
-        elif environ.get("PUREFB_URL") and environ.get("PUREFB_API"):
-            system = flashblade.Client(
-                target=(environ.get("PUREFB_URL")),
-                api_token=(environ.get("PUREFB_API")),
-                user_agent=user_agent,
-            )
-        else:
-            module.fail_json(
-                msg="You must set PUREFB_URL and PUREFB_API environment variables "
-                "or the fb_url and api_token module arguments"
-            )
-        res = system.get_hardware()
-        if res.status_code != 200:
-            module.fail_json(
-                msg="Pure Storage FlashBlade authentication failed. Error: {0}".format(
-                    get_error_message(res)
-                )
-            )
+    # Module parameters take precedence over the matching PUREFB_* env vars.
+    target = module.params["fb_url"] or environ.get("PUREFB_URL")
+    api = module.params["api_token"] or environ.get("PUREFB_API")
+    id_token = module.params.get("id_token") or environ.get("PUREFB_ID_TOKEN")
+    private_key_file = module.params.get("private_key_file") or environ.get(
+        "PUREFB_PRIVATE_KEY_FILE"
+    )
+    private_key_password = module.params.get("private_key_password") or environ.get(
+        "PUREFB_PRIVATE_KEY_PASSWORD"
+    )
+    username = module.params.get("username") or environ.get("PUREFB_USERNAME")
+    client_id = module.params.get("client_id") or environ.get("PUREFB_CLIENT_ID")
+    key_id = module.params.get("key_id") or environ.get("PUREFB_KEY_ID")
+    issuer = module.params.get("issuer") or environ.get("PUREFB_ISSUER")
+
+    common = {"target": target, "user_agent": user_agent}
+
+    if target and api:
+        system = flashblade.Client(api_token=api, **common)
+    elif target and id_token:
+        system = flashblade.Client(id_token=id_token, **common)
+    elif target and private_key_file and client_id and key_id and issuer and username:
+        system = flashblade.Client(
+            private_key_file=private_key_file,
+            private_key_password=private_key_password,
+            client_id=client_id,
+            key_id=key_id,
+            issuer=issuer,
+            username=username,
+            **common,
+        )
     else:
-        module.fail_json(msg="pypureclient SDK not installed.")
+        module.fail_json(
+            msg="You must set PUREFB_URL and PUREFB_API environment variables "
+            "or the fb_url and api_token module arguments. Alternatively, use "
+            "token-based authentication via id_token, or private_key_file with "
+            "client_id, key_id, issuer and username (or the matching PUREFB_* "
+            "environment variables)."
+        )
+    res = system.get_hardware()
+    if res.status_code != 200:
+        module.fail_json(
+            msg="Pure Storage FlashBlade authentication failed. Error: {0}".format(
+                get_error_message(res)
+            )
+        )
     return system
 
 
@@ -160,5 +190,14 @@ def purefb_argument_spec():
     return dict(
         fb_url=dict(),
         api_token=dict(no_log=True),
+        # OAuth2 / API-client token authentication (alternatives to api_token).
+        # See the purefb_apiclient module for registering the trusted key.
+        id_token=dict(no_log=True),
+        private_key_file=dict(no_log=False),
+        private_key_password=dict(no_log=True),
+        username=dict(),
+        client_id=dict(),
+        key_id=dict(no_log=False),
+        issuer=dict(),
         disable_warnings=dict(type="bool", default=False),
     )

--- a/tests/unit/plugins/module_utils/test_purefb.py
+++ b/tests/unit/plugins/module_utils/test_purefb.py
@@ -49,8 +49,31 @@ class TestPurefbArgumentSpec:
     def test_all_expected_keys(self):
         """Test that spec contains exactly the expected keys."""
         result = purefb_argument_spec()
-        expected_keys = {"fb_url", "api_token", "disable_warnings"}
+        expected_keys = {
+            "fb_url",
+            "api_token",
+            "id_token",
+            "private_key_file",
+            "private_key_password",
+            "username",
+            "client_id",
+            "key_id",
+            "issuer",
+            "disable_warnings",
+        }
         assert set(result.keys()) == expected_keys
+
+    def test_token_auth_secrets_no_log(self):
+        """Secret token-auth params must be marked no_log."""
+        result = purefb_argument_spec()
+        assert result["id_token"]["no_log"] is True
+        assert result["private_key_password"]["no_log"] is True
+
+    def test_non_secret_params_no_log_false(self):
+        """Non-secret params that trip the no_log heuristic are silenced."""
+        result = purefb_argument_spec()
+        assert result["private_key_file"]["no_log"] is False
+        assert result["key_id"]["no_log"] is False
 
 
 class TestGetSystem:
@@ -274,3 +297,97 @@ class TestGetSystem:
         call_kwargs = mock_client_class.call_args[1]
         assert "Ubuntu 22.04" in call_kwargs["user_agent"]
         assert "Ansible" in call_kwargs["user_agent"]
+
+    @patch("plugins.module_utils.purefb.flashblade.Client")
+    @patch("plugins.module_utils.purefb.HAS_PYPURECLIENT", True)
+    @patch("plugins.module_utils.purefb.environ")
+    def test_with_id_token(self, mock_environ, mock_client_class):
+        """Test get_system authenticates with a pre-signed id_token."""
+        mock_environ.get.return_value = None
+        mock_module = Mock()
+        mock_module.params = {
+            "fb_url": "https://flashblade.example.com",
+            "api_token": None,
+            "id_token": "eyJhbGciOiJSUzI1NiJ9.payload.sig",
+            "disable_warnings": False,
+        }
+        mock_client = Mock()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_client.get_hardware.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        result = get_system(mock_module)
+
+        call_kwargs = mock_client_class.call_args[1]
+        assert call_kwargs["target"] == "https://flashblade.example.com"
+        assert call_kwargs["id_token"] == "eyJhbGciOiJSUzI1NiJ9.payload.sig"
+        assert "api_token" not in call_kwargs
+        assert result == mock_client
+
+    @patch("plugins.module_utils.purefb.flashblade.Client")
+    @patch("plugins.module_utils.purefb.HAS_PYPURECLIENT", True)
+    @patch("plugins.module_utils.purefb.environ")
+    def test_with_private_key(self, mock_environ, mock_client_class):
+        """Test get_system authenticates with the private-key app flow."""
+        mock_environ.get.return_value = None
+        mock_module = Mock()
+        mock_module.params = {
+            "fb_url": "https://flashblade.example.com",
+            "api_token": None,
+            "id_token": None,
+            "private_key_file": "/run/secrets/aap.pem",
+            "private_key_password": "s3cret",
+            "username": "automation",
+            "client_id": "cid-123",
+            "key_id": "kid-456",
+            "issuer": "AAP",
+            "disable_warnings": False,
+        }
+        mock_client = Mock()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_client.get_hardware.return_value = mock_response
+        mock_client_class.return_value = mock_client
+
+        result = get_system(mock_module)
+
+        call_kwargs = mock_client_class.call_args[1]
+        assert call_kwargs["target"] == "https://flashblade.example.com"
+        assert call_kwargs["private_key_file"] == "/run/secrets/aap.pem"
+        assert call_kwargs["private_key_password"] == "s3cret"
+        assert call_kwargs["username"] == "automation"
+        assert call_kwargs["client_id"] == "cid-123"
+        assert call_kwargs["key_id"] == "kid-456"
+        assert call_kwargs["issuer"] == "AAP"
+        assert "api_token" not in call_kwargs
+        assert result == mock_client
+
+    @patch("plugins.module_utils.purefb.flashblade.Client")
+    @patch("plugins.module_utils.purefb.HAS_PYPURECLIENT", True)
+    @patch("plugins.module_utils.purefb.environ")
+    def test_incomplete_private_key_set_fails(self, mock_environ, mock_client_class):
+        """An incomplete private-key set (no username) must fail cleanly."""
+        mock_module = Mock()
+        mock_module.params = {
+            "fb_url": "https://flashblade.example.com",
+            "api_token": None,
+            "id_token": None,
+            "private_key_file": "/run/secrets/aap.pem",
+            "private_key_password": None,
+            "username": None,  # missing -> not a complete set
+            "client_id": "cid-123",
+            "key_id": "kid-456",
+            "issuer": "AAP",
+            "disable_warnings": False,
+        }
+        mock_module.fail_json.side_effect = SystemExit("fail_json called")
+        mock_environ.get.return_value = None
+
+        try:
+            get_system(mock_module)
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        mock_client_class.assert_not_called()


### PR DESCRIPTION
##### SUMMARY

Adds API-client token authentication to the collection's shared auth layer as an
alternative to the static `api_token`, addressing the feasibility request in #542.

The underlying `py-pure-client` SDK already supports FlashBlade's OAuth2 /
API-client token flow; this PR simply wires it into `get_system()` and
`purefb_argument_spec()` so every module can use it. Two new modes are supported
alongside `api_token`:

- **`id_token`** — a pre-signed JWT, exchanged by the array for a short-lived
  access token at `/oauth2/1.0/token`.
- **`private_key_file`** (with `client_id`, `key_id`, `issuer`, `username`) — the
  SDK signs the identity token locally before exchange.

Both modes require a matching API Client to be registered on the array (already
managed by the `purefb_apiclient` module: `issuer` + `max_role` + PEM `public_key`).
This lets automation authenticate with a managed key instead of a long-lived API
token — a meaningful zero-trust improvement for AAP / sovereign-cloud deployments.

**Design decisions / notes:**
- The three modes are mutually exclusive; `api_token` is selected first, so all
  existing playbooks are **100% backwards compatible**.
- Each credential resolves from the module parameter first, then the matching
  `PUREFB_*` environment variable (`PUREFB_ID_TOKEN`, `PUREFB_PRIVATE_KEY_FILE`,
  `PUREFB_PRIVATE_KEY_PASSWORD`, `PUREFB_USERNAME`, `PUREFB_CLIENT_ID`,
  `PUREFB_KEY_ID`, `PUREFB_ISSUER`).
- The original "must set PUREFB_URL and PUREFB_API…" failure message is preserved
  as the lead sentence of the no-auth error, with the new options appended.
- New options are documented once, centrally, in the `purestorage.fb` doc fragment.
- `no_log`: secrets (`id_token`, `private_key_password`) are `no_log: true`;
  non-secret params that trip the heuristic (`private_key_file`, `key_id`) are
  explicitly `no_log: false` (same pattern as the existing `token_ttl`).

**Scope / out of scope:**
- This implements the *static-key* path: the array validates the JWT against a
  locally-registered API Client public key. It does **not** add external OIDC
  federation (validating tokens against an IdP's discovery/JWKS endpoint) — that
  requires Purity//FB firmware support and is a separate product ask (see #542).
- `flashblade.Client()` is intentionally not wrapped in `try/except PureError`
  in this PR (matches current behaviour; auth is validated by the existing
  `get_hardware()` status check). Friendlier error wrapping is a possible follow-up.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

purefb (module_utils auth layer — `get_system` / `purefb_argument_spec`, applies to all modules)

##### ADDITIONAL INFORMATION

Relates to #542.

Changelog fragment included:
- `changelogs/fragments/551_apiclient_token_auth.yaml`

Example using the local-signing flow (no static API token in the playbook):

```yaml
- name: Create a filesystem authenticating with an API-client key
  purestorage.flashblade.purefb_fs:
    name: demo
    size: 1T
    fb_url: 10.10.10.2
    private_key_file: /run/secrets/aap.pem
    client_id: "{{ pure_client_id }}"
    key_id: "{{ pure_key_id }}"
    issuer: AAP
    username: automation