### PR TITLE
Bugfix for updating server

### DIFF
--- a/changelogs/fragments/562-purefb_server_update_server.yaml
+++ b/changelogs/fragments/562-purefb_server_update_server.yaml
@@ -1,0 +1,2 @@
+Bugfixes:
+  - purefb_server - When a server existed and it should update the existing server. This will use the dns variable from the loop instead of referencing it.

--- a/changelogs/fragments/562-purefb_server_update_server.yaml
+++ b/changelogs/fragments/562-purefb_server_update_server.yaml
@@ -1,2 +1,2 @@
-Bugfixes:
+bugfixes:
   - purefb_server - When a server existed and it should update the existing server. This will use the dns variable from the loop instead of referencing it.

--- a/plugins/modules/purefb_server.py
+++ b/plugins/modules/purefb_server.py
@@ -111,7 +111,7 @@ def update_server(module, blade):
         dns_list = server_info.dns
         current_dns = []
         for dns in dns_list:
-            current_dns.append(getattr(server_info.dns[dns], "name", None))
+            current_dns.append(getattr(dns, "name", None))
         if set(module.params["dns"]) != set(current_dns):
             changed = True
             res = blade.patch_servers(


### PR DESCRIPTION
##### SUMMARY
When you have created a server and you rerun the playbook, the purefb_server would give the following error: 
```bash
'Task failed: Module failed: list indices must be integers or slices, not Reference'
```

This was because of it trying to loop the dns list and try to get attribute of the dns in the loop. Now it will be the same as for the `directory_services` on row 132

This will fix the issue #567 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_server.py

##### ADDITIONAL INFORMATION
To test the new bugfix:
- Create a server using the purefb_server module. 
-  Rerun the same playbook with the same data as before
- The module should return OK as no changes has been made.

``` bash
black --check plugins/modules/purefb_server.py
All done! ✨ 🍰 ✨
1 file would be left unchanged.
```

Please LMK if there is any issues with my PR.