### PR TITLE
Fix purefb realm docustring

### DIFF
--- a/changelogs/fragments/561_fix_realm_documentation.yaml
+++ b/changelogs/fragments/561_fix_realm_documentation.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefb_realm - Fixed incorrect documentation for ``purefb_realm`` module that was causing confusion about the required parameters. Changed from fa_url to fb_url

--- a/changelogs/fragments/561_fix_realm_documentation.yaml
+++ b/changelogs/fragments/561_fix_realm_documentation.yaml
@@ -1,2 +1,3 @@
 bugfixes:
   - purefb_realm - Fixed incorrect documentation for ``purefb_realm`` module that was causing confusion about the required parameters. Changed from fa_url to fb_url
+  

--- a/changelogs/fragments/561_fix_realm_documentation.yaml
+++ b/changelogs/fragments/561_fix_realm_documentation.yaml
@@ -1,3 +1,2 @@
 bugfixes:
   - purefb_realm - Fixed incorrect documentation for ``purefb_realm`` module that was causing confusion about the required parameters. Changed from fa_url to fb_url
-  

--- a/plugins/modules/purefb_realm.py
+++ b/plugins/modules/purefb_realm.py
@@ -60,27 +60,27 @@ EXAMPLES = r"""
     name: foo
     qos_policy: realm1_qos
     iops_qos: 100
-    fa_url: 10.10.10.2
+    fb_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
 
 - name: Destroy realm
   purestorage.flashblade.purefb_realm:
     name: foo
-    fa_url: 10.10.10.2
+    fb_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
     state: absent
 
 - name: Recover deleted realm
   purestorage.flashblade.purefb_realm:
     name: foo
-    fa_url: 10.10.10.2
+    fb_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
 
 - name: Destroy and Eradicate realm
   purestorage.flashblade.purefb_realm:
     name: foo
     eradicate: true
-    fa_url: 10.10.10.2
+    fb_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
     state: absent
 
@@ -88,7 +88,7 @@ EXAMPLES = r"""
   purestorage.flashblade.purefb_realm:
     name: foo
     rename: bar
-    fa_url: 10.10.10.2
+    fb_url: 10.10.10.2
     api_token: T-9f276a18-50ab-446e-8a0c-666a3529a1b6
 """
 


### PR DESCRIPTION
##### SUMMARY
Changed to correct variable fa_url  fb_url. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
purestorage.flashblade.purefb_realm (purefb_realm)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- Changelog fragment included: changelogs/fragments/561_fix_realm_documentation.yaml 
```bash
black --check plugins/modules/purefb_realm.py
All done! ✨ 🍰 ✨
1 file would be left unchanged.
```

Please, LMK if there is something that needs to be changed in this PR.