### PR TITLE
purefb_dns - fix non-existent DnsPatch class reference

### DIFF
--- a/changelogs/fragments/560_fix_dns_patch_class.yaml
+++ b/changelogs/fragments/560_fix_dns_patch_class.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefb_dns - Fix incorrect ``DnsPatch`` class reference (now ``DnsPost``) that made the module wrongly report py-pure-client as not installed

--- a/plugins/modules/purefb_dns.py
+++ b/plugins/modules/purefb_dns.py
@@ -95,7 +95,7 @@ RETURN = r"""
 
 HAS_PYPURECLIENT = True
 try:
-    from pypureclient.flashblade import Dns, DnsPatch, DnsPost, Reference
+    from pypureclient.flashblade import Dns, DnsPost, Reference
 except ImportError:
     HAS_PYPURECLIENT = False
 
@@ -149,7 +149,7 @@ def create_dns(module, blade):
         if not module.check_mode:
             res = blade.post_dns(
                 names=["management"],
-                dns=DnsPatch(
+                dns=DnsPost(
                     domain=module.params["domain"],
                     nameservers=module.params["nameservers"][0:3],
                 ),


### PR DESCRIPTION
##### SUMMARY
`purefb_dns` imported `DnsPatch` from `pypureclient.flashblade` and used it in the `create_dns()` `post_dns` call. `DnsPatch` does not exist in py-pure-client; the correct model for `post_dns` is `DnsPost` (`domain` and `nameservers` are optional fields on it).

Because the bad name sat in the guarded `from pypureclient.flashblade import (...)` block, the `ImportError` was swallowed by `except ImportError: HAS_PYPURECLIENT = False`, so the module incorrectly reported that py-pure-client was not installed even when it was present.

Found via an AST sweep of every `plugins/**/*.py`, cross-checking all `pypureclient.*` imports against the installed py-pure-client 1.88.0 (the collection minimum) through the SDK lazy loader. `DnsPatch` was the only remaining non-existent class.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_dns

##### ADDITIONAL INFORMATION
- Changelog fragment included: `changelogs/fragments/560_fix_dns_patch_class.yaml`

```paste below
# black
$ black --check plugins/modules/purefb_dns.py
All done! ✨ 🍰 ✨
1 file would be left unchanged.

# unit tests
$ python3 -m pytest tests/unit -q
288 passed in 2.90s
```