### PR TITLE
Bugfix post realms required field

### DIFF
--- a/changelogs/fragments/562_fix_required_field_realm.yml
+++ b/changelogs/fragments/562_fix_required_field_realm.yml
@@ -1,3 +1,2 @@
 bugfixes:
-  - purefb_realm - Fix required field ``without_default_access_list`` for post_realms. The py-pure-client requires without_default_access_list to post a new realm.
-  - test_purefb_realm - Added test with field ``without_default_access_list`` for creating realms.
+  - purefb_realm - Pass the new optional ``without_default_access_list`` parameter (default false) to post_realms, as required by py-pure-client when creating a realm

--- a/changelogs/fragments/562_fix_required_field_realm.yml
+++ b/changelogs/fragments/562_fix_required_field_realm.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefb_realm - Fix required field ``without_default_access_list`` for post_realms. The py-pure-client requires without_default_access_list to post a new realm.

--- a/changelogs/fragments/562_fix_required_field_realm.yml
+++ b/changelogs/fragments/562_fix_required_field_realm.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - purefb_realm - Fix required field ``without_default_access_list`` for post_realms. The py-pure-client requires without_default_access_list to post a new realm.
+  - test_purefb_realm - Added test with field ``without_default_access_list`` for creating realms.

--- a/changelogs/fragments/562_fix_required_field_realm.yml
+++ b/changelogs/fragments/562_fix_required_field_realm.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - purefb_realm - Fix required field ``without_default_access_list`` for post_realms. The py-pure-client requires without_default_access_list to post a new realm.
+  

--- a/changelogs/fragments/562_fix_required_field_realm.yml
+++ b/changelogs/fragments/562_fix_required_field_realm.yml
@@ -1,3 +1,2 @@
 bugfixes:
   - purefb_realm - Fix required field ``without_default_access_list`` for post_realms. The py-pure-client requires without_default_access_list to post a new realm.
-  

--- a/plugins/modules/purefb_realm.py
+++ b/plugins/modules/purefb_realm.py
@@ -30,6 +30,12 @@ options:
     - This has to be unique and not equal to any existing realm or pod.
     type: str
     required: true
+  without_default_access_list:
+    description:
+      - This required option ensures a realm is created with or without any resource accesses.
+      - Only used when creating a new Realm.
+    type: bool
+    required: true
   state:
     description:
     - Define whether the realm should exist or not.
@@ -58,6 +64,7 @@ EXAMPLES = r"""
 - name: Create new realm
   purestorage.flashblade.purefb_realm:
     name: foo
+    without_default_access_list: true
     qos_policy: realm1_qos
     iops_qos: 100
     fb_url: 10.10.10.2
@@ -161,7 +168,10 @@ def make_realm(module, blade):
     """Create Realm"""
     changed = True
     if not module.check_mode:
-        res = blade.post_realms(names=[module.params["name"]])
+        res = blade.post_realms(
+            names=[module.params["name"]],
+            without_default_access_list=[module.params["without_default_access_list"]],
+        )
         if res.status_code != 200:
             module.fail_json(
                 msg="Creation of realm {0} failed. Error: {1}".format(
@@ -279,6 +289,7 @@ def main():
         dict(
             name=dict(type="str", required=True),
             state=dict(type="str", default="present", choices=["absent", "present"]),
+            without_default_access_list=dict(type="bool", required=True),
             qos_policy=dict(type="str"),
             eradicate=dict(type="bool", default=False),
             rename=dict(type="str"),

--- a/plugins/modules/purefb_realm.py
+++ b/plugins/modules/purefb_realm.py
@@ -32,10 +32,11 @@ options:
     required: true
   without_default_access_list:
     description:
-      - This required option ensures a realm is created with or without any resource accesses.
-      - Only used when creating a new Realm.
+      - When creating a new realm, ensure it is created without any default resource accesses.
+      - Only used when creating a new realm.
     type: bool
-    required: true
+    default: false
+    version_added: '1.27.0'
   state:
     description:
     - Define whether the realm should exist or not.
@@ -288,7 +289,7 @@ def main():
     argument_spec.update(
         dict(
             name=dict(type="str", required=True),
-            without_default_access_list=dict(type="bool", required=True),
+            without_default_access_list=dict(type="bool", default=False),
             state=dict(type="str", default="present", choices=["absent", "present"]),
             qos_policy=dict(type="str"),
             eradicate=dict(type="bool", default=False),

--- a/plugins/modules/purefb_realm.py
+++ b/plugins/modules/purefb_realm.py
@@ -170,7 +170,7 @@ def make_realm(module, blade):
     if not module.check_mode:
         res = blade.post_realms(
             names=[module.params["name"]],
-            without_default_access_list=[module.params["without_default_access_list"]],
+            without_default_access_list=module.params["without_default_access_list"],
         )
         if res.status_code != 200:
             module.fail_json(
@@ -288,8 +288,8 @@ def main():
     argument_spec.update(
         dict(
             name=dict(type="str", required=True),
-            state=dict(type="str", default="present", choices=["absent", "present"]),
             without_default_access_list=dict(type="bool", required=True),
+            state=dict(type="str", default="present", choices=["absent", "present"]),
             qos_policy=dict(type="str"),
             eradicate=dict(type="bool", default=False),
             rename=dict(type="str"),

--- a/tests/unit/plugins/modules/test_purefb_realm.py
+++ b/tests/unit/plugins/modules/test_purefb_realm.py
@@ -135,7 +135,9 @@ class TestPurefbRealm:
             pass
 
         # Verify post_realms was called
-        mock_blade.post_realms.assert_called_once_with(names=["test-realm"])
+        mock_blade.post_realms.assert_called_once_with(
+            names=["test-realm"], without_default_access_list=True
+        )
 
         # Verify exit_json was called with changed=True
         mock_module.exit_json.assert_called_once()
@@ -202,7 +204,9 @@ class TestPurefbRealm:
             pass
 
         # Verify post_realms was called
-        mock_blade.post_realms.assert_called_once_with(names=["test-realm"])
+        mock_blade.post_realms.assert_called_once_with(
+            names=["test-realm"], without_default_access_list=True
+        )
 
         # Verify QoS policy was assigned
         mock_blade.post_qos_policies_members.assert_called_once_with(
@@ -670,6 +674,7 @@ class TestPurefbRealm:
         mock_module.fail_json = Mock(side_effect=SystemExit)
         mock_module.params = {
             "name": "test-realm",
+            "without_default_access_list": True,
             "state": "present",
             "qos_policy": "test-qos-policy",
             "eradicate": False,

--- a/tests/unit/plugins/modules/test_purefb_realm.py
+++ b/tests/unit/plugins/modules/test_purefb_realm.py
@@ -102,6 +102,7 @@ class TestPurefbRealm:
         mock_module.fail_json = Mock(side_effect=SystemExit)
         mock_module.params = {
             "name": "test-realm",
+            "without_default_access_list": True,
             "state": "present",
             "qos_policy": None,
             "eradicate": False,
@@ -164,6 +165,7 @@ class TestPurefbRealm:
         mock_module.fail_json = Mock(side_effect=SystemExit)
         mock_module.params = {
             "name": "test-realm",
+            "without_default_access_list": True,
             "state": "present",
             "qos_policy": "test-qos-policy",
             "eradicate": False,
@@ -549,6 +551,7 @@ class TestPurefbRealm:
         mock_module.fail_json = Mock(side_effect=SystemExit)
         mock_module.params = {
             "name": "test-realm",
+            "without_default_access_list": True,
             "state": "present",
             "qos_policy": None,
             "eradicate": False,
@@ -604,6 +607,7 @@ class TestPurefbRealm:
         mock_module.fail_json = Mock(side_effect=SystemExit)
         mock_module.params = {
             "name": "test-realm",
+            "without_default_access_list": True,
             "state": "present",
             "qos_policy": None,
             "eradicate": False,


### PR DESCRIPTION
##### SUMMARY
Bugfix for posting a new Realm on the flashBlade. When I try to post a new realm using Ansible, i got error: 

``` bash
Task failed: Module failed: Client.post_realms() missing 1 required positional argument: ''without_default_access_list''
```
When inspecting the Client.post_realms() I noticed it had a required field. In the py-pure-client, the post_realms has an required field. 
[FB_2_26](https://raw.githubusercontent.com/PureStorage-OpenConnect/py-pure-client/refs/heads/master/pypureclient/flashblade/FB_2_26/client.py)
[FB_2_27](https://raw.githubusercontent.com/PureStorage-OpenConnect/py-pure-client/refs/heads/master/pypureclient/flashblade/FB_2_27/client.py)
``` python
    def post_realms(
        self,
        names: Annotated[conlist(StrictStr), Field(..., description="A comma-separated list of resource names.")],
        without_default_access_list: Annotated[StrictBool, Field(..., description="Specifying this option ensures a realm is created without any resource accesses.")],
        references: Optional[Union[ReferenceType, List[ReferenceType]]] = None,
        x_request_id: Annotated[Optional[StrictStr], Field(description="Supplied by client during request or generated by server.")] = None,
        _preload_content: bool = True,
        _return_http_data_only: Optional[bool] = None,
        _request_timeout: Optional[Union[float, Tuple[float, float]]] = None
    ) -> Union[ValidResponse, ErrorResponse]:
...
:param without_default_access_list: Specifying this option ensures a realm is created without any resource accesses.
                                            (required)
```
It is weird that it says "Specifying" when it is a required field. Hence I changed it in the documentation of this PR to "This required option...". If you have better documentation strings, lmk in this PR.

So this bugfix add in documentation of the module, that the without_default_access_list is a required field when creating a new realm. I also verified that it is not required for patch or delete. 

I also have to update the unit tests for creating the realm. Due to without_default_access_list is required, I need to add it to the tests.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
purefb_realm

##### ADDITIONAL INFORMATION
The data that I send in to the purefb_realm:
``` yaml
- name: Create a new realm
  everpure.flashblade.purefb_realm
    name: foo
```
I also tried to add the variable in the purefb_realm module but it does not accept the `without_default_access_list`. 


I have tested the code and now I don't get an error and it creates the realm.

``` yaml
- name: Create a new realm
  everpure.flashblade.purefb_realm
    name: foo
    without_default_access_list: True
```

```paste below
black --check plugins/modules/purefb_realm.py                
All done! ✨ 🍰 ✨
1 file would be left unchanged.
```

Please verify as well. It works on my computer 😄 