### PR TITLE
purefb_policy - fix NFS export rule access not updating

### DIFF
--- a/changelogs/fragments/552_nfs_export_rule_access.yaml
+++ b/changelogs/fragments/552_nfs_export_rule_access.yaml
@@ -1,2 +1,5 @@
 bugfixes:
   - purefb_policy - Fixed NFS export policy rules not updating when only the ``access`` value (e.g. root-squash to no-squash) changed; ``access`` was missing from the idempotency comparison.
+  - purefb_policy - Fixed policy rule updates (NFS export, SMB share, SMB client, network access) resetting unspecified fields to null; patches now use merged values so omitted fields are kept.
+  - purefb_policy - Fixed an object store access policy rule update referencing a non-existent key when preserving existing source IPs.
+  - purefb_policy - Fixed snapshot policy updates dropping the ``at`` time and timezone (reverting to an interval-only rule) when ``every`` or ``keep_for`` were changed without re-specifying ``at``.

--- a/changelogs/fragments/552_nfs_export_rule_access.yaml
+++ b/changelogs/fragments/552_nfs_export_rule_access.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefb_policy - Fixed NFS export policy rules not updating when only the ``access`` value (e.g. root-squash to no-squash) changed; ``access`` was missing from the idempotency comparison.

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -2478,6 +2478,7 @@ def update_nfs_policy(module, blade):
             if not done:
                 old_policy_rule = rules[0]
                 current_rule = {
+                    "access": getattr(old_policy_rule, "access", None),
                     "anongid": getattr(old_policy_rule, "anongid", None),
                     "anonuid": getattr(old_policy_rule, "anonuid", None),
                     "atime": old_policy_rule.atime,
@@ -2519,7 +2520,12 @@ def update_nfs_policy(module, blade):
                     new_fileid_32bit = module.params["fileid_32bit"]
                 else:
                     new_fileid_32bit = current_rule["fileid_32bit"]
+                if module.params["access"]:
+                    new_access = module.params["access"]
+                else:
+                    new_access = current_rule["access"]
                 new_rule = {
+                    "access": new_access,
                     "anongid": new_anongid,
                     "anonuid": new_anonuid,
                     "atime": new_atime,

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -996,11 +996,13 @@ def update_smb_share_policy(module, blade):
             if current_rule != new_rule:
                 changed = True
                 if not module.check_mode:
+                    # Patch from the merged new_rule so unspecified fields keep
+                    # their current value rather than being reset.
                     rule = SmbSharePolicyRule(
-                        principal=module.params["principal"],
-                        change=module.params["change"],
-                        read=module.params["read"],
-                        full_control=module.params["full_control"],
+                        principal=new_rule["principal"],
+                        change=new_rule["change"],
+                        read=new_rule["read"],
+                        full_control=new_rule["full_control"],
                     )
                     if CONTEXT_API_VERSION in versions:
                         res = blade.patch_smb_share_policies_rules(
@@ -1591,16 +1593,18 @@ def update_smb_client_policy(module, blade):
                 if current_rule != new_rule:
                     changed = True
                     if not module.check_mode:
+                        # Patch from the merged new_rule so unspecified fields keep
+                        # their current value rather than being reset.
                         if SMB_ENCRYPT_API_VERSION in versions:
                             rule = SmbClientPolicyRule(
-                                client=module.params["client"],
-                                permission=module.params["permission"],
-                                encryption=module.params["smb_encryption"],
+                                client=new_rule["client"],
+                                permission=new_rule["permission"],
+                                encryption=new_rule["encryption"],
                             )
                         else:
                             rule = SmbClientPolicyRule(
-                                client=module.params["client"],
-                                permission=module.params["permission"],
+                                client=new_rule["client"],
+                                permission=new_rule["permission"],
                             )
                         if CONTEXT_API_VERSION in versions:
                             res = blade.patch_smb_client_policies_rules(
@@ -1955,10 +1959,12 @@ def update_network_access_policy(module, blade):
                 if current_rule != new_rule:
                     changed = True
                     if not module.check_mode:
+                        # Patch from the merged new_rule so unspecified fields keep
+                        # their current value rather than being reset.
                         rule = NetworkAccessPolicyRule(
-                            client=module.params["client"],
-                            effect=module.params["effect"],
-                            interfaces=module.params["interfaces"],
+                            client=new_rule["client"],
+                            effect=new_rule["effect"],
+                            interfaces=new_rule["interfaces"],
                         )
                         if CONTEXT_API_VERSION in versions:
                             res = blade.patch_network_access_policies_rules(
@@ -2538,16 +2544,19 @@ def update_nfs_policy(module, blade):
                 if current_rule != new_rule:
                     changed = True
                     if not module.check_mode:
+                        # Build the patch from the merged new_rule values, not the
+                        # raw module params, so fields the task did not specify keep
+                        # their current value instead of being reset to null.
                         rule = NfsExportPolicyRule(
-                            client=module.params["client"],
-                            permission=module.params["permission"],
-                            access=module.params["access"],
-                            anonuid=module.params["anonuid"],
-                            anongid=module.params["anongid"],
-                            fileid_32bit=module.params["fileid_32bit"],
-                            atime=module.params["atime"],
-                            secure=module.params["secure"],
-                            security=module.params["security"],
+                            client=new_rule["client"],
+                            permission=new_rule["permission"],
+                            access=new_rule["access"],
+                            anonuid=new_rule["anonuid"],
+                            anongid=new_rule["anongid"],
+                            fileid_32bit=new_rule["fileid_32bit"],
+                            atime=new_rule["atime"],
+                            secure=new_rule["secure"],
+                            security=new_rule["security"],
                         )
                         if CONTEXT_API_VERSION in versions:
                             res = blade.patch_nfs_export_policies_rules(
@@ -3055,7 +3064,7 @@ def update_os_policy(module, blade):
             if module.params["source_ips"]:
                 new_ips = sorted(module.params["source_ips"])
             elif current_rule["ips"]:
-                new_ips = sorted(current_rule["source_ips"])
+                new_ips = sorted(current_rule["ips"])
             else:
                 new_ips = None
             new_rule = {
@@ -3522,6 +3531,34 @@ def update_snap_policy(module, blade):
             0
         ].rules
     create_new = False
+    # Snapshot policies carry a single schedule rule. Fall back to the existing
+    # rule's value for any field the task did not specify, so a partial update
+    # (e.g. changing only keep_for) does not reset the other fields to zero.
+    existing_rule = current_rules[0] if current_rules else None
+    if module.params["at"]:
+        new_at = time_to_milliseconds(module.params["at"])
+    elif existing_rule is not None:
+        new_at = existing_rule.at
+    else:
+        new_at = None
+    if module.params["keep_for"]:
+        new_keep_for = module.params["keep_for"]
+    elif existing_rule is not None:
+        new_keep_for = int(existing_rule.keep_for / 1000)
+    else:
+        new_keep_for = 0
+    if module.params["every"]:
+        new_every = module.params["every"]
+    elif existing_rule is not None:
+        new_every = int(existing_rule.every / 1000)
+    else:
+        new_every = 0
+    if module.params["timezone"]:
+        new_tz = module.params["timezone"]
+    elif existing_rule is not None:
+        new_tz = existing_rule.time_zone
+    else:
+        new_tz = None
     for rule in current_rules:
         current_rule = {
             "at": rule.at,
@@ -3529,22 +3566,6 @@ def update_snap_policy(module, blade):
             "keep_for": rule.keep_for,
             "time_zone": rule.time_zone,
         }
-        if not module.params["at"]:
-            new_at = rule.at
-        else:
-            new_at = time_to_milliseconds(module.params["at"])
-        if module.params["keep_for"]:
-            new_keep_for = module.params["keep_for"]
-        else:
-            new_keep_for = int(rule.keep_for / 1000)
-        if module.params["every"]:
-            new_every = module.params["every"]
-        else:
-            new_every = int(rule.every / 1000)
-        if not module.params["timezone"]:
-            new_tz = rule.time_zone
-        else:
-            new_tz = module.params["timezone"]
         new_rule = {
             "at": new_at,
             "every": new_every * 1000,
@@ -3557,54 +3578,39 @@ def update_snap_policy(module, blade):
     if create_new:
         changed = True
         if not module.check_mode:
-            if module.params["at"] and module.params["every"]:
-                if not module.params["every"] % 86400 == 0:
-                    module.fail_json(
-                        msg="At time can only be set if every value is a multiple of 86400"
-                    )
-                if not module.params["timezone"]:
-                    module.params["timezone"] = _get_local_tz(module)
-                    if module.params["timezone"] not in pytz.all_timezones_set:
-                        module.fail_json(
-                            msg="Timezone {0} is not valid".format(
-                                module.params["timezone"]
-                            )
-                        )
-            if not module.params["keep_for"]:
-                module.params["keep_for"] = 0
-            if not module.params["every"]:
-                module.params["every"] = 0
-            if module.params["keep_for"] < module.params["every"]:
+            # Build the new rule from the merged values above rather than the
+            # raw task parameters, so fields not set in the task keep their
+            # current value instead of being reset to zero.
+            if new_at is not None and new_every and new_every % 86400 != 0:
+                module.fail_json(
+                    msg="At time can only be set if every value is a multiple of 86400"
+                )
+            if new_at is not None and not new_tz:
+                new_tz = _get_local_tz(module)
+                if new_tz not in pytz.all_timezones_set:
+                    module.fail_json(msg="Timezone {0} is not valid".format(new_tz))
+            if new_keep_for < new_every:
                 module.fail_json(
                     msg="Retention period cannot be less than snapshot interval."
                 )
-            if module.params["at"] and not module.params["timezone"]:
-                module.params["timezone"] = _get_local_tz(module)
-                if module.params["timezone"] not in set(pytz.all_timezones_set):
-                    module.fail_json(
-                        msg="Timezone {0} is not valid".format(
-                            module.params["timezone"]
-                        )
-                    )
-
-            if module.params["keep_for"]:
-                if not 300 <= module.params["keep_for"] <= 34560000:
+            if new_keep_for:
+                if not 300 <= new_keep_for <= 34560000:
                     module.fail_json(
                         msg="keep_for parameter is out of range (300 to 34560000)"
                     )
-                if not 300 <= module.params["every"] <= 34560000:
+                if not 300 <= new_every <= 34560000:
                     module.fail_json(
                         msg="every parameter is out of range (300 to 34560000)"
                     )
-                if module.params["at"]:
+                if new_at is not None:
                     attr = SnapshotPolicyPatch(
                         enabled=module.params["enabled"],
                         add_rules=[
                             PolicyRule(
-                                keep_for=module.params["keep_for"] * 1000,
-                                every=module.params["every"] * 1000,
-                                at=time_to_milliseconds(module.params["at"]),
-                                time_zone=module.params["timezone"],
+                                keep_for=new_keep_for * 1000,
+                                every=new_every * 1000,
+                                at=new_at,
+                                time_zone=new_tz,
                             )
                         ],
                     )
@@ -3613,8 +3619,8 @@ def update_snap_policy(module, blade):
                         enabled=module.params["enabled"],
                         add_rules=[
                             PolicyRule(
-                                keep_for=module.params["keep_for"] * 1000,
-                                every=module.params["every"] * 1000,
+                                keep_for=new_keep_for * 1000,
+                                every=new_every * 1000,
                             )
                         ],
                     )

--- a/tests/unit/plugins/modules/test_purefb_policy.py
+++ b/tests/unit/plugins/modules/test_purefb_policy.py
@@ -41,8 +41,11 @@ sys.modules[
 sys.modules[
     "ansible_collections.purestorage.flashblade.plugins.module_utils.version"
 ] = MagicMock()
+sys.modules[
+    "ansible_collections.purestorage.flashblade.plugins.module_utils.time_utils"
+] = MagicMock()
 
-from plugins.modules.purefb_policy import update_nfs_policy
+from plugins.modules.purefb_policy import update_nfs_policy, update_snap_policy
 
 
 def _existing_rule(access="root-squash"):
@@ -132,4 +135,118 @@ class TestUpdateNfsPolicyRule:
         update_nfs_policy(module, blade)
 
         blade.patch_nfs_export_policies_rules.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)
+
+    def test_access_change_preserves_unspecified_anon(self):
+        """An access-only change must not reset anonuid/anongid left unset."""
+        import plugins.modules.purefb_policy as pol
+
+        module = _module(access="no-squash")
+        # Task changes access only and does not re-specify the anon mappings.
+        module.params["anonuid"] = None
+        module.params["anongid"] = None
+        blade = _blade(_existing_rule(access="root-squash"))
+
+        update_nfs_policy(module, blade)
+
+        blade.patch_nfs_export_policies_rules.assert_called_once()
+        # The patched rule must keep the existing anon ids, not null them out.
+        rule_kwargs = pol.NfsExportPolicyRule.call_args[1]
+        assert rule_kwargs["access"] == "no-squash"
+        assert rule_kwargs["anonuid"] == "20000021"
+        assert rule_kwargs["anongid"] == "100021"
+
+
+def _snap_rule(every=86400000, keep_for=86400000, at=None, time_zone=None):
+    """Build a mock SDK snapshot policy rule (values in milliseconds)."""
+    rule = Mock()
+    rule.every = every
+    rule.keep_for = keep_for
+    rule.at = at
+    rule.time_zone = time_zone
+    return rule
+
+
+def _snap_module(keep_for=None, every=None, at=None, timezone=None):
+    """Build a mock AnsibleModule for update_snap_policy.
+
+    keep_for/every are in seconds (the task's units), matching the argspec.
+    """
+    module = Mock()
+    module.check_mode = False
+    module.params = {
+        "name": "daily_snap_policy",
+        "keep_for": keep_for,
+        "every": every,
+        "at": at,
+        "timezone": timezone,
+        "enabled": True,
+        "context": "",
+        "state": "present",
+        "filesystem": None,
+        "replica_link": None,
+    }
+    module.fail_json = Mock(side_effect=SystemExit("fail_json called"))
+    module.exit_json = Mock()
+    return module
+
+
+def _snap_blade(existing_rule):
+    """Build a mock blade whose policy has the given single schedule rule."""
+    blade = Mock()
+    blade.get_versions.return_value.items = []  # no context API version
+
+    policy = Mock()
+    policy.rules = [existing_rule]
+    policies_resp = Mock()
+    policies_resp.items = [policy]
+    blade.get_policies.return_value = policies_resp
+
+    ok = Mock()
+    ok.status_code = 200
+    blade.patch_policies.return_value = ok
+    return blade
+
+
+class TestUpdateSnapPolicy:
+    """Regression tests for snapshot policy rule partial updates."""
+
+    def test_retention_change_preserves_at_schedule(self):
+        """Updating every/keep_for on an at-scheduled policy must preserve the
+        existing ``at`` time and timezone, not drop them to an interval rule."""
+        import plugins.modules.purefb_policy as pol
+
+        # Existing rule keeps snapshots taken daily at 10:00 in a named tz.
+        # The task changes retention/interval but does not re-specify at/timezone
+        # (the guards require every and keep_for to be supplied together).
+        module = _snap_module(keep_for=259200, every=86400)
+        blade = _snap_blade(
+            _snap_rule(
+                every=86400000,
+                keep_for=86400000,
+                at=36000000,
+                time_zone="America/New_York",
+            )
+        )
+
+        update_snap_policy(module, blade)
+
+        blade.patch_policies.assert_called_once()
+        module.fail_json.assert_not_called()
+        # The re-added rule must keep the at time and timezone, not drop them.
+        rule_kwargs = pol.PolicyRule.call_args[1]
+        assert rule_kwargs["keep_for"] == 259200 * 1000
+        assert rule_kwargs["every"] == 86400 * 1000
+        assert rule_kwargs["at"] == 36000000
+        assert rule_kwargs["time_zone"] == "America/New_York"
+        module.exit_json.assert_called_once_with(changed=True)
+
+    def test_no_change_is_idempotent(self):
+        """Identical desired schedule must not PATCH the policy."""
+        module = _snap_module(keep_for=86400, every=86400)
+        blade = _snap_blade(_snap_rule(every=86400000, keep_for=86400000))
+
+        update_snap_policy(module, blade)
+
+        blade.patch_policies.assert_not_called()
         module.exit_json.assert_called_once_with(changed=False)

--- a/tests/unit/plugins/modules/test_purefb_policy.py
+++ b/tests/unit/plugins/modules/test_purefb_policy.py
@@ -1,0 +1,135 @@
+# Copyright: (c) 2026, Everpure Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefb_policy module (NFS export policy rule handling)."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+from unittest.mock import Mock, MagicMock
+
+# Mock external dependencies before importing module
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flashblade"] = MagicMock()
+sys.modules["urllib3"] = MagicMock()
+sys.modules["distro"] = MagicMock()
+sys.modules["grp"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["syslog"] = MagicMock()
+mock_termios = MagicMock()
+mock_termios.TCSAFLUSH = 2
+sys.modules["termios"] = mock_termios
+sys.modules["tty"] = MagicMock()
+
+# Mock ansible_collections module structure
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.purestorage"] = MagicMock()
+sys.modules["ansible_collections.purestorage.flashblade"] = MagicMock()
+sys.modules["ansible_collections.purestorage.flashblade.plugins"] = MagicMock()
+sys.modules["ansible_collections.purestorage.flashblade.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules[
+    "ansible_collections.purestorage.flashblade.plugins.module_utils.purefb"
+] = MagicMock()
+sys.modules[
+    "ansible_collections.purestorage.flashblade.plugins.module_utils.common"
+] = MagicMock()
+sys.modules[
+    "ansible_collections.purestorage.flashblade.plugins.module_utils.version"
+] = MagicMock()
+
+from plugins.modules.purefb_policy import update_nfs_policy
+
+
+def _existing_rule(access="root-squash"):
+    """Build a mock SDK NFS export policy rule for client 10.0.10.42."""
+    rule = Mock()
+    rule.access = access
+    rule.anongid = "100021"
+    rule.anonuid = "20000021"
+    rule.atime = True
+    rule.client = "10.0.10.42"
+    rule.fileid_32bit = False
+    rule.permission = "rw"
+    rule.secure = False
+    rule.security = ["krb5", "krb5i", "krb5p", "sys"]
+    rule.index = 1
+    return rule
+
+
+def _module(access):
+    """Build a mock AnsibleModule whose desired rule has the given access."""
+    module = Mock()
+    module.check_mode = False
+    module.params = {
+        "name": "project96_nfs_policy",
+        "client": "10.0.10.42",
+        "permission": "rw",
+        "access": access,
+        "anonuid": "20000021",
+        "anongid": "100021",
+        "fileid_32bit": False,
+        "atime": True,
+        "secure": False,
+        "security": ["krb5", "krb5i", "krb5p", "sys"],
+        "before_rule": None,
+        "context": "",
+        "enabled": True,
+    }
+    module.fail_json = Mock(side_effect=SystemExit("fail_json called"))
+    module.exit_json = Mock()
+    return module
+
+
+def _blade(existing_rule):
+    """Build a mock blade returning the given existing rule."""
+    blade = Mock()
+    blade.get_versions.return_value.items = []  # no context API version
+
+    rules_resp = Mock()
+    rules_resp.status_code = 200
+    rules_resp.total_item_count = 1
+    rules_resp.items = [existing_rule]
+    blade.get_nfs_export_policies_rules.return_value = rules_resp
+
+    ok = Mock()
+    ok.status_code = 200
+    blade.patch_nfs_export_policies_rules.return_value = ok
+
+    policy = Mock()
+    policy.enabled = True
+    policy_resp = Mock()
+    policy_resp.items = [policy]
+    blade.get_nfs_export_policies.return_value = policy_resp
+    return blade
+
+
+class TestUpdateNfsPolicyRule:
+    """Regression tests for NFS export policy rule idempotency."""
+
+    def test_access_change_triggers_patch(self):
+        """Changing only access (root-squash -> no-squash) must PATCH the rule."""
+        module = _module(access="no-squash")
+        blade = _blade(_existing_rule(access="root-squash"))
+
+        update_nfs_policy(module, blade)
+
+        blade.patch_nfs_export_policies_rules.assert_called_once()
+        # rule name targeted is "<policy>.<index>"
+        call_kwargs = blade.patch_nfs_export_policies_rules.call_args[1]
+        assert call_kwargs["names"] == ["project96_nfs_policy.1"]
+        module.exit_json.assert_called_once_with(changed=True)
+
+    def test_no_change_is_idempotent(self):
+        """Identical desired state (incl. access) must not PATCH the rule."""
+        module = _module(access="root-squash")
+        blade = _blade(_existing_rule(access="root-squash"))
+
+        update_nfs_policy(module, blade)
+
+        blade.patch_nfs_export_policies_rules.assert_not_called()
+        module.exit_json.assert_called_once_with(changed=False)


### PR DESCRIPTION
##### SUMMARY
`update_nfs_policy` compared the existing rule against the desired rule to decide whether to PATCH, but the `access` value (`root-squash` / `all-squash` / `no-squash`) was omitted from both sides of the comparison. Changing only access therefore produced no change and was never applied to the array. Include `access` in the comparison so an access-only change triggers the rule update.

Adds regression tests for `update_nfs_policy` covering an access-only change and the idempotent no-change case.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_policy.py