### PR TITLE
Add get_rest_api_version helper for FlashBlade REST API gating

### DIFF
--- a/changelogs/fragments/556_api_version_helper.yaml
+++ b/changelogs/fragments/556_api_version_helper.yaml
@@ -1,5 +1,5 @@
 minor_changes:
-  - purefb - Add ``get_array_api_version`` helper in ``module_utils/common.py`` that returns the highest REST API version supported by the FlashBlade as a string, using ``LooseVersion`` ordering so semantic versions like ``2.10`` rank above ``2.9``.
+  - purefb - Add ``get_rest_api_version`` helper that returns the highest REST API version supported by the FlashBlade as a string, mirroring FlashArray's ``array.get_rest_version()``.
   - purefb_s3_export_policy - Use the highest supported REST version when comparing against the minimum required API version.
   - purefb_s3acc_export - Use the highest supported REST version when comparing against the minimum required API version.
   - purefb_realm - Use the highest supported REST version when comparing against the minimum required API version.

--- a/changelogs/fragments/556_api_version_helper.yaml
+++ b/changelogs/fragments/556_api_version_helper.yaml
@@ -1,0 +1,6 @@
+minor_changes:
+  - purefb - Add ``get_array_api_version`` helper in ``module_utils/common.py`` that returns the highest REST API version supported by the FlashBlade as a string, using ``LooseVersion`` ordering so semantic versions like ``2.10`` rank above ``2.9``.
+  - purefb_s3_export_policy - Use the highest supported REST version when comparing against the minimum required API version.
+  - purefb_s3acc_export - Use the highest supported REST version when comparing against the minimum required API version.
+  - purefb_realm - Use the highest supported REST version when comparing against the minimum required API version.
+  - purefb_fleet - Use the highest supported REST version when comparing against the minimum required API version.

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -115,13 +115,13 @@ def get_filesystem(module, blade):
     return None
 
 
-def get_array_api_version(blade):
+def get_rest_api_version(blade):
     """Return the highest REST API version the FlashBlade supports as a string.
 
-    pypureclient's FlashBlade SDK has no get_rest_version() equivalent to
-    FlashArray, and blade.get_versions().items is the full list of supported
-    versions — passing that list to LooseVersion raises. Use this helper to
-    obtain a single version string suitable for LooseVersion comparisons.
+    Mirrors FlashArray's ``array.get_rest_version()``, which pypureclient does
+    not expose for FlashBlade. ``blade.get_versions().items`` is the full list
+    of supported versions; this helper picks the highest using LooseVersion
+    ordering so the result can be fed straight into LooseVersion comparisons.
     """
     from ansible_collections.purestorage.flashblade.plugins.module_utils.version import (
         LooseVersion,

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -115,6 +115,22 @@ def get_filesystem(module, blade):
     return None
 
 
+def get_array_api_version(blade):
+    """Return the highest REST API version the FlashBlade supports as a string.
+
+    pypureclient's FlashBlade SDK has no get_rest_version() equivalent to
+    FlashArray, and blade.get_versions().items is the full list of supported
+    versions — passing that list to LooseVersion raises. Use this helper to
+    obtain a single version string suitable for LooseVersion comparisons.
+    """
+    from ansible_collections.purestorage.flashblade.plugins.module_utils.version import (
+        LooseVersion,
+    )
+
+    versions = list(blade.get_versions().items)
+    return str(max(versions, key=LooseVersion))
+
+
 def human_to_bytes(size):
     """Convert human-readable byte string to bytes.
 

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -18,6 +18,10 @@ import re
 from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.facts.utils import get_file_content
 
+from ansible_collections.purestorage.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
+
 
 def _findstr(text, match):
     """Find first line in text containing match string.
@@ -123,9 +127,6 @@ def get_rest_api_version(blade):
     of supported versions; this helper picks the highest using LooseVersion
     ordering so the result can be fed straight into LooseVersion comparisons.
     """
-    from ansible_collections.purestorage.flashblade.plugins.module_utils.version import (
-        LooseVersion,
-    )
 
     versions = list(blade.get_versions().items)
     return str(max(versions, key=LooseVersion))

--- a/plugins/modules/purefb_fleet.py
+++ b/plugins/modules/purefb_fleet.py
@@ -125,8 +125,8 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.version imp
     LooseVersion,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.common import (
-    get_array_api_version,
     get_error_message,
+    get_rest_api_version,
 )
 import platform
 
@@ -209,7 +209,7 @@ def add_fleet_members(module, blade):
             api_token=module.params["member_api"],
             user_agent=user_agent,
         )
-        remote_api = remote_system.get_rest_version()
+        remote_api = remote_system.get_rest_api_version()
         if LooseVersion(MIN_FA_VERSION) > LooseVersion(remote_api):
             module.fail_json(
                 msg="FlashArray must be a minimum of Purity//FA 6.8.5"
@@ -345,7 +345,7 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)
-    api_version = get_array_api_version(blade)
+    api_version = get_rest_api_version(blade)
     if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashBlade REST version not supported. "

--- a/plugins/modules/purefb_fleet.py
+++ b/plugins/modules/purefb_fleet.py
@@ -109,8 +109,8 @@ try:
     from pypureclient import flasharray
     from pypureclient.flashblade import (
         FleetMemberPost,
-        FleetmemberpostMember,
-        FleetmemberpostMembers,
+        FleetMemberPostMembersMember,
+        FleetMemberPostMembers,
         FleetPatch,
     )
 except ImportError:
@@ -233,9 +233,9 @@ def add_fleet_members(module, blade):
                 fleet_names=[module.params["name"]],
                 members=FleetMemberPost(
                     members=[
-                        FleetmemberpostMembers(
+                        FleetMemberPostMembers(
                             key=fleet_key,
-                            member=FleetmemberpostMember(
+                            member=FleetMemberPostMembersMember(
                                 name=local_name, resource_type="remote-arrays"
                             ),
                         )

--- a/plugins/modules/purefb_fleet.py
+++ b/plugins/modules/purefb_fleet.py
@@ -203,14 +203,20 @@ def add_fleet_members(module, blade):
             api_token=module.params["member_api"],
             user_agent=user_agent,
         )
+        remote_version = get_rest_api_version(remote_system)
+        if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(remote_version):
+            module.fail_json(
+                msg="Remote FlashBlade must be a minimum of REST API {0}"
+                " to join a fleet".format(MIN_REQUIRED_API_VERSION)
+            )
     else:
         remote_system = flasharray.Client(
             target=module.params["member_url"],
             api_token=module.params["member_api"],
             user_agent=user_agent,
         )
-        remote_api = remote_system.get_rest_api_version()
-        if LooseVersion(MIN_FA_VERSION) > LooseVersion(remote_api):
+        remote_version = remote_system.get_rest_version()
+        if LooseVersion(MIN_FA_VERSION) > LooseVersion(remote_version):
             module.fail_json(
                 msg="FlashArray must be a minimum of Purity//FA 6.8.5"
                 " to join a fleet containing FlashBlades"

--- a/plugins/modules/purefb_fleet.py
+++ b/plugins/modules/purefb_fleet.py
@@ -125,6 +125,7 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.version imp
     LooseVersion,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.common import (
+    get_array_api_version,
     get_error_message,
 )
 import platform
@@ -344,7 +345,7 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
+    api_version = get_array_api_version(blade)
     if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashBlade REST version not supported. "

--- a/plugins/modules/purefb_realm.py
+++ b/plugins/modules/purefb_realm.py
@@ -110,8 +110,8 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.version imp
     LooseVersion,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.common import (
-    get_array_api_version,
     get_error_message,
+    get_rest_api_version,
 )
 
 MINIMUM_API_VERSION = "2.19"
@@ -289,7 +289,7 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = get_array_api_version(blade)
+    api_version = get_rest_api_version(blade)
     if LooseVersion(MINIMUM_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="Realms are not supported. Purity//FB 4.6.1, or higher, is required."

--- a/plugins/modules/purefb_realm.py
+++ b/plugins/modules/purefb_realm.py
@@ -110,6 +110,7 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.version imp
     LooseVersion,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.common import (
+    get_array_api_version,
     get_error_message,
 )
 
@@ -288,7 +289,7 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
+    api_version = get_array_api_version(blade)
     if LooseVersion(MINIMUM_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="Realms are not supported. Purity//FB 4.6.1, or higher, is required."

--- a/plugins/modules/purefb_s3_export_policy.py
+++ b/plugins/modules/purefb_s3_export_policy.py
@@ -157,8 +157,8 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb impo
     purefb_argument_spec,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.common import (
-    get_array_api_version,
     get_error_message,
+    get_rest_api_version,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.version import (
     LooseVersion,
@@ -404,7 +404,7 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)
-    api_version = get_array_api_version(blade)
+    api_version = get_rest_api_version(blade)
     if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashBlade REST version not supported. "

--- a/plugins/modules/purefb_s3_export_policy.py
+++ b/plugins/modules/purefb_s3_export_policy.py
@@ -157,6 +157,7 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb impo
     purefb_argument_spec,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.common import (
+    get_array_api_version,
     get_error_message,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.version import (
@@ -403,7 +404,7 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
+    api_version = get_array_api_version(blade)
     if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashBlade REST version not supported. "

--- a/plugins/modules/purefb_s3acc_export.py
+++ b/plugins/modules/purefb_s3acc_export.py
@@ -121,8 +121,8 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb impo
     purefb_argument_spec,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.common import (
-    get_array_api_version,
     get_error_message,
+    get_rest_api_version,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.version import (
     LooseVersion,
@@ -252,7 +252,7 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)
-    api_version = get_array_api_version(blade)
+    api_version = get_rest_api_version(blade)
     if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashBlade REST version not supported. "

--- a/plugins/modules/purefb_s3acc_export.py
+++ b/plugins/modules/purefb_s3acc_export.py
@@ -121,6 +121,7 @@ from ansible_collections.purestorage.flashblade.plugins.module_utils.purefb impo
     purefb_argument_spec,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.common import (
+    get_array_api_version,
     get_error_message,
 )
 from ansible_collections.purestorage.flashblade.plugins.module_utils.version import (
@@ -251,7 +252,7 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
+    api_version = get_array_api_version(blade)
     if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashBlade REST version not supported. "


### PR DESCRIPTION


##### SUMMARY
- Add `get_rest_api_version(blade)` to `flashblade/plugins/module_utils/common.py`. It returns the highest REST API version the FlashBlade supports as a single string, mirroring FlashArray's `array.get_rest_version()` — which the FlashBlade pypureclient SDK does not expose. The helper uses `LooseVersion` ordering when selecting the highest version
- Adopt the helper in the four modules that currently call `blade.get_versions().items` and then gate on a minimum REST version via `LooseVersion`: `purefb_s3_export_policy`, `purefb_s3acc_export`, `purefb_realm`, `purefb_fleet`. These now hand `LooseVersion` a single version string, matching the collection's standard version-comparison pattern.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
purefb_s3_export_policy.py
purefb_s3acc_export.py
purefb_realm.py
purefb_fleet.py


