### PR TITLE
purefb_info: fix AttributeError in policies subset by splitting policy endpoints

### DIFF
--- a/changelogs/fragments/570_fix_info_policies.yaml
+++ b/changelogs/fragments/570_fix_info_policies.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_info - Fix AttributeError in `policies` subset when any policy exists; `snapshot_policies` now reports snapshot policies with rules and `policies` reports a cross-type policy summary

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -793,7 +793,7 @@ def generate_array_conn_dict(blade):
 
 def generate_policies_dict(blade):
     policies_info = {}
-    policies = list(blade.get_policies_all().items)
+    policies = list(blade.get_policies().items)
     for policy in policies:
         policy_name = policy.name
         policies_info[policy_name] = {
@@ -809,6 +809,21 @@ def generate_policies_dict(blade):
                 "keep_for": getattr(policy.rules[0], "keep_for", None),
                 "time_zone": getattr(policy.rules[0], "time_zone", None),
             }
+    return policies_info
+
+
+def generate_all_policies_dict(blade):
+    policies_info = {}
+    policies = list(blade.get_policies_all().items)
+    for policy in policies:
+        policy_name = policy.name
+        policies_info[policy_name] = {
+            "id": policy.id,
+            "enabled": policy.enabled,
+            "is_local": getattr(policy, "is_local", None),
+            "location": getattr(getattr(policy, "location", None), "name", None),
+            "policy_type": policy.policy_type,
+        }
     return policies_info
 
 
@@ -1398,7 +1413,7 @@ def main():
     if "buckets" in subset or "all" in subset:
         info["buckets"] = generate_bucket_dict(blade)
     if "policies" in subset or "all" in subset:
-        info["policies"] = generate_policies_dict(blade)
+        info["policies"] = generate_all_policies_dict(blade)
         info["snapshot_policies"] = generate_policies_dict(blade)
     if "arrays" in subset or "all" in subset:
         info["arrays"] = generate_array_conn_dict(blade)

--- a/tests/unit/plugins/modules/test_purefb_info.py
+++ b/tests/unit/plugins/modules/test_purefb_info.py
@@ -260,6 +260,7 @@ class TestPurefbInfo:
     @patch("plugins.modules.purefb_info.generate_admin_dict")
     @patch("plugins.modules.purefb_info.generate_snap_dict")
     @patch("plugins.modules.purefb_info.generate_bucket_dict")
+    @patch("plugins.modules.purefb_info.generate_all_policies_dict")
     @patch("plugins.modules.purefb_info.generate_policies_dict")
     @patch("plugins.modules.purefb_info.generate_array_conn_dict")
     @patch("plugins.modules.purefb_info.generate_file_repl_dict")
@@ -292,6 +293,7 @@ class TestPurefbInfo:
         mock_generate_file_repl,
         mock_generate_array_conn,
         mock_generate_policies,
+        mock_generate_all_policies,
         mock_generate_bucket,
         mock_generate_snap,
         mock_generate_admin,
@@ -329,6 +331,7 @@ class TestPurefbInfo:
         mock_generate_snap.return_value = {}
         mock_generate_bucket.return_value = {}
         mock_generate_policies.return_value = {}
+        mock_generate_all_policies.return_value = {}
         mock_generate_array_conn.return_value = {}
         mock_generate_file_repl.return_value = {}
         mock_generate_bucket_repl.return_value = {}
@@ -356,7 +359,8 @@ class TestPurefbInfo:
         mock_generate_admin.assert_called_once()
         mock_generate_snap.assert_called_once()
         mock_generate_bucket.assert_called_once()
-        mock_generate_policies.assert_called()  # Called multiple times
+        mock_generate_policies.assert_called_once()
+        mock_generate_all_policies.assert_called_once()
         mock_generate_array_conn.assert_called_once()
         mock_module.exit_json.assert_called_once()
         call_args = mock_module.exit_json.call_args[1]


### PR DESCRIPTION
##### SUMMARY

`purefb_info` with `gather_subset: [policies]` (or `all`) fails on any FlashBlade with at least one policy:

```
AttributeError: 'PolicyBaseContext' object has no attribute 'rules'
  File ".../plugins/modules/purefb_info.py", line 805, in generate_policies_dict
    if policy.rules:
```

`generate_policies_dict()` had been switched from `blade.get_policies()` to `blade.get_policies_all()`. These are two complementary py-pure-client endpoints (neither is deprecated) that return different response models: `get_policies()` returns `Policy` items (snapshot policies, with `rules`, `retention_lock`, etc.), while `get_policies_all()` returns `PolicyBase`/`PolicyBaseContext` items (every policy type, but only `id`, `name`, `enabled`, `is_local`, `location`, `policy_type`). The surrounding code still read `policy.rules[0].at` / `.every` / `.keep_for` / `.time_zone`, which the `get_policies_all()` model does not carry.

Additionally, `main()` called `generate_policies_dict(blade)` twice — once each for `info["policies"]` and `info["snapshot_policies"]` — populating both keys with identical data via two identical REST round-trips.

This PR splits the two output keys onto the endpoints that match their semantics:

- `snapshot_policies` — `generate_policies_dict()` reverted to `get_policies()`, returning snapshot policies with their `rules` (`at`, `every`, `keep_for`, `time_zone`) and `retention_lock`.
- `policies` — new `generate_all_policies_dict()` using `get_policies_all()`, returning a cross-type summary of every policy on the array (`id`, `enabled`, `is_local`, `location`, `policy_type`).

The crash is fixed, the duplicate REST call is gone, and the two keys now carry meaningfully different data, as their names suggest.

Closes #568 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_info

##### ADDITIONAL INFORMATION

Reproduction:

```yaml
- hosts: localhost
  gather_facts: false
  tasks:
    - everpure.flashblade.purefb_info:
        fb_url: "{{ fb_url }}"
        api_token: "{{ api_token }}"
        gather_subset: [policies]
```

Before (py-pure-client 1.88.0, ansible-core 2.17.14):

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
...
AttributeError: 'PolicyBaseContext' object has no attribute 'rules'
```

After — the task succeeds; `snapshot_policies` contains snapshot policies with rules, and `policies` contains the cross-type summary:

```json
{
    "policies": {
        "daily": {
            "id": "...",
            "enabled": true,
            "is_local": true,
            "location": "myarray",
            "policy_type": "snapshot"
        },
        "export-nfs": {
            "id": "...",
            "enabled": true,
            "is_local": true,
            "location": "myarray",
            "policy_type": "nfs"
        }
    },
    "snapshot_policies": {
        "daily": {
            "enabled": true,
            "retention_lock": "unlocked",
            "policy_type": "snapshot",
            "rules": {
                "at": null,
                "every": 86400000,
                "keep_for": 604800000,
                "time_zone": "America/New_York"
            }
        }
    }
}
```

A changelog fragment is included (`changelogs/fragments/570_fix_info_policies.yaml`).
