### PR TITLE
Do not send fleet context on standalone arrays (context-aware modules)

### DIFF
--- a/changelogs/fragments/553_context_not_in_fleet_sweep.yaml
+++ b/changelogs/fragments/553_context_not_in_fleet_sweep.yaml
@@ -1,0 +1,16 @@
+bugfixes:
+  - purefb_bucket - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_bucket - Stop sending context_names when destroying a bucket without a context, which leaked an empty/invalid fleet context
+  - purefb_bucket_access - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_bucket_replica - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_connect - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_export - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_groupquota - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_lifecycle - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_remote_cred - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_s3acc - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_s3user - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_snap - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_userpolicy - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_userquota - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays
+  - purefb_virtualhost - Only send context_names when a context is set, and only default it for fleet members, fixing "not in a fleet" errors on standalone arrays

--- a/plugins/modules/purefb_bucket.py
+++ b/plugins/modules/purefb_bucket.py
@@ -259,7 +259,7 @@ CONTEXT_API_VERSION = "2.17"
 def get_s3acc(module, blade):
     """Return Object Store Account or None"""
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_object_store_accounts(
             context_names=[module.params["context"]],
             names=[module.params["account"]],
@@ -274,7 +274,7 @@ def get_s3acc(module, blade):
 def get_bucket(module, blade):
     """Return Bucket or None"""
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_buckets(
             context_names=[module.params["context"]],
             names=[module.params["name"]],
@@ -292,7 +292,7 @@ def create_bucket(module, blade):
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
         if VSO_VERSION in api_version:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 account_defaults = list(
                     blade.get_object_store_accounts(
                         names=[module.params["account"]],
@@ -342,7 +342,7 @@ def create_bucket(module, blade):
                     account=ReferenceWritable(name=module.params["account"]),
                     bucket_type=module.params["mode"],
                 )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_buckets(
                     names=[module.params["name"]],
                     bucket=bucket,
@@ -397,7 +397,7 @@ def create_bucket(module, blade):
                         versioning=None,
                     )
 
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_buckets(
                     names=[module.params["name"]],
                     bucket=bucket,
@@ -416,7 +416,7 @@ def create_bucket(module, blade):
             bucket = BucketPost(
                 account=ReferenceWritable(name=module.params["account"]),
             )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_buckets(
                     names=[module.params["name"]],
                     bucket=bucket,
@@ -433,7 +433,7 @@ def create_bucket(module, blade):
                     )
                 )
             if module.params["versioning"] != "absent":
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.buckets.patch_buckets(
                         names=[module.params["name"]],
                         bucket=BucketPatch(versioning=module.params["versioning"]),
@@ -463,7 +463,7 @@ def create_bucket(module, blade):
                     block_public_access=module.params["block_public_access"],
                 )
             )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_buckets(
                     bucket=pac,
                     names=[module.params["name"]],
@@ -485,7 +485,7 @@ def create_bucket(module, blade):
                 policy = BucketAccessPolicyPost(
                     name=module.params["name"],
                 )
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.post_buckets_bucket_access_policies(
                         bucket_names=[module.params["name"]],
                         policy=policy,
@@ -507,7 +507,7 @@ def create_bucket(module, blade):
                     principals=BucketAccessPolicyRulePrincipal(all=True),
                     resources=[module.params["name"] + "/*"],
                 )
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.post_buckets_bucket_access_policies_rules(
                         bucket_names=[module.params["name"]],
                         rule=rule,
@@ -544,7 +544,7 @@ def create_bucket(module, blade):
                     eradication_delay=module.params["eradication_delay"],
                 )
             )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_buckets(
                     bucket=worm,
                     names=[module.params["name"]],
@@ -562,7 +562,7 @@ def create_bucket(module, blade):
 
 def _delete_bucket(module, blade):
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         blade.patch_buckets(
             names=[module.params["name"]],
             bucket=BucketPatch(destroyed=True),
@@ -575,11 +575,8 @@ def _delete_bucket(module, blade):
         blade.patch_buckets(
             names=[module.params["name"]],
             bucket=BucketPatch(destroyed=True),
-            context_names=[module.params["context"]],
         )
-        blade.buckets.delete_buckets(
-            names=[module.params["name"]], context_names=[module.params["context"]]
-        )
+        blade.buckets.delete_buckets(names=[module.params["name"]])
 
 
 def delete_bucket(module, blade):
@@ -587,7 +584,7 @@ def delete_bucket(module, blade):
     changed = True
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.patch_buckets(
                 names=[module.params["name"]],
                 bucket=BucketPatch(destroyed=True),
@@ -603,7 +600,7 @@ def delete_bucket(module, blade):
                 "Error: {1}".format(module.params["name"], get_error_message(res))
             )
         if module.params["eradicate"]:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.delete_buckets(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -623,7 +620,7 @@ def recover_bucket(module, blade):
     changed = True
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.patch_buckets(
                 names=[module.params["name"]],
                 bucket=BucketPatch(destroyed=False),
@@ -649,7 +646,7 @@ def update_bucket(module, blade, bucket):
     change_worm = False
     change_quota = False
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         bucket_detail = list(
             blade.get_buckets(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -700,7 +697,7 @@ def update_bucket(module, blade, bucket):
         if bucket.versioning != versioning:
             changed = True
             if not module.check_mode:
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.patch_buckets(
                         names=[module.params["name"]],
                         bucket=BucketPatch(versioning=versioning),
@@ -720,7 +717,7 @@ def update_bucket(module, blade, bucket):
     elif module.params["versioning"] != "absent":
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_buckets(
                     names=[module.params["name"]],
                     bucket=BucketPatch(versioning=module.params["versioning"]),
@@ -771,7 +768,7 @@ def update_bucket(module, blade, bucket):
                     quota_limit=str(new_quota["quota"]),
                     hard_limit_enabled=new_quota["hard"],
                 )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_buckets(
                     bucket=bucket,
                     names=[module.params["name"]],
@@ -810,7 +807,7 @@ def update_bucket(module, blade, bucket):
                 )
             )
         if change_pac and not module.check_mode:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_buckets(
                     bucket=pac,
                     names=[module.params["name"]],
@@ -862,7 +859,7 @@ def update_bucket(module, blade, bucket):
                 )
             )
         if change_worm and not module.check_mode:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_buckets(
                     bucket=worm,
                     names=[module.params["name"]],
@@ -883,7 +880,7 @@ def eradicate_bucket(module, blade):
     changed = True
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.delete_buckets(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -951,7 +948,9 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
 
     # From REST 2.12 classic is no longer the default mode
     if MODE_VERSION in api_version:

--- a/plugins/modules/purefb_bucket_access.py
+++ b/plugins/modules/purefb_bucket_access.py
@@ -214,7 +214,7 @@ def delete_cors_policy(module, blade):
     changed = True
     if not module.check_mode:
         if module.params["rule"]:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.get_buckets_cross_origin_resource_sharing_policies_rules(
                     bucket_names=[module.params["name"]],
                     names=[module.params["rule"]],
@@ -228,7 +228,7 @@ def delete_cors_policy(module, blade):
                 changed = False
                 module.exit_json(changed=changed)
 
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.delete_buckets_cross_origin_resource_sharing_policies_rules(
                     names=module.params["rule"],
                     bucket_names=module.params["name"],
@@ -247,7 +247,7 @@ def delete_cors_policy(module, blade):
                     )
                 )
         else:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.get_buckets_cross_origin_resource_sharing_policies(
                     bucket_names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -260,7 +260,7 @@ def delete_cors_policy(module, blade):
                 changed = False
                 module.exit_json(changed=changed)
 
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.delete_buckets_cross_origin_resource_sharing_policies(
                     bucket_names=module.params["name"],
                     context_names=[module.params["context"]],
@@ -286,7 +286,7 @@ def delete_access_policy(module, blade):
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
         if module.params["rule"]:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.get_buckets_bucket_access_policies_rules(
                     bucket_names=[module.params["name"]],
                     names=[module.params["rule"]],
@@ -300,7 +300,7 @@ def delete_access_policy(module, blade):
                 changed = False
                 module.exit_json(changed=changed)
 
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.delete_buckets_bucket_access_policies_rules(
                     names=module.params["rule"],
                     bucket_names=module.params["name"],
@@ -319,7 +319,7 @@ def delete_access_policy(module, blade):
                     )
                 )
         else:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.get_buckets_bucket_access_policies(
                     bucket_names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -332,7 +332,7 @@ def delete_access_policy(module, blade):
                 changed = False
                 module.exit_json(changed=changed)
 
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.delete_buckets_bucket_access_policies(
                     bucket_names=module.params["name"],
                     context_names=[module.params["context"]],
@@ -355,7 +355,7 @@ def create_access_policy(module, blade):
     """Create bucket access policy or rule"""
     changed = False
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_buckets_bucket_access_policies(
             bucket_names=[module.params["name"]],
             context_names=[module.params["context"]],
@@ -368,7 +368,7 @@ def create_access_policy(module, blade):
         # Need to create the policy with its first rule
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_buckets_bucket_access_policies(
                     bucket_names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -386,7 +386,7 @@ def create_access_policy(module, blade):
     # Create a new rule for the policy
     if not module.check_mode:
         changed = True
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_buckets_bucket_access_policies_rules(
                 bucket_names=[module.params["name"]],
                 names=[module.params["rule"]],
@@ -403,7 +403,7 @@ def create_access_policy(module, blade):
         all_resources = []
         for resource in module.params["resources"]:
             all_resources.append(module.params["name"] + "/" + resource)
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.post_buckets_bucket_access_policies_rules(
                 bucket_names=[module.params["name"]],
                 names=module.params["rule"],
@@ -444,7 +444,7 @@ def create_cors_policy(module, blade):
     """Create CORS policy or rule"""
     changed = False
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_buckets_cross_origin_resource_sharing_policies(
             bucket_names=[module.params["name"]],
             context_names=[module.params["context"]],
@@ -457,7 +457,7 @@ def create_cors_policy(module, blade):
         # Need to create the policy with its first rule
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_buckets_cross_origin_resource_sharing_policies(
                     bucket_names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -475,7 +475,7 @@ def create_cors_policy(module, blade):
     # Create a new rule for the policy
     if not module.check_mode:
         changed = True
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_buckets_cross_origin_resource_sharing_policies_rules(
                 bucket_names=[module.params["name"]],
                 names=[module.params["rule"]],
@@ -489,7 +489,7 @@ def create_cors_policy(module, blade):
             changed = False
             module.exit_json(changed=changed)
 
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.post_buckets_cross_origin_resource_sharing_policies_rules(
                 bucket_names=[module.params["name"]],
                 names=module.params["rule"],
@@ -618,14 +618,16 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
     if MIN_API_VERSION not in api_version:
         module.fail_json(
             msg=(
                 "Minimum FlashBlade REST version required: {0}".format(MIN_API_VERSION)
             )
         )
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_buckets(
             names=[module.params["name"]],
             destroyed=False,

--- a/plugins/modules/purefb_bucket_replica.py
+++ b/plugins/modules/purefb_bucket_replica.py
@@ -133,7 +133,7 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.common impo
 def get_local_bucket(module, blade):
     """Return Bucket or None"""
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_buckets(
             context_names=[module.params["context"]],
             names=[module.params["name"]],
@@ -150,7 +150,7 @@ def get_local_bucket(module, blade):
 def get_remote_cred(module, blade, target):
     """Return Remote Credential or None"""
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_object_store_remote_credentials(
             names=[target + "/" + module.params["credential"]],
             context_names=[module.params["context"]],
@@ -169,7 +169,7 @@ def get_remote_cred(module, blade, target):
 def get_local_rl(module, blade):
     """Return Bucket Replica Link or None"""
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_bucket_replica_links(
             local_bucket_names=[module.params["name"]],
             context_names=[module.params["context"]],
@@ -185,7 +185,7 @@ def get_local_rl(module, blade):
 
 def get_connected(module, blade):
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         connected_blades = blade.get_array_connections(
             context_names=[module.params["context"]]
         )
@@ -198,7 +198,7 @@ def get_connected(module, blade):
             "partially_connected",
         ]:
             return item.remote.name
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         connected_targets = blade.get_targets(context_names=[module.params["context"]])
     else:
         connected_targets = blade.get_targets()
@@ -225,7 +225,7 @@ def create_rl(module, blade, remote_cred):
             cascading_enabled=module.params["cascading"],
             paused=module.params["paused"],
         )
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.post_bucket_replica_links(
                 local_bucket_names=[module.params["name"]],
                 remote_bucket_names=[module.params["target_bucket"]],
@@ -270,7 +270,7 @@ def update_rl_policy(module, blade, local_replica_link):
     else:
         cascading = local_replica_link.cascading_enabled
     if not module.check_mode and changed:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.patch_bucket_replica_links(
                 local_bucket_names=[module.params["name"]],
                 remote_bucket_names=[local_replica_link.remote_bucket.name],
@@ -307,7 +307,7 @@ def delete_rl_policy(module, blade, local_replica_link):
     api_version = list(blade.get_versions().items)
     changed = True
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.delete_bucket_replica_links(
                 remote_names=[local_replica_link.remote.name],
                 local_bucket_names=[module.params["name"]],
@@ -355,7 +355,9 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
 
     local_replica_link = get_local_rl(module, blade)
 

--- a/plugins/modules/purefb_connect.py
+++ b/plugins/modules/purefb_connect.py
@@ -153,7 +153,7 @@ FAN_OUT_MAXIMUM = 5
 
 def _check_connected(module, blade):
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         connected_blades = list(
             blade.get_array_connections(context_names=[module.params["context"]]).items
         )
@@ -191,7 +191,7 @@ def break_connection(module, blade, target_blade):
     api_version = list(blade.get_versions().items)
     changed = True
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             source_blade = (
                 blade.get_arrays(context_names=[module.params["context"]]).items[0].name
             )
@@ -201,7 +201,7 @@ def break_connection(module, blade, target_blade):
             module.fail_json(
                 msg="Disconnect can only happen from the array that formed the connection"
             )
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.delete_array_connections(
                 remote_names=[target_blade.remote.name],
                 context_names=[module.params["context"]],
@@ -223,7 +223,7 @@ def create_connection(module, blade):
     """Create connection between REST 2 capable arrays"""
     api_version = list(blade.get_versions().items)
     changed = True
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_array_connections(context_names=[module.params["context"]])
     else:
         res = blade.get_array_connections()
@@ -295,7 +295,7 @@ def create_connection(module, blade):
             connection_key=connection_key,
         )
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.post_array_connections(
                 array_connection=connection_info,
                 context_names=[module.params["context"]],
@@ -327,7 +327,7 @@ def update_connection(module, blade):
             msg="Update can only happen from the array that formed the connection"
         )
     if module.params["encrypted"] != remote_connection.encrypted:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_file_system_replica_links(
                 context_names=[module.params["context"]]
             )
@@ -346,7 +346,7 @@ def update_connection(module, blade):
         not remote_connection.throttle.default_limit
         and not remote_connection.throttle.window_limit
     ):
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             blade.get_bucket_replica_links(context_names=[module.params["context"]])
         else:
             blade.get_bucket_replica_links()
@@ -417,7 +417,7 @@ def update_connection(module, blade):
                 encrypted=new_connection["encrypted"],
                 throttle=throttle,
             )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_array_connections(
                     remote_names=[remote_name],
                     array_connection=connection_info,
@@ -467,7 +467,9 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
 
     if module.params["default_limit"]:
         if (

--- a/plugins/modules/purefb_export.py
+++ b/plugins/modules/purefb_export.py
@@ -143,6 +143,17 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.common impo
 MIN_API_VERSION = "2.17"
 
 
+def _context_kwargs(module):
+    """Return context_names kwargs only when a context is set.
+
+    A standalone array is "not in a fleet" and rejects fleet context, so
+    only send context_names when a context has actually been provided.
+    """
+    if module.params["context"]:
+        return {"context_names": [module.params["context"]]}
+    return {}
+
+
 def get_export(module, blade):
     """Return Filesystem export true name or None"""
     filter_string = (
@@ -156,9 +167,7 @@ def get_export(module, blade):
         + module.params["server"]
         + "'"
     )
-    res = blade.get_file_system_exports(
-        context_names=[module.params["context"]], filter=filter_string
-    )
+    res = blade.get_file_system_exports(filter=filter_string, **_context_kwargs(module))
     if res.status_code == 200 and res.total_item_count != 0:
         return list(res.items)[0]
     return None
@@ -175,9 +184,9 @@ def create_export(module, blade):
             )
             res = blade.post_file_system_exports(
                 file_system_export=exp_obj,
-                context_names=[module.params["context"]],
                 member_names=[module.params["filesystem"]],
                 policy_names=[module.params["export_policy"]],
+                **_context_kwargs(module),
             )
         else:
             if not module.params["client_policy"]:
@@ -191,9 +200,9 @@ def create_export(module, blade):
             )
             res = blade.post_file_system_exports(
                 file_system_export=exp_obj,
-                context_names=[module.params["context"]],
                 member_names=[module.params["filesystem"]],
                 policy_names=[module.params["client_policy"]],
+                **_context_kwargs(module),
             )
 
     if res.status_code != 200:
@@ -333,7 +342,9 @@ def main():
     api_version = list(blade.get_versions().items)
     if MIN_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
     server_exists = bool(
         blade.get_servers(names=[module.params["server"]]).status_code == 200
     )

--- a/plugins/modules/purefb_groupquota.py
+++ b/plugins/modules/purefb_groupquota.py
@@ -144,7 +144,7 @@ def get_quota(module, blade):
     """Return Filesystem User Quota or None"""
     api_version = list(blade.get_versions().items)
     if module.params["gid"]:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_quotas_groups(
                 file_system_names=[module.params["name"]],
                 filter="group.id=" + str(module.params["gid"]),
@@ -156,7 +156,7 @@ def get_quota(module, blade):
                 filter="group.id=" + str(module.params["gid"]),
             )
     else:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_quotas_groups(
                 file_system_names=[module.params["name"]],
                 filter="group.name='" + module.params["gname"] + "'",
@@ -178,7 +178,7 @@ def create_quota(module, blade):
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
         if module.params["gid"]:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_quotas_groups(
                     file_system_names=[module.params["name"]],
                     gids=[module.params["gid"]],
@@ -204,7 +204,7 @@ def create_quota(module, blade):
                     )
                 )
         else:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_quotas_groups(
                     file_system_names=[module.params["name"]],
                     group_names=[module.params["gname"]],
@@ -241,7 +241,7 @@ def update_quota(module, blade):
         changed = True
         if not module.check_mode:
             if module.params["gid"]:
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.patch_quotas_groups(
                         file_system_names=[module.params["name"]],
                         gids=[module.params["gid"]],
@@ -267,7 +267,7 @@ def update_quota(module, blade):
                         )
                     )
             else:
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.patch_quotas_groups(
                         file_system_names=[module.params["name"]],
                         group_names=[module.params["gname"]],
@@ -301,7 +301,7 @@ def delete_quota(module, blade):
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
         if module.params["gid"]:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.delete_quotas_groups(
                     file_system_names=[module.params["name"]],
                     gids=[module.params["gid"]],
@@ -319,7 +319,7 @@ def delete_quota(module, blade):
                     )
                 )
         else:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.delete_quotas_groups(
                     file_system_names=[module.params["name"]],
                     group_names=[module.params["gname"]],
@@ -371,7 +371,9 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
     fsys = get_filesystem(module, blade)
     if not fsys:
         module.fail_json(

--- a/plugins/modules/purefb_lifecycle.py
+++ b/plugins/modules/purefb_lifecycle.py
@@ -145,7 +145,7 @@ CONTEXT_API_VERSION = "2.17"
 
 def _get_bucket(module, blade):
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_buckets(
             names=[module.params["bucket"]], context_names=[module.params["context"]]
         )
@@ -175,7 +175,7 @@ def delete_rule(module, blade):
     changed = True
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.delete_lifecycle_rules(
                 names=[module.params["bucket"] + "/" + module.params["name"]],
                 context_names=[module.params["context"]],
@@ -232,7 +232,7 @@ def create_rule(module, blade):
             prefix=module.params["prefix"],
         )
         if attr.keep_current_version_until:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_lifecycle_rules(
                     rule=attr,
                     confirm_date=True,
@@ -241,7 +241,7 @@ def create_rule(module, blade):
             else:
                 res = blade.post_lifecycle_rules(rule=attr, confirm_date=True)
         else:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_lifecycle_rules(
                     rule=attr, context_names=[module.params["context"]]
                 )
@@ -257,7 +257,7 @@ def create_rule(module, blade):
             )
         if not module.params["enabled"]:
             attr = LifecycleRulePatch(enabled=module.params["enabled"])
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_lifecycle_rules(
                     names=[module.params["bucket"] + "/" + module.params["name"]],
                     lifecycle=attr,
@@ -330,7 +330,7 @@ def update_rule(module, blade, rule):
                 enabled=new_rule["enabled"],
             )
             if attr.keep_current_version_until:
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.patch_lifecycle_rules(
                         names=[module.params["bucket"] + "/" + module.params["name"]],
                         lifecycle=attr,
@@ -344,7 +344,7 @@ def update_rule(module, blade, rule):
                         confirm_date=True,
                     )
             else:
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.patch_lifecycle_rules(
                         names=[module.params["bucket"] + "/" + module.params["name"]],
                         lifecycle=attr,
@@ -399,7 +399,9 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
 
     if module.params["keep_previous_for"] and not module.params["keep_previous_for"][
         -1:
@@ -427,7 +429,7 @@ def main():
     rule = None
     if module.params["keep_current_until"]:
         module.params["keep_current_until"] = _convert_date_to_epoch(module)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_lifecycle_rules(
             names=[module.params["bucket"] + "/" + module.params["name"]],
             context_names=[module.params["context"]],

--- a/plugins/modules/purefb_remote_cred.py
+++ b/plugins/modules/purefb_remote_cred.py
@@ -112,7 +112,7 @@ CONTEXT_API_VERSION = "2.17"
 def get_connected(module, blade):
     """Return connected device or None"""
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         connected_blades = list(
             blade.get_array_connections(context_names=[module.params["context"]]).items
         )
@@ -128,7 +128,7 @@ def get_connected(module, blade):
             "partially_connected",
         ]:
             return target.remote.name
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         connected_targets = list(
             blade.get_targets(context_names=[module.params["context"]]).items
         )
@@ -147,7 +147,7 @@ def get_connected(module, blade):
 def get_remote_cred(module, blade):
     """Return Remote Credential or None"""
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_object_store_remote_credentials(
             names=[module.params["target"] + "/" + module.params["name"]],
             context_names=[module.params["context"]],
@@ -171,7 +171,7 @@ def create_credential(module, blade):
             access_key_id=module.params["access_key"],
             secret_access_key=module.params["secret"],
         )
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.post_object_store_remote_credentials(
                 names=[remote_cred],
                 remote_credentials=remote_credentials,
@@ -200,7 +200,7 @@ def update_credential(module, blade):
             access_key_id=module.params["access_key"],
             secret_access_key=module.params["secret"],
         )
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.patch_object_store_remote_credentials(
                 names=[remote_cred],
                 remote_credentials=new_attr,
@@ -225,7 +225,7 @@ def delete_credential(module, blade):
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
         remote_cred = module.params["target"] + "/" + module.params["name"]
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.delete_object_store_remote_credentials(
                 names=[remote_cred], context_names=[module.params["context"]]
             )
@@ -266,7 +266,9 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
     target = get_connected(module, blade)
 
     if not target:

--- a/plugins/modules/purefb_s3acc.py
+++ b/plugins/modules/purefb_s3acc.py
@@ -143,7 +143,7 @@ CONTEXT_API_VERSION = "2.17"
 def get_s3acc(module, blade):
     """Return Object Store Account or None"""
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_object_store_accounts(
             names=[module.params["name"]], context_names=[module.params["context"]]
         )
@@ -159,7 +159,7 @@ def update_s3acc(module, blade):
     changed = False
     api_version = list(blade.get_versions().items)
     public = False
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         acc_settings = list(
             blade.get_object_store_accounts(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -263,7 +263,7 @@ def update_s3acc(module, blade):
                         quota_limit=new_account["default_quota"],
                     ),
                 )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_object_store_accounts(
                     object_store_account=osa,
                     names=[module.params["name"]],
@@ -287,7 +287,7 @@ def create_s3acc(module, blade):
     changed = True
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.post_object_store_accounts(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -321,7 +321,7 @@ def create_s3acc(module, blade):
                     quota_limit=default_quota,
                 ),
             )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_object_store_accounts(
                     object_store_account=osa,
                     names=[module.params["name"]],
@@ -332,7 +332,7 @@ def create_s3acc(module, blade):
                     object_store_account=osa, names=[module.params["name"]]
                 )
             if res.status_code != 200:
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     blade.object_store_accounts.delete_object_store_accounts(
                         names=[module.params["name"]],
                         context_names=[module.params["context"]],
@@ -358,7 +358,7 @@ def create_s3acc(module, blade):
                     block_public_access=module.params["block_public_access"],
                 )
             )
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.patch_object_store_accounts(
                     object_store_account=osa,
                     names=[module.params["name"]],
@@ -382,7 +382,7 @@ def delete_s3acc(module, blade):
     changed = True
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_object_store_users(
                 names=[module.params["name"] + "/*'"],
                 context_names=[module.params["context"]],
@@ -393,7 +393,7 @@ def delete_s3acc(module, blade):
             module.fail_json(msg="Remove all Users from Object Store Account {0} \
                                  before deletion".format(module.params["name"]))
         else:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.delete_object_store_accounts(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -432,7 +432,9 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
 
     if module.params["quota"] or module.params["default_quota"]:
         if not HAS_PYPURECLIENT:

--- a/plugins/modules/purefb_s3user.py
+++ b/plugins/modules/purefb_s3user.py
@@ -182,7 +182,7 @@ CONTEXT_API_VERSION = "2.17"
 def get_s3acc(module, blade):
     """Return Object Store Account or None"""
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_object_store_accounts(
             names=[module.params["account"]], context_names=[module.params["context"]]
         )
@@ -197,7 +197,7 @@ def get_s3user(module, blade):
     """Return Object Store Account or None"""
     api_version = list(blade.get_versions().items)
     full_user = module.params["account"] + "/" + module.params["name"]
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_object_store_users(
             names=[full_user], context_names=[module.params["context"]]
         )
@@ -217,7 +217,7 @@ def update_s3user(module, blade):
     user = module.params["account"] + "/" + module.params["name"]
     if module.params["access_key"] or module.params["imported_key"]:
         key_count = 0
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             keys = list(
                 blade.get_object_store_access_keys(
                     context_names=[module.params["context"]]
@@ -242,7 +242,10 @@ def update_s3user(module, blade):
                     ):
                         changed = True
                         if not module.check_mode:
-                            if CONTEXT_API_VERSION in api_version:
+                            if (
+                                CONTEXT_API_VERSION in api_version
+                                and module.params["context"]
+                            ):
                                 res = blade.post_object_store_access_keys(
                                     object_store_access_key=ObjectStoreAccessKeyPost(
                                         user={"name": user}
@@ -258,7 +261,10 @@ def update_s3user(module, blade):
                             if res.status_code == 200:
                                 result = list(res.items)[0]
                                 if not module.params["enable_key"]:
-                                    if CONTEXT_API_VERSION in api_version:
+                                    if (
+                                        CONTEXT_API_VERSION in api_version
+                                        and module.params["context"]
+                                    ):
                                         blade.patch_object_store_access_keys(
                                             names=[result.name],
                                             object_store_access_key=ObjectStoreAccessKey(
@@ -290,7 +296,10 @@ def update_s3user(module, blade):
                 else:
                     changed = True
                     if not module.check_mode:
-                        if CONTEXT_API_VERSION in api_version:
+                        if (
+                            CONTEXT_API_VERSION in api_version
+                            and module.params["context"]
+                        ):
                             res = blade.post_object_store_access_keys(
                                 names=[module.params["imported_key"]],
                                 object_store_access_key=ObjectStoreAccessKeyPost(
@@ -310,7 +319,10 @@ def update_s3user(module, blade):
                         if res.status_code == 200:
                             result = list(res.items)[0]
                             if not module.params["enable_key"]:
-                                if CONTEXT_API_VERSION in api_version:
+                                if (
+                                    CONTEXT_API_VERSION in api_version
+                                    and module.params["context"]
+                                ):
                                     blade.patch_object_store_access_keys(
                                         names=[result.name],
                                         object_store_access_key=ObjectStoreAccessKey(
@@ -349,7 +361,7 @@ def create_s3user(module, blade):
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
         user = module.params["account"] + "/" + module.params["name"]
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.post_object_store_users(
                 names=[user], context_names=[module.params["context"]]
             )
@@ -364,7 +376,7 @@ def create_s3user(module, blade):
         if module.params["access_key"] and module.params["imported_key"]:
             module.warn("'access_key: true' overrides imported keys")
         if module.params["access_key"]:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_object_store_access_keys(
                     object_store_access_key=ObjectStoreAccessKeyPost(
                         user={"name": user}
@@ -380,7 +392,7 @@ def create_s3user(module, blade):
             if res.status_code == 200:
                 result = list(res.items)[0]
                 if not module.params["enable_key"]:
-                    if CONTEXT_API_VERSION in api_version:
+                    if CONTEXT_API_VERSION in api_version and module.params["context"]:
                         blade.patch_object_store_access_keys(
                             names=[result.name],
                             object_store_access_key=ObjectStoreAccessKey(enabled=False),
@@ -406,7 +418,7 @@ def create_s3user(module, blade):
                 )
         else:
             if module.params["imported_key"]:
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.post_object_store_access_keys(
                         names=[module.params["imported_key"]],
                         object_store_access_key=ObjectStoreAccessKeyPost(
@@ -426,7 +438,10 @@ def create_s3user(module, blade):
                 if res.status_code == 200:
                     result = list(res.items)[0]
                     if not module.params["enable_key"]:
-                        if CONTEXT_API_VERSION in api_version:
+                        if (
+                            CONTEXT_API_VERSION in api_version
+                            and module.params["context"]
+                        ):
                             blade.patch_object_store_access_keys(
                                 names=[result.name],
                                 object_store_access_key=ObjectStoreAccessKey(
@@ -450,7 +465,7 @@ def create_s3user(module, blade):
         if module.params["policy"]:
             policy_list = module.params["policy"]
             for policy in policy_list:
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.get_object_store_access_policies(
                         names=[policy],
                         context_names=[module.params["context"]],
@@ -462,7 +477,7 @@ def create_s3user(module, blade):
                     policy_list.remove(policy)
             username = module.params["account"] + "/" + module.params["name"]
             for policy in policy_list:
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.get_object_store_users_object_store_access_policies(
                         member_names=[username],
                         policy_names=[policy],
@@ -473,7 +488,7 @@ def create_s3user(module, blade):
                         member_names=[username], policy_names=[policy]
                     )
                 if not list(res.items):
-                    if CONTEXT_API_VERSION in api_version:
+                    if CONTEXT_API_VERSION in api_version and module.params["context"]:
                         res = (
                             blade.post_object_store_access_policies_object_store_users(
                                 member_names=[username],
@@ -510,7 +525,7 @@ def remove_key(module, blade):
     """Remove Access Key from User"""
     changed = False
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_object_store_access_keys(
             names=[module.params["key_name"]], context_names=[module.params["context"]]
         )
@@ -519,7 +534,7 @@ def remove_key(module, blade):
     if res.status_code == 200:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.delete_object_store_access_keys(
                     names=[module.params["key_name"]],
                     context_names=[module.params["context"]],
@@ -543,7 +558,7 @@ def change_key(module, blade):
     changed = False
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_object_store_access_keys(
                 names=[module.params["key_name"]],
                 context_names=[module.params["context"]],
@@ -554,7 +569,7 @@ def change_key(module, blade):
             key = list(res.items)[0]
             if key.enabled != module.params["enable_key"]:
                 changed = True
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.patch_object_store_access_keys(
                         names=[module.params["key_name"]],
                         object_store_access_key=ObjectStoreAccessKey(
@@ -585,7 +600,7 @@ def delete_s3user(module, blade, internal=False):
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
         user = module.params["account"] + "/" + module.params["name"]
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.delete_object_store_users(
                 names=[user], context_names=[module.params["context"]]
             )
@@ -641,7 +656,9 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
 
     upper = False
     for element in module.params["account"]:

--- a/plugins/modules/purefb_snap.py
+++ b/plugins/modules/purefb_snap.py
@@ -166,7 +166,7 @@ CONTEXT_API_VERSION = "2.17"
 def get_latest_fssnapshot(module, blade):
     """Get the name of the latest snpshot or None"""
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_file_system_snapshots(
             names_or_owner_names=[module.params["name"]],
             context_names=[module.params["context"]],
@@ -195,7 +195,7 @@ def get_latest_fssnapshot(module, blade):
 def get_fssnapshot(module, blade):
     """Return Snapshot or None"""
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         res = blade.get_file_system_snapshots(
             names_or_owner_names=[
                 module.params["name"] + "." + module.params["suffix"]
@@ -221,7 +221,7 @@ def create_snapshot(module, blade):
     # so this provides backwards compatability
     # target = module.params["target"].replace("[", "").replace("'", "").replace("]", "")
     blade_exists = False
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         connected_blades = list(
             blade.get_array_connections(context_names=[module.params["context"]]).items
         )
@@ -240,7 +240,7 @@ def create_snapshot(module, blade):
     changed = True
     if not module.check_mode:
         if module.params["target"]:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_file_system_snapshots(
                     source_names=[module.params["name"]],
                     send=module.params["now"],
@@ -260,7 +260,7 @@ def create_snapshot(module, blade):
                     ),
                 )
         else:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_file_system_snapshots(
                     source_names=[module.params["name"]],
                     file_system_snapshot=FileSystemSnapshotPost(
@@ -291,7 +291,7 @@ def restore_snapshot(module, blade):
     snapname = get_latest_fssnapshot(module, blade)
     if snapname is not None:
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.post_file_systems(
                     names=[module.params["name"]],
                     overwrite=True,
@@ -327,7 +327,7 @@ def recover_snapshot(module, blade):
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
         snapname = module.params["name"] + "." + module.params["suffix"]
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.patch_file_system_snapshots(
                 names=[snapname],
                 file_system_snapshot=FileSystemSnapshot(destroyed=False),
@@ -359,7 +359,7 @@ def delete_snapshot(module, blade):
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
         snapname = module.params["name"] + "." + module.params["suffix"]
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.patch_file_system_snapshots(
                 names=[snapname],
                 latest_replica=module.params["latest_replica"],
@@ -379,7 +379,7 @@ def delete_snapshot(module, blade):
                 )
             )
         if module.params["eradicate"]:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.delete_file_system_snapshots(
                     names=[snapname], context_names=[module.params["context"]]
                 )
@@ -400,7 +400,7 @@ def eradicate_snapshot(module, blade):
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
         snapname = module.params["name"] + "." + module.params["suffix"]
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.delete_file_system_snapshots(
                 names=[snapname], context_names=[module.params["context"]]
             )
@@ -449,7 +449,9 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
 
     if SNAP_NOW_API not in api_version and module.params["now"]:
         module.fail_json(

--- a/plugins/modules/purefb_userpolicy.py
+++ b/plugins/modules/purefb_userpolicy.py
@@ -123,7 +123,7 @@ CONTEXT_API_VERSION = "2.17"
 
 def _check_valid_policy(module, blade, policy):
     api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         return bool(
             blade.get_object_store_access_policies(
                 names=[policy], context_names=[module.params["context"]]
@@ -143,7 +143,7 @@ def add_policy(module, blade):
             module.fail_json(msg="Policy {0} is not valid.".format(policy))
     username = module.params["account"] + "/" + module.params["name"]
     for policy in policy_list:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_object_store_users_object_store_access_policies(
                 member_names=[username],
                 policy_names=[policy],
@@ -156,7 +156,7 @@ def add_policy(module, blade):
         if not list(res.items):
             if not module.check_mode:
                 changed = True
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.post_object_store_access_policies_object_store_users(
                         member_names=[username],
                         policy_names=[policy],
@@ -171,7 +171,7 @@ def add_policy(module, blade):
                                 policy, get_error_message(res)
                             )
                         )
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     user_policies = list(
                         blade.get_object_store_access_policies_object_store_users(
                             member_names=[username],
@@ -206,7 +206,7 @@ def remove_policy(module, blade):
             module.fail_json(msg="Policy {0} is not valid.".format(policy))
     username = module.params["account"] + "/" + module.params["name"]
     for policy in policy_list:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.get_object_store_users_object_store_access_policies(
                 member_names=[username],
                 policy_names=[policy],
@@ -219,7 +219,7 @@ def remove_policy(module, blade):
         if res == 1:
             if not module.check_mode:
                 changed = True
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.delete_object_store_access_policies_object_store_users(
                         member_names=[username],
                         policy_names=[policy],
@@ -229,7 +229,7 @@ def remove_policy(module, blade):
                     res = blade.delete_object_store_access_policies_object_store_users(
                         member_names=[username], policy_names=[policy]
                     )
-                if CONTEXT_API_VERSION in api_version:
+                if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     user_policies = list(
                         blade.get_object_store_access_policies_object_store_users(
                             member_names=[username],
@@ -261,7 +261,7 @@ def list_policy(module, blade):
     if not module.check_mode:
         if module.params["account"] and module.params["name"]:
             username = module.params["account"] + "/" + module.params["name"]
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 user_policies = list(
                     blade.get_object_store_access_policies_object_store_users(
                         member_names=[username],
@@ -277,7 +277,7 @@ def list_policy(module, blade):
             for user_policy in user_policies:
                 policy_list.append(user_policy.policy.name)
         else:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 policies = blade.get_object_store_access_policies(
                     context_names=[module.params["context"]]
                 )
@@ -316,7 +316,9 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
 
     state = module.params["state"]
     if (

--- a/plugins/modules/purefb_userquota.py
+++ b/plugins/modules/purefb_userquota.py
@@ -144,7 +144,7 @@ def get_quota(module, blade):
     """Return Filesystem User Quota or None"""
     versions = list(blade.get_versions().items)
     if module.params["uid"]:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.get_quotas_users(
                 file_system_names=[module.params["name"]],
                 filter="user.id=" + str(module.params["uid"]),
@@ -156,7 +156,7 @@ def get_quota(module, blade):
                 filter="user.id=" + str(module.params["uid"]),
             )
     else:
-        if CONTEXT_API_VERSION in versions:
+        if CONTEXT_API_VERSION in versions and module.params["context"]:
             res = blade.get_quotas_users(
                 file_system_names=[module.params["name"]],
                 filter="user.name='" + module.params["uname"] + "'",
@@ -179,7 +179,7 @@ def create_quota(module, blade):
     quota = int(human_to_bytes(module.params["quota"]))
     if not module.check_mode:
         if module.params["uid"]:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.post_quotas_users(
                     file_system_names=[module.params["name"]],
                     uids=[module.params["uid"]],
@@ -193,7 +193,7 @@ def create_quota(module, blade):
                     quota=UserQuotaPost(quota=quota),
                 )
         else:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.post_quotas_users(
                     file_system_names=[module.params["name"]],
                     user_names=[module.params["uname"]],
@@ -236,7 +236,7 @@ def update_quota(module, blade):
         changed = True
         if not module.check_mode:
             if module.params["uid"]:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.patch_quotas_users(
                         file_system_names=[module.params["name"]],
                         uids=[module.params["uid"]],
@@ -258,7 +258,7 @@ def update_quota(module, blade):
                         )
                     )
             else:
-                if CONTEXT_API_VERSION in versions:
+                if CONTEXT_API_VERSION in versions and module.params["context"]:
                     res = blade.patch_quotas_users(
                         file_system_names=[module.params["name"]],
                         user_names=[module.params["uname"]],
@@ -288,7 +288,7 @@ def delete_quota(module, blade):
     versions = list(blade.get_versions().items)
     if not module.check_mode:
         if module.params["uid"]:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.delete_quotas_users(
                     file_system_names=[module.params["name"]],
                     uids=[module.params["uid"]],
@@ -300,7 +300,7 @@ def delete_quota(module, blade):
                     uids=[module.params["uid"]],
                 )
         else:
-            if CONTEXT_API_VERSION in versions:
+            if CONTEXT_API_VERSION in versions and module.params["context"]:
                 res = blade.delete_quotas_users(
                     file_system_names=[module.params["name"]],
                     user_names=[module.params["uname"]],
@@ -361,7 +361,9 @@ def main():
     versions = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in versions and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
     fsys = get_filesystem(module, blade)
     if not fsys:
         module.fail_json(

--- a/plugins/modules/purefb_virtualhost.py
+++ b/plugins/modules/purefb_virtualhost.py
@@ -86,7 +86,7 @@ def delete_host(module, blade):
     else:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version:
+            if CONTEXT_API_VERSION in api_version and module.params["context"]:
                 res = blade.delete_object_store_virtual_hosts(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -109,7 +109,7 @@ def add_host(module, blade):
     changed = True
     api_version = list(blade.get_versions().items)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version:
+        if CONTEXT_API_VERSION in api_version and module.params["context"]:
             res = blade.post_object_store_virtual_hosts(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -140,10 +140,12 @@ def main():
     api_version = list(blade.get_versions().items)
     if CONTEXT_API_VERSION in api_version and not module.params["context"]:
         # If no context is provided set the context to the local array name
-        module.params["context"] = list(blade.get_arrays().items)[0].name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
     state = module.params["state"]
 
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         exists = bool(
             blade.get_object_store_virtual_hosts(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -157,7 +159,7 @@ def main():
             ).status_code
             == 200
         )
-    if CONTEXT_API_VERSION in api_version:
+    if CONTEXT_API_VERSION in api_version and module.params["context"]:
         vhosts = blade.get_object_store_virtual_hosts(
             context_names=[module.params["context"]]
         )


### PR DESCRIPTION
##### SUMMARY
The `context_names` handling assumed any REST 2.17+ array was fleet-capable: it defaulted context to the local array name and sent `context_names` on every call, causing `"Cannot find array in fleet: not in a fleet"` on standalone (non-fleet) arrays.

Across all remaining context-aware modules:
  - Only send `context_names` when a `context` is explicitly set (the existing no-context else branch now runs otherwise).
  - Only default the `context` to the local array name when the array is actually a fleet member (gated on `get_fleets()`).

Also fixes `purefb_bucket._delete_bucket`, whose else branch still sent `context_names`, and routes `purefb_export`'s unconditional sends through a `_context_kwargs` helper.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Multiple