### PR TITLE
purefb_tls_policy: add module to manage TLS policies and interface attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ All modules are idempotent with the exception of modules that change or set pass
 - purefb_syslog - manage FlashBlade syslog server configuration
 - purefb_target - manage remote S3-capable targets for a FlashBlade
 - purefb_timeout - manage FlashBlade GUI timeout
+- purefb_tls_policy - manage FlashBlade TLS policies and their network interface attachments
 - purefb_user - manage local *pureuser* account password on a FlashBlade
 - purefb_userpolicy - manage FlashBlade Object Store User Access Policies
 - purefb_userquota - manage individual user quotas on FlashBlade filesystems

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -54,6 +54,7 @@ action_groups:
    - purefb_syslog
    - purefb_target
    - purefb_timeout
+   - purefb_tls_policy
    - purefb_tz
    - purefb_user
    - purefb_userpolicy

--- a/plugins/modules/purefb_tls_policy.py
+++ b/plugins/modules/purefb_tls_policy.py
@@ -1,0 +1,585 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2026, Simon Dodsley (simon@everpuredata.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefb_tls_policy
+version_added: '1.26.0'
+short_description: Manage FlashBlade TLS policies
+description:
+- Create, update or delete FlashBlade TLS policies and manage the
+  network interfaces they are applied to.
+- A TLS policy controls the server certificate presented on a network
+  interface, the TLS versions and ciphers permitted, and optional
+  mutual-TLS settings for verifying client certificates.
+author:
+- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@everpuredata.com>
+options:
+  name:
+    description:
+    - Name of the TLS policy.
+    type: str
+    required: true
+  state:
+    description:
+    - Define whether the TLS policy should exist or not.
+    default: present
+    choices: [ absent, present ]
+    type: str
+  enabled:
+    description:
+    - If C(true) the policy is enabled.
+    - Defaults to C(true) on creation if not specified.
+    type: bool
+  appliance_certificate:
+    description:
+    - Name of the certificate to present as the server certificate during
+      TLS negotiation with clients connecting to network interfaces
+      covered by this policy.
+    - Set to C(global) to reset the policy to the built-in appliance
+      certificate, effectively removing a previously assigned custom
+      certificate.
+    type: str
+  client_certificates_required:
+    description:
+    - If C(true), all clients must present a client certificate during
+      TLS negotiation; failure to do so will be rejected.
+    - If C(false), client certificates are optional.
+    - Requires Purity//FB REST API 2.18 or later.
+    type: bool
+  trusted_client_certificate_authority:
+    description:
+    - Name of a certificate, or certificate group, used to verify
+      certificates presented by clients when
+      I(verify_client_certificate_trust) is C(true).
+    - Set to an empty string (C("")) to clear a previously assigned
+      trusted CA reference. This only applies on update; on create an
+      empty string is treated the same as omitting the parameter.
+    - Requires Purity//FB REST API 2.18 or later.
+    type: str
+  verify_client_certificate_trust:
+    description:
+    - If C(true), certificates presented by clients in TLS negotiation
+      will undergo strict trust verification using the certificate(s)
+      referenced by I(trusted_client_certificate_authority).
+    - Requires Purity//FB REST API 2.18 or later.
+    type: bool
+  min_tls_version:
+    description:
+    - Minimum TLS version permitted for inbound connections.
+    - C(default) lets the array pick a recommended minimum that may shift
+      across software upgrades.
+    type: str
+    choices: [ default, '1.0', '1.1', '1.2', '1.3' ]
+  enabled_tls_ciphers:
+    description:
+    - List of TLS ciphers to enable.
+    - When supplied, only these ciphers will be enabled.
+    type: list
+    elements: str
+  disabled_tls_ciphers:
+    description:
+    - List of TLS ciphers to disable.
+    type: list
+    elements: str
+  network_interfaces:
+    description:
+    - Desired set of network interfaces this policy should be applied to.
+    - On update, the set of attached interfaces is reconciled against
+      this list - missing interfaces are attached, extras are detached.
+    - Omit entirely to leave existing attachments untouched.
+    - Use an empty list to detach the policy from all interfaces.
+    - On create, an empty list creates the policy with no interfaces
+      attached; this is equivalent to omitting the parameter.
+    type: list
+    elements: str
+extends_documentation_fragment:
+- everpure.flashblade.everpure.fb
+"""
+
+EXAMPLES = r"""
+- name: Create TLS policy with a server cert and minimum TLS 1.2
+  everpure.flashblade.purefb_tls_policy:
+    name: secure_data_plane
+    appliance_certificate: my_cert
+    min_tls_version: '1.2'
+    fb_url: 10.10.10.2
+    api_token: T-68618f31-0c9e-4e57-aa44-5306a2cf10e3
+
+- name: Require mutual TLS using a trusted CA group
+  everpure.flashblade.purefb_tls_policy:
+    name: secure_data_plane
+    client_certificates_required: true
+    verify_client_certificate_trust: true
+    trusted_client_certificate_authority: corp_ca_group
+    fb_url: 10.10.10.2
+    api_token: T-68618f31-0c9e-4e57-aa44-5306a2cf10e3
+
+- name: Apply the policy to a specific set of data network interfaces
+  everpure.flashblade.purefb_tls_policy:
+    name: secure_data_plane
+    network_interfaces:
+      - data1.eth0
+      - data2.eth0
+    fb_url: 10.10.10.2
+    api_token: T-68618f31-0c9e-4e57-aa44-5306a2cf10e3
+
+- name: Detach the TLS policy from all network interfaces
+  everpure.flashblade.purefb_tls_policy:
+    name: secure_data_plane
+    network_interfaces: []
+    fb_url: 10.10.10.2
+    api_token: T-68618f31-0c9e-4e57-aa44-5306a2cf10e3
+
+- name: Disable a TLS policy without deleting it
+  everpure.flashblade.purefb_tls_policy:
+    name: secure_data_plane
+    enabled: false
+    fb_url: 10.10.10.2
+    api_token: T-68618f31-0c9e-4e57-aa44-5306a2cf10e3
+
+- name: Reset appliance cert to the built-in global cert and clear the trusted CA
+  everpure.flashblade.purefb_tls_policy:
+    name: secure_data_plane
+    appliance_certificate: global
+    trusted_client_certificate_authority: ""
+    fb_url: 10.10.10.2
+    api_token: T-68618f31-0c9e-4e57-aa44-5306a2cf10e3
+
+- name: Delete a TLS policy
+  everpure.flashblade.purefb_tls_policy:
+    name: secure_data_plane
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-68618f31-0c9e-4e57-aa44-5306a2cf10e3
+"""
+
+RETURN = r"""
+"""
+
+HAS_PYPURECLIENT = True
+try:
+    from pypureclient.flashblade import (
+        TlsPolicy,
+        TlsPolicyPost,
+        ReferenceWritable,
+    )
+except ImportError:
+    HAS_PYPURECLIENT = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import (
+    get_system,
+    purefb_argument_spec,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
+    get_error_message,
+    get_rest_api_version,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
+
+MIN_REQUIRED_API_VERSION = "2.17"
+MIN_MUTUAL_TLS_API_VERSION = "2.18"
+MUTUAL_TLS_PARAMS = (
+    "client_certificates_required",
+    "trusted_client_certificate_authority",
+    "verify_client_certificate_trust",
+)
+
+
+def _check_mutual_tls_support(module, api_version):
+    """Fail early if mutual-TLS options were set but the array does not advertise REST 2.18.
+
+    pypureclient silently drops unknown fields when serialising TlsPolicyPost, so
+    without this guard a user on 2.17 would get a successful create with the
+    mutual-TLS settings missing from the policy.
+    """
+    if LooseVersion(MIN_MUTUAL_TLS_API_VERSION) > LooseVersion(api_version):
+        used = [p for p in MUTUAL_TLS_PARAMS if module.params.get(p) is not None]
+        if used:
+            module.fail_json(
+                msg=(
+                    "Mutual TLS options ({0}) require Purity//FB REST API {1} or later."
+                ).format(", ".join(used), MIN_MUTUAL_TLS_API_VERSION)
+            )
+
+
+def _validate_attachable(module, blade, interfaces):
+    """Validate every interface in C(interfaces) exists and isn't bound to another TLS policy.
+
+    Called for the to-attach subset only: interfaces already bound to *this* policy
+    do not conflict and are left alone.
+    """
+    if not interfaces:
+        return
+    res = blade.get_network_interfaces(
+        names=interfaces,
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg="Network interface(s) not found: {0}. Error: {1}".format(
+                interfaces, get_error_message(res)
+            )
+        )
+    found = {getattr(i, "name", None) for i in (res.items or [])}
+    missing = [i for i in interfaces if i not in found]
+    if missing:
+        module.fail_json(msg="Network interface(s) not found: {0}".format(missing))
+
+    res = blade.get_tls_policies_network_interfaces(
+        member_names=interfaces,
+    )
+    if res.status_code != 200:
+        return
+    our_name = module.params["name"]
+    conflicts = []
+    for item in res.items or []:
+        policy_name = getattr(getattr(item, "policy", None), "name", None)
+        member_name = getattr(getattr(item, "member", None), "name", None)
+        if policy_name and policy_name != our_name:
+            conflicts.append((member_name, policy_name))
+    if conflicts:
+        formatted = ", ".join("{0}=>{1}".format(m, p) for m, p in conflicts)
+        module.fail_json(
+            msg=(
+                "Cannot attach TLS policy {0} - the following interface(s) already "
+                "have a different TLS policy applied: {1}. Detach the existing "
+                "policy before re-attaching."
+            ).format(our_name, formatted)
+        )
+
+
+def _get_policy(module, blade):
+    """Return the existing TLS policy object or None."""
+    res = blade.get_tls_policies(
+        names=[module.params["name"]],
+    )
+    if res.status_code != 200:
+        return None
+    items = list(res.items)
+    return items[0] if items else None
+
+
+def _get_attached_interfaces(module, blade):
+    """Return a sorted list of network interface names this policy is applied to."""
+    res = blade.get_tls_policies_network_interfaces(
+        policy_names=[module.params["name"]],
+    )
+    if res.status_code != 200:
+        return []
+    names = []
+    for item in res.items:
+        member = getattr(item, "member", None)
+        member_name = getattr(member, "name", None)
+        if member_name:
+            names.append(member_name)
+    return sorted(names)
+
+
+def _build_post_kwargs(module):
+    """Build kwargs for TlsPolicyPost from module params."""
+    kwargs = {}
+    if module.params["enabled"] is not None:
+        kwargs["enabled"] = module.params["enabled"]
+    if module.params["appliance_certificate"]:
+        kwargs["appliance_certificate"] = ReferenceWritable(
+            name=module.params["appliance_certificate"]
+        )
+    if module.params["client_certificates_required"] is not None:
+        kwargs["client_certificates_required"] = module.params[
+            "client_certificates_required"
+        ]
+    if module.params["trusted_client_certificate_authority"]:
+        kwargs["trusted_client_certificate_authority"] = ReferenceWritable(
+            name=module.params["trusted_client_certificate_authority"]
+        )
+    if module.params["verify_client_certificate_trust"] is not None:
+        kwargs["verify_client_certificate_trust"] = module.params[
+            "verify_client_certificate_trust"
+        ]
+    if module.params["min_tls_version"]:
+        kwargs["min_tls_version"] = module.params["min_tls_version"]
+    if module.params["enabled_tls_ciphers"] is not None:
+        kwargs["enabled_tls_ciphers"] = module.params["enabled_tls_ciphers"]
+    if module.params["disabled_tls_ciphers"] is not None:
+        kwargs["disabled_tls_ciphers"] = module.params["disabled_tls_ciphers"]
+    return kwargs
+
+
+def _reconcile_interfaces(module, blade):
+    """Reconcile policy network-interface attachments to the desired set.
+
+    Returns True if any attach/detach was needed.
+    """
+    desired = sorted(module.params["network_interfaces"])
+    current = _get_attached_interfaces(module, blade)
+    to_attach = [i for i in desired if i not in current]
+    to_detach = [i for i in current if i not in desired]
+
+    if not (to_attach or to_detach):
+        return False
+
+    if to_attach:
+        _validate_attachable(module, blade, to_attach)
+
+    if module.check_mode:
+        return True
+
+    attached = []
+    for iface in to_attach:
+        res = blade.post_tls_policies_network_interfaces(
+            policy_names=[module.params["name"]],
+            member_names=[iface],
+        )
+        if res.status_code != 200:
+            note = " Already attached: {0}.".format(attached) if attached else ""
+            module.fail_json(
+                msg="Failed to attach TLS policy {0} to interface {1}. Error: {2}.{3}".format(
+                    module.params["name"], iface, get_error_message(res), note
+                )
+            )
+        attached.append(iface)
+
+    detached = []
+    for iface in to_detach:
+        res = blade.delete_tls_policies_network_interfaces(
+            policy_names=[module.params["name"]],
+            member_names=[iface],
+        )
+        if res.status_code != 200:
+            note = " Already detached: {0}.".format(detached) if detached else ""
+            module.fail_json(
+                msg="Failed to detach TLS policy {0} from interface {1}. Error: {2}.{3}".format(
+                    module.params["name"], iface, get_error_message(res), note
+                )
+            )
+        detached.append(iface)
+
+    return True
+
+
+def delete_policy(module, blade):
+    """Delete a TLS policy, detaching it from any network interfaces first."""
+    changed = True
+    if not module.check_mode:
+        attached = _get_attached_interfaces(module, blade)
+        detached = []
+        for iface in attached:
+            res = blade.delete_tls_policies_network_interfaces(
+                policy_names=[module.params["name"]],
+                member_names=[iface],
+            )
+            if res.status_code != 200:
+                note = " Already detached: {0}.".format(detached) if detached else ""
+                module.fail_json(
+                    msg="Failed to detach TLS policy {0} from interface {1}. Error: {2}.{3}".format(
+                        module.params["name"], iface, get_error_message(res), note
+                    )
+                )
+            detached.append(iface)
+        res = blade.delete_tls_policies(
+            names=[module.params["name"]],
+        )
+        if res.status_code != 200:
+            detached_note = ""
+            if attached:
+                detached_note = (
+                    " The policy has already been detached from interfaces {0};"
+                    " re-run to retry deletion or reattach manually if needed."
+                ).format(attached)
+            module.fail_json(
+                msg="Failed to delete TLS policy {0}. Error: {1}.{2}".format(
+                    module.params["name"], get_error_message(res), detached_note
+                )
+            )
+    module.exit_json(changed=changed)
+
+
+def create_policy(module, blade):
+    """Create a new TLS policy and optionally attach it to interfaces."""
+    changed = True
+    if module.params["network_interfaces"]:
+        _validate_attachable(module, blade, module.params["network_interfaces"])
+    if not module.check_mode:
+        res = blade.post_tls_policies(
+            names=[module.params["name"]],
+            policy=TlsPolicyPost(**_build_post_kwargs(module)),
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to create TLS policy {0}. Error: {1}".format(
+                    module.params["name"], get_error_message(res)
+                )
+            )
+        attached = []
+        for iface in module.params["network_interfaces"] or []:
+            res = blade.post_tls_policies_network_interfaces(
+                policy_names=[module.params["name"]],
+                member_names=[iface],
+            )
+            if res.status_code != 200:
+                note = " Already attached: {0}.".format(attached) if attached else ""
+                module.fail_json(
+                    msg="Failed to attach TLS policy {0} to interface {1}. Error: {2}.{3}".format(
+                        module.params["name"], iface, get_error_message(res), note
+                    )
+                )
+            attached.append(iface)
+    module.exit_json(changed=changed)
+
+
+def update_policy(module, blade, policy):
+    """Update a TLS policy and reconcile its network-interface attachments."""
+    changed = False
+    patch_kwargs = {}
+
+    if module.params["enabled"] is not None and module.params["enabled"] != getattr(
+        policy, "enabled", None
+    ):
+        patch_kwargs["enabled"] = module.params["enabled"]
+
+    if module.params["min_tls_version"] and module.params["min_tls_version"] != getattr(
+        policy, "min_tls_version", None
+    ):
+        patch_kwargs["min_tls_version"] = module.params["min_tls_version"]
+
+    if module.params["client_certificates_required"] is not None and module.params[
+        "client_certificates_required"
+    ] != getattr(policy, "client_certificates_required", None):
+        patch_kwargs["client_certificates_required"] = module.params[
+            "client_certificates_required"
+        ]
+
+    if module.params["verify_client_certificate_trust"] is not None and module.params[
+        "verify_client_certificate_trust"
+    ] != getattr(policy, "verify_client_certificate_trust", None):
+        patch_kwargs["verify_client_certificate_trust"] = module.params[
+            "verify_client_certificate_trust"
+        ]
+
+    if module.params["enabled_tls_ciphers"] is not None:
+        current = list(getattr(policy, "enabled_tls_ciphers", None) or [])
+        if sorted(module.params["enabled_tls_ciphers"]) != sorted(current):
+            patch_kwargs["enabled_tls_ciphers"] = module.params["enabled_tls_ciphers"]
+
+    if module.params["disabled_tls_ciphers"] is not None:
+        current = list(getattr(policy, "disabled_tls_ciphers", None) or [])
+        if sorted(module.params["disabled_tls_ciphers"]) != sorted(current):
+            patch_kwargs["disabled_tls_ciphers"] = module.params["disabled_tls_ciphers"]
+
+    if module.params["appliance_certificate"]:
+        current = getattr(getattr(policy, "appliance_certificate", None), "name", None)
+        if module.params["appliance_certificate"] != current:
+            patch_kwargs["appliance_certificate"] = ReferenceWritable(
+                name=module.params["appliance_certificate"]
+            )
+
+    if module.params["trusted_client_certificate_authority"] is not None:
+        current = (
+            getattr(
+                getattr(policy, "trusted_client_certificate_authority", None),
+                "name",
+                None,
+            )
+            or ""
+        )
+        if module.params["trusted_client_certificate_authority"] != current:
+            patch_kwargs["trusted_client_certificate_authority"] = ReferenceWritable(
+                name=module.params["trusted_client_certificate_authority"]
+            )
+
+    if module.params["network_interfaces"] is not None:
+        if _reconcile_interfaces(module, blade):
+            changed = True
+
+    if patch_kwargs:
+        changed = True
+        if not module.check_mode:
+            res = blade.patch_tls_policies(
+                names=[module.params["name"]],
+                policy=TlsPolicy(**patch_kwargs),
+            )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Failed to update TLS policy {0}. Error: {1}".format(
+                        module.params["name"], get_error_message(res)
+                    )
+                )
+
+    module.exit_json(changed=changed)
+
+
+def main():
+    argument_spec = purefb_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            name=dict(type="str", required=True),
+            enabled=dict(type="bool"),
+            appliance_certificate=dict(type="str"),
+            client_certificates_required=dict(type="bool"),
+            trusted_client_certificate_authority=dict(type="str"),
+            verify_client_certificate_trust=dict(type="bool"),
+            min_tls_version=dict(
+                type="str",
+                choices=[
+                    "default",
+                    "1.0",
+                    "1.1",
+                    "1.2",
+                    "1.3",
+                ],
+            ),
+            enabled_tls_ciphers=dict(type="list", elements="str"),
+            disabled_tls_ciphers=dict(type="list", elements="str"),
+            network_interfaces=dict(type="list", elements="str"),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        supports_check_mode=True,
+    )
+
+    if not HAS_PYPURECLIENT:
+        module.fail_json(msg="py-pure-client sdk is required for this module")
+
+    blade = get_system(module)
+    api_version = get_rest_api_version(blade)
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
+        module.fail_json(
+            msg="FlashBlade REST version not supported. "
+            "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
+        )
+    _check_mutual_tls_support(module, api_version)
+
+    state = module.params["state"]
+    policy = _get_policy(module, blade)
+
+    if state == "present" and policy is None:
+        create_policy(module, blade)
+    elif state == "present" and policy is not None:
+        update_policy(module, blade, policy)
+    elif state == "absent" and policy is not None:
+        delete_policy(module, blade)
+
+    module.exit_json(changed=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/purefb_tls_policy.py
+++ b/plugins/modules/purefb_tls_policy.py
@@ -554,7 +554,11 @@ def main():
     module = AnsibleModule(
         argument_spec,
         required_if=[
-            ("verify_client_certificate_trust", True, ["trusted_client_certificate_authority"]),
+            (
+                "verify_client_certificate_trust",
+                True,
+                ["trusted_client_certificate_authority"],
+            ),
         ],
         supports_check_mode=True,
     )

--- a/plugins/modules/purefb_tls_policy.py
+++ b/plugins/modules/purefb_tls_policy.py
@@ -17,7 +17,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = r"""
 ---
 module: purefb_tls_policy
-version_added: '1.26.0'
+version_added: '1.28.0'
 short_description: Manage FlashBlade TLS policies
 description:
 - Create, update or delete FlashBlade TLS policies and manage the
@@ -26,7 +26,7 @@ description:
   interface, the TLS versions and ciphers permitted, and optional
   mutual-TLS settings for verifying client certificates.
 author:
-- Pure Storage Ansible Team (@sdodsley) <pure-ansible-team@everpuredata.com>
+- Pure Storage Ansible Team (@avk) <pure-ansible-team@everpuredata.com>
 options:
   name:
     description:
@@ -283,7 +283,7 @@ def _get_attached_interfaces(module, blade):
     if res.status_code != 200:
         return []
     names = []
-    for item in res.items:
+    for item in res.items or []:
         member = getattr(item, "member", None)
         member_name = getattr(member, "name", None)
         if member_name:
@@ -553,6 +553,9 @@ def main():
 
     module = AnsibleModule(
         argument_spec,
+        required_if=[
+            ("verify_client_certificate_trust", True, ["trusted_client_certificate_authority"]),
+        ],
         supports_check_mode=True,
     )
 

--- a/tests/unit/plugins/modules/test_purefb_tls_policy.py
+++ b/tests/unit/plugins/modules/test_purefb_tls_policy.py
@@ -1,0 +1,1700 @@
+# Copyright: (c) 2026, Pure Storage Ansible Team <pure-ansible-team@purestorage.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefb_tls_policy module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+import multiprocessing
+import ctypes
+from unittest.mock import Mock, patch, MagicMock, call
+
+# Mock multiprocessing context for Windows
+if sys.platform == "win32":
+    original_get_context = multiprocessing.get_context
+
+    def mock_get_context(method=None):
+        if method == "fork":
+            return original_get_context("spawn")
+        return original_get_context(method)
+
+    multiprocessing.get_context = mock_get_context
+
+    # Mock ctypes LoadLibrary to prevent Windows errors
+    original_load_library = ctypes.cdll.LoadLibrary
+
+    def mock_load_library(name):
+        if name is None or not isinstance(name, str):
+            return MagicMock()
+        try:
+            return original_load_library(name)
+        except (OSError, TypeError):
+            return MagicMock()
+
+    ctypes.cdll.LoadLibrary = mock_load_library
+
+# Mock external dependencies before importing module
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flashblade"] = MagicMock()
+sys.modules["urllib3"] = MagicMock()
+sys.modules["distro"] = MagicMock()
+# Mock Unix-specific modules for Windows compatibility
+sys.modules["grp"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["syslog"] = MagicMock()
+# Mock termios with required constants
+mock_termios = MagicMock()
+mock_termios.TCSAFLUSH = 2
+sys.modules["termios"] = mock_termios
+sys.modules["tty"] = MagicMock()
+
+# Mock ansible_collections module structure
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.purefb"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.common"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.version"] = (
+    MagicMock()
+)
+
+from plugins.modules.purefb_tls_policy import (
+    main,
+    _get_policy,
+    _get_attached_interfaces,
+    _reconcile_interfaces,
+    _validate_attachable,
+    _check_mutual_tls_support,
+)
+
+
+class TestPurefbTlsPolicy:
+    """Test cases for purefb_tls_policy module"""
+
+    # ---------------- helper-function unit tests ----------------
+
+    def test_get_policy_returns_first_item(self):
+        """Test _get_policy returns the first policy when present"""
+        mock_module = Mock()
+        mock_module.params = {"name": "tls1"}
+
+        existing = Mock()
+        existing.name = "tls1"
+
+        mock_blade = Mock()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.items = [existing]
+        mock_blade.get_tls_policies.return_value = mock_response
+
+        out = _get_policy(mock_module, mock_blade)
+
+        assert out is existing
+        mock_blade.get_tls_policies.assert_called_once_with(names=["tls1"])
+
+    def test_get_policy_returns_none_when_empty(self):
+        """Test _get_policy returns None when items is empty"""
+        mock_module = Mock()
+        mock_module.params = {"name": "tls1"}
+
+        mock_blade = Mock()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.items = []
+        mock_blade.get_tls_policies.return_value = mock_response
+
+        assert _get_policy(mock_module, mock_blade) is None
+
+    def test_get_policy_returns_none_on_error(self):
+        """Test _get_policy returns None when status is non-200"""
+        mock_module = Mock()
+        mock_module.params = {"name": "tls1"}
+
+        mock_blade = Mock()
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.items = []
+        mock_blade.get_tls_policies.return_value = mock_response
+
+        assert _get_policy(mock_module, mock_blade) is None
+
+    def test_get_attached_interfaces_returns_sorted_names(self):
+        """Test _get_attached_interfaces returns member names sorted"""
+        mock_module = Mock()
+        mock_module.params = {"name": "tls1"}
+
+        m1 = Mock()
+        m1.member = Mock()
+        m1.member.name = "data2.eth0"
+        m2 = Mock()
+        m2.member = Mock()
+        m2.member.name = "data1.eth0"
+
+        mock_blade = Mock()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.items = [m1, m2]
+        mock_blade.get_tls_policies_network_interfaces.return_value = mock_response
+
+        out = _get_attached_interfaces(mock_module, mock_blade)
+        assert out == ["data1.eth0", "data2.eth0"]
+        mock_blade.get_tls_policies_network_interfaces.assert_called_once_with(
+            policy_names=["tls1"]
+        )
+
+    def test_get_attached_interfaces_returns_empty_on_error(self):
+        """Test _get_attached_interfaces returns [] when status is non-200"""
+        mock_module = Mock()
+        mock_module.params = {"name": "tls1"}
+
+        mock_blade = Mock()
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.items = []
+        mock_blade.get_tls_policies_network_interfaces.return_value = mock_response
+
+        assert _get_attached_interfaces(mock_module, mock_blade) == []
+
+    # ---------------- _reconcile_interfaces tests ----------------
+
+    def test_reconcile_attaches_missing(self):
+        """Test _reconcile_interfaces POSTs interfaces not yet attached"""
+        mock_module = Mock()
+        mock_module.params = {
+            "name": "tls1",
+            "network_interfaces": ["data1.eth0", "data2.eth0"],
+        }
+        mock_module.check_mode = False
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+
+        mock_blade = Mock()
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        # serves both _get_attached_interfaces and _validate_attachable
+        mock_blade.get_tls_policies_network_interfaces.return_value = get_response
+
+        iface1 = Mock()
+        iface1.name = "data1.eth0"
+        iface2 = Mock()
+        iface2.name = "data2.eth0"
+        ni_response = Mock()
+        ni_response.status_code = 200
+        ni_response.items = [iface1, iface2]
+        mock_blade.get_network_interfaces.return_value = ni_response
+
+        post_response = Mock()
+        post_response.status_code = 200
+        mock_blade.post_tls_policies_network_interfaces.return_value = post_response
+
+        changed = _reconcile_interfaces(mock_module, mock_blade)
+
+        assert changed is True
+        assert mock_blade.post_tls_policies_network_interfaces.call_args_list == [
+            call(policy_names=["tls1"], member_names=["data1.eth0"]),
+            call(policy_names=["tls1"], member_names=["data2.eth0"]),
+        ]
+        mock_blade.delete_tls_policies_network_interfaces.assert_not_called()
+
+    def test_reconcile_detaches_extras(self):
+        """Test _reconcile_interfaces DELETEs interfaces not in desired list"""
+        mock_module = Mock()
+        mock_module.params = {
+            "name": "tls1",
+            "network_interfaces": ["data1.eth0"],
+        }
+        mock_module.check_mode = False
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+
+        keep = Mock()
+        keep.member = Mock()
+        keep.member.name = "data1.eth0"
+        drop = Mock()
+        drop.member = Mock()
+        drop.member.name = "data2.eth0"
+
+        mock_blade = Mock()
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [keep, drop]
+        mock_blade.get_tls_policies_network_interfaces.return_value = get_response
+
+        delete_response = Mock()
+        delete_response.status_code = 200
+        mock_blade.delete_tls_policies_network_interfaces.return_value = delete_response
+
+        changed = _reconcile_interfaces(mock_module, mock_blade)
+
+        assert changed is True
+        mock_blade.delete_tls_policies_network_interfaces.assert_called_once_with(
+            policy_names=["tls1"], member_names=["data2.eth0"]
+        )
+        mock_blade.post_tls_policies_network_interfaces.assert_not_called()
+
+    def test_reconcile_idempotent_when_match(self):
+        """Test _reconcile_interfaces is a no-op when current == desired"""
+        mock_module = Mock()
+        mock_module.params = {
+            "name": "tls1",
+            "network_interfaces": ["data1.eth0"],
+        }
+        mock_module.check_mode = False
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+
+        match = Mock()
+        match.member = Mock()
+        match.member.name = "data1.eth0"
+
+        mock_blade = Mock()
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [match]
+        mock_blade.get_tls_policies_network_interfaces.return_value = get_response
+
+        changed = _reconcile_interfaces(mock_module, mock_blade)
+
+        assert changed is False
+        mock_blade.post_tls_policies_network_interfaces.assert_not_called()
+        mock_blade.delete_tls_policies_network_interfaces.assert_not_called()
+
+    def test_reconcile_empty_desired_detaches_all(self):
+        """Test _reconcile_interfaces with [] desired detaches everything"""
+        mock_module = Mock()
+        mock_module.params = {
+            "name": "tls1",
+            "network_interfaces": [],
+        }
+        mock_module.check_mode = False
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+
+        drop1 = Mock()
+        drop1.member = Mock()
+        drop1.member.name = "data1.eth0"
+        drop2 = Mock()
+        drop2.member = Mock()
+        drop2.member.name = "data2.eth0"
+
+        mock_blade = Mock()
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [drop1, drop2]
+        mock_blade.get_tls_policies_network_interfaces.return_value = get_response
+
+        delete_response = Mock()
+        delete_response.status_code = 200
+        mock_blade.delete_tls_policies_network_interfaces.return_value = delete_response
+
+        changed = _reconcile_interfaces(mock_module, mock_blade)
+
+        assert changed is True
+        assert mock_blade.delete_tls_policies_network_interfaces.call_args_list == [
+            call(policy_names=["tls1"], member_names=["data1.eth0"]),
+            call(policy_names=["tls1"], member_names=["data2.eth0"]),
+        ]
+
+    def test_reconcile_check_mode_skips_writes(self):
+        """Test _reconcile_interfaces reports changed but skips writes in check mode"""
+        mock_module = Mock()
+        mock_module.params = {
+            "name": "tls1",
+            "network_interfaces": ["data1.eth0"],
+        }
+        mock_module.check_mode = True
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+
+        mock_blade = Mock()
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        mock_blade.get_tls_policies_network_interfaces.return_value = get_response
+
+        iface = Mock()
+        iface.name = "data1.eth0"
+        ni_response = Mock()
+        ni_response.status_code = 200
+        ni_response.items = [iface]
+        mock_blade.get_network_interfaces.return_value = ni_response
+
+        changed = _reconcile_interfaces(mock_module, mock_blade)
+
+        assert changed is True
+        mock_blade.post_tls_policies_network_interfaces.assert_not_called()
+        mock_blade.delete_tls_policies_network_interfaces.assert_not_called()
+
+    # ---------------- _check_mutual_tls_support tests ----------------
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    def test_mutual_tls_support_ok_on_218(self, mock_loose_version):
+        """Test mutual-TLS gate passes when api version meets MIN_MUTUAL_TLS_API_VERSION"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.params = {
+            "client_certificates_required": True,
+            "trusted_client_certificate_authority": "ca1",
+            "verify_client_certificate_trust": True,
+        }
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        _check_mutual_tls_support(mock_module, ["2.17", "2.18"])
+        mock_module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    def test_mutual_tls_support_no_params_skipped(self, mock_loose_version):
+        """Test mutual-TLS gate is a no-op when none of the gated params are set"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=True)
+        mock_module = Mock()
+        mock_module.params = {
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+        }
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        _check_mutual_tls_support(mock_module, ["2.17"])
+        mock_module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    def test_mutual_tls_support_fails_when_param_set_on_217(self, mock_loose_version):
+        """Test mutual-TLS gate fails clearly when a gated param is set on a 2.17-only array"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=True)
+        mock_module = Mock()
+        mock_module.params = {
+            "client_certificates_required": True,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+        }
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        try:
+            _check_mutual_tls_support(mock_module, ["2.17"])
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "client_certificates_required" in msg
+        assert "2.18" in msg
+
+    # ---------------- _validate_attachable tests ----------------
+
+    def test_validate_attachable_passes_when_clean(self):
+        """Test _validate_attachable returns silently when interfaces exist and have no conflict"""
+        mock_module = Mock()
+        mock_module.params = {"name": "tls1"}
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+
+        iface = Mock()
+        iface.name = "data1.eth0"
+        ni_response = Mock()
+        ni_response.status_code = 200
+        ni_response.items = [iface]
+
+        ti_response = Mock()
+        ti_response.status_code = 200
+        ti_response.items = []
+
+        mock_blade = Mock()
+        mock_blade.get_network_interfaces.return_value = ni_response
+        mock_blade.get_tls_policies_network_interfaces.return_value = ti_response
+
+        _validate_attachable(mock_module, mock_blade, ["data1.eth0"])
+        mock_module.fail_json.assert_not_called()
+
+    def test_validate_attachable_empty_is_noop(self):
+        """Test _validate_attachable returns silently when interface list is empty"""
+        mock_module = Mock()
+        mock_module.params = {"name": "tls1"}
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_blade = Mock()
+
+        _validate_attachable(mock_module, mock_blade, [])
+        mock_module.fail_json.assert_not_called()
+        mock_blade.get_network_interfaces.assert_not_called()
+
+    def test_validate_attachable_fails_on_missing_interface(self):
+        """Test _validate_attachable fails when a requested interface does not exist"""
+        mock_module = Mock()
+        mock_module.params = {"name": "tls1"}
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+
+        iface = Mock()
+        iface.name = "data1.eth0"
+        ni_response = Mock()
+        ni_response.status_code = 200
+        ni_response.items = [iface]
+
+        mock_blade = Mock()
+        mock_blade.get_network_interfaces.return_value = ni_response
+
+        try:
+            _validate_attachable(mock_module, mock_blade, ["data1.eth0", "ghost.eth0"])
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "ghost.eth0" in msg
+
+    def test_validate_attachable_fails_when_get_network_interfaces_errors(self):
+        """Test _validate_attachable fails when the lookup itself errors"""
+        mock_module = Mock()
+        mock_module.params = {"name": "tls1"}
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+
+        ni_response = Mock()
+        ni_response.status_code = 400
+        ni_response.items = []
+        ni_response.errors = []
+
+        mock_blade = Mock()
+        mock_blade.get_network_interfaces.return_value = ni_response
+
+        try:
+            _validate_attachable(mock_module, mock_blade, ["data1.eth0"])
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        assert "not found" in mock_module.fail_json.call_args[1]["msg"]
+
+    def test_validate_attachable_fails_on_conflict(self):
+        """Test _validate_attachable fails when an interface is bound to a different policy"""
+        mock_module = Mock()
+        mock_module.params = {"name": "tls1"}
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+
+        iface = Mock()
+        iface.name = "data1.eth0"
+        ni_response = Mock()
+        ni_response.status_code = 200
+        ni_response.items = [iface]
+
+        member = Mock()
+        member.member = Mock()
+        member.member.name = "data1.eth0"
+        member.policy = Mock()
+        member.policy.name = "other-tls"
+
+        ti_response = Mock()
+        ti_response.status_code = 200
+        ti_response.items = [member]
+
+        mock_blade = Mock()
+        mock_blade.get_network_interfaces.return_value = ni_response
+        mock_blade.get_tls_policies_network_interfaces.return_value = ti_response
+
+        try:
+            _validate_attachable(mock_module, mock_blade, ["data1.eth0"])
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "data1.eth0=>other-tls" in msg
+        assert "Detach" in msg
+
+    def test_validate_attachable_self_attachment_is_not_conflict(self):
+        """Test _validate_attachable treats existing self-attachment as non-conflicting"""
+        mock_module = Mock()
+        mock_module.params = {"name": "tls1"}
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+
+        iface = Mock()
+        iface.name = "data1.eth0"
+        ni_response = Mock()
+        ni_response.status_code = 200
+        ni_response.items = [iface]
+
+        member = Mock()
+        member.member = Mock()
+        member.member.name = "data1.eth0"
+        member.policy = Mock()
+        member.policy.name = "tls1"  # same as ours
+
+        ti_response = Mock()
+        ti_response.status_code = 200
+        ti_response.items = [member]
+
+        mock_blade = Mock()
+        mock_blade.get_network_interfaces.return_value = ni_response
+        mock_blade.get_tls_policies_network_interfaces.return_value = ti_response
+
+        _validate_attachable(mock_module, mock_blade, ["data1.eth0"])
+        mock_module.fail_json.assert_not_called()
+
+    # ---------------- main() flows ----------------
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.TlsPolicyPost")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_creates_policy(
+        self,
+        mock_ansible_module,
+        mock_get_system,
+        mock_policy_post,
+        mock_loose_version,
+    ):
+        """Test creating a new TLS policy"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": "my_cert",
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": "1.2",
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        mock_blade.get_tls_policies.return_value = get_response
+
+        post_response = Mock()
+        post_response.status_code = 200
+        mock_blade.post_tls_policies.return_value = post_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_blade.post_tls_policies.assert_called_once()
+        call_kwargs = mock_blade.post_tls_policies.call_args[1]
+        assert call_kwargs["names"] == ["tls1"]
+        mock_module.exit_json.assert_called_once()
+        assert mock_module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.TlsPolicyPost")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_create_with_attachments(
+        self,
+        mock_ansible_module,
+        mock_get_system,
+        mock_policy_post,
+        mock_loose_version,
+    ):
+        """Test create + initial attachments POSTs to both endpoints"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": ["data1.eth0", "data2.eth0"],
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        mock_blade.get_tls_policies.return_value = get_response
+
+        iface1 = Mock()
+        iface1.name = "data1.eth0"
+        iface2 = Mock()
+        iface2.name = "data2.eth0"
+        ni_response = Mock()
+        ni_response.status_code = 200
+        ni_response.items = [iface1, iface2]
+        mock_blade.get_network_interfaces.return_value = ni_response
+
+        conflict_response = Mock()
+        conflict_response.status_code = 200
+        conflict_response.items = []
+        mock_blade.get_tls_policies_network_interfaces.return_value = conflict_response
+
+        ok = Mock()
+        ok.status_code = 200
+        mock_blade.post_tls_policies.return_value = ok
+        mock_blade.post_tls_policies_network_interfaces.return_value = ok
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_blade.post_tls_policies.assert_called_once()
+        assert mock_blade.post_tls_policies_network_interfaces.call_args_list == [
+            call(policy_names=["tls1"], member_names=["data1.eth0"]),
+            call(policy_names=["tls1"], member_names=["data2.eth0"]),
+        ]
+        assert mock_module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_create_check_mode_skips_post(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test create reports changed but skips POST in check mode"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = True
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        mock_blade.get_tls_policies.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_blade.post_tls_policies.assert_not_called()
+        assert mock_module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.TlsPolicy")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_updates_enabled_flag(
+        self,
+        mock_ansible_module,
+        mock_get_system,
+        mock_tls_policy,
+        mock_loose_version,
+    ):
+        """Test updating the enabled flag on an existing policy"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": False,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        existing = Mock()
+        existing.name = "tls1"
+        existing.enabled = True
+        existing.min_tls_version = None
+        existing.enabled_tls_ciphers = None
+        existing.disabled_tls_ciphers = None
+        existing.appliance_certificate = None
+        existing.trusted_client_certificate_authority = None
+        existing.client_certificates_required = None
+        existing.verify_client_certificate_trust = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        mock_blade.get_tls_policies.return_value = get_response
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        mock_blade.patch_tls_policies.return_value = patch_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_blade.patch_tls_policies.assert_called_once()
+        call_kwargs = mock_blade.patch_tls_policies.call_args[1]
+        assert mock_module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_update_idempotent(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test update is a no-op when desired matches current state"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": True,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": "1.2",
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        existing = Mock()
+        existing.name = "tls1"
+        existing.enabled = True
+        existing.min_tls_version = "1.2"
+        existing.enabled_tls_ciphers = None
+        existing.disabled_tls_ciphers = None
+        existing.appliance_certificate = None
+        existing.trusted_client_certificate_authority = None
+        existing.client_certificates_required = None
+        existing.verify_client_certificate_trust = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        mock_blade.get_tls_policies.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_blade.patch_tls_policies.assert_not_called()
+        mock_blade.post_tls_policies.assert_not_called()
+        assert mock_module.exit_json.call_args[1]["changed"] is False
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.TlsPolicy")
+    @patch("plugins.modules.purefb_tls_policy.ReferenceWritable")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_updates_appliance_certificate(
+        self,
+        mock_ansible_module,
+        mock_get_system,
+        mock_reference_writable,
+        mock_tls_policy,
+        mock_loose_version,
+    ):
+        """Test updating the appliance certificate triggers a patch"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": "new_cert",
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        existing_cert = Mock()
+        existing_cert.name = "old_cert"
+        existing = Mock()
+        existing.name = "tls1"
+        existing.enabled = True
+        existing.min_tls_version = None
+        existing.enabled_tls_ciphers = None
+        existing.disabled_tls_ciphers = None
+        existing.appliance_certificate = existing_cert
+        existing.trusted_client_certificate_authority = None
+        existing.client_certificates_required = None
+        existing.verify_client_certificate_trust = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        mock_blade.get_tls_policies.return_value = get_response
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        mock_blade.patch_tls_policies.return_value = patch_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_reference_writable.assert_called_with(name="new_cert")
+        mock_blade.patch_tls_policies.assert_called_once()
+        assert mock_module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.TlsPolicy")
+    @patch("plugins.modules.purefb_tls_policy.ReferenceWritable")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_resets_appliance_certificate_to_global(
+        self,
+        mock_ansible_module,
+        mock_get_system,
+        mock_reference_writable,
+        mock_tls_policy,
+        mock_loose_version,
+    ):
+        """Test setting appliance_certificate='global' patches with ReferenceWritable(name='global')"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": "global",
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        existing_cert = Mock()
+        existing_cert.name = "custom_cert"
+        existing = Mock()
+        existing.name = "tls1"
+        existing.enabled = True
+        existing.min_tls_version = None
+        existing.enabled_tls_ciphers = None
+        existing.disabled_tls_ciphers = None
+        existing.appliance_certificate = existing_cert
+        existing.trusted_client_certificate_authority = None
+        existing.client_certificates_required = None
+        existing.verify_client_certificate_trust = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        mock_blade.get_tls_policies.return_value = get_response
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        mock_blade.patch_tls_policies.return_value = patch_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_reference_writable.assert_called_with(name="global")
+        mock_blade.patch_tls_policies.assert_called_once()
+        assert mock_module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.TlsPolicy")
+    @patch("plugins.modules.purefb_tls_policy.ReferenceWritable")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_clears_trusted_client_certificate_authority(
+        self,
+        mock_ansible_module,
+        mock_get_system,
+        mock_reference_writable,
+        mock_tls_policy,
+        mock_loose_version,
+    ):
+        """Test setting trusted_client_certificate_authority='' patches with ReferenceWritable(name='')"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": "",
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.18"]
+        mock_get_system.return_value = mock_blade
+
+        existing_ca = Mock()
+        existing_ca.name = "corp_ca"
+        existing = Mock()
+        existing.name = "tls1"
+        existing.enabled = True
+        existing.min_tls_version = None
+        existing.enabled_tls_ciphers = None
+        existing.disabled_tls_ciphers = None
+        existing.appliance_certificate = None
+        existing.trusted_client_certificate_authority = existing_ca
+        existing.client_certificates_required = None
+        existing.verify_client_certificate_trust = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        mock_blade.get_tls_policies.return_value = get_response
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        mock_blade.patch_tls_policies.return_value = patch_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_reference_writable.assert_called_with(name="")
+        mock_blade.patch_tls_policies.assert_called_once()
+        assert mock_module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_clear_trusted_ca_idempotent_when_already_unset(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test clearing CA with '' is a no-op when the policy has no CA set"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": "",
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.18"]
+        mock_get_system.return_value = mock_blade
+
+        existing = Mock()
+        existing.name = "tls1"
+        existing.enabled = True
+        existing.min_tls_version = None
+        existing.enabled_tls_ciphers = None
+        existing.disabled_tls_ciphers = None
+        existing.appliance_certificate = None
+        existing.trusted_client_certificate_authority = None
+        existing.client_certificates_required = None
+        existing.verify_client_certificate_trust = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        mock_blade.get_tls_policies.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_blade.patch_tls_policies.assert_not_called()
+        assert mock_module.exit_json.call_args[1]["changed"] is False
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_deletes_policy_with_attachments(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test delete detaches network interfaces before removing the policy"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "absent",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        existing = Mock()
+        existing.name = "tls1"
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        mock_blade.get_tls_policies.return_value = get_response
+
+        # Currently attached to one interface
+        m1 = Mock()
+        m1.member = Mock()
+        m1.member.name = "data1.eth0"
+        attached_response = Mock()
+        attached_response.status_code = 200
+        attached_response.items = [m1]
+        mock_blade.get_tls_policies_network_interfaces.return_value = attached_response
+
+        ok = Mock()
+        ok.status_code = 200
+        mock_blade.delete_tls_policies_network_interfaces.return_value = ok
+        mock_blade.delete_tls_policies.return_value = ok
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_blade.delete_tls_policies_network_interfaces.assert_called_once_with(
+            policy_names=["tls1"],
+            member_names=["data1.eth0"],
+        )
+        mock_blade.delete_tls_policies.assert_called_once_with(names=["tls1"])
+        assert mock_module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_delete_nonexistent_is_noop(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test delete on a non-existent policy is a no-op"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "absent",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        mock_blade.get_tls_policies.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_blade.delete_tls_policies.assert_not_called()
+        mock_blade.delete_tls_policies_network_interfaces.assert_not_called()
+        assert mock_module.exit_json.call_args[1]["changed"] is False
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_reconcile_attaches_on_update(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test update reconciles network interface attachments"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": ["data1.eth0"],
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        existing = Mock()
+        existing.name = "tls1"
+        existing.enabled = True
+        existing.min_tls_version = None
+        existing.enabled_tls_ciphers = None
+        existing.disabled_tls_ciphers = None
+        existing.appliance_certificate = None
+        existing.trusted_client_certificate_authority = None
+        existing.client_certificates_required = None
+        existing.verify_client_certificate_trust = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        mock_blade.get_tls_policies.return_value = get_response
+
+        # Currently nothing attached (also serves _validate_attachable)
+        ifaces_response = Mock()
+        ifaces_response.status_code = 200
+        ifaces_response.items = []
+        mock_blade.get_tls_policies_network_interfaces.return_value = ifaces_response
+
+        iface = Mock()
+        iface.name = "data1.eth0"
+        ni_response = Mock()
+        ni_response.status_code = 200
+        ni_response.items = [iface]
+        mock_blade.get_network_interfaces.return_value = ni_response
+
+        ok = Mock()
+        ok.status_code = 200
+        mock_blade.post_tls_policies_network_interfaces.return_value = ok
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_blade.patch_tls_policies.assert_not_called()
+        mock_blade.post_tls_policies_network_interfaces.assert_called_once_with(
+            policy_names=["tls1"],
+            member_names=["data1.eth0"],
+        )
+        assert mock_module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.TlsPolicyPost")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_create_fails(
+        self,
+        mock_ansible_module,
+        mock_get_system,
+        mock_policy_post,
+        mock_loose_version,
+    ):
+        """Test create surfaces backend errors via fail_json"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        mock_blade.get_tls_policies.return_value = get_response
+
+        post_response = Mock()
+        post_response.status_code = 400
+        err = Mock()
+        err.message = "boom"
+        post_response.errors = [err]
+        mock_blade.post_tls_policies.return_value = post_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        assert (
+            "Failed to create TLS policy" in mock_module.fail_json.call_args[1]["msg"]
+        )
+
+    # ---------------- main() failure paths for new gating ----------------
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_mutual_tls_blocked_on_217(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test main fails when a mutual-TLS param is set on a 2.17-only array"""
+        # Base 2.17 check passes (False), but mutual-TLS 2.18 check fails (True).
+        mock_loose_version.return_value.__gt__ = Mock(side_effect=[False, True])
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": True,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "Mutual TLS" in msg
+        assert "2.18" in msg
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_attach_to_missing_interface_fails(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test main fails before posting when a target interface does not exist"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": ["ghost.eth0"],
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        # Policy doesn't exist -> create path
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        mock_blade.get_tls_policies.return_value = get_response
+
+        # No interfaces match
+        ni_response = Mock()
+        ni_response.status_code = 200
+        ni_response.items = []
+        mock_blade.get_network_interfaces.return_value = ni_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        assert "ghost.eth0" in mock_module.fail_json.call_args[1]["msg"]
+        mock_blade.post_tls_policies.assert_not_called()
+        mock_blade.post_tls_policies_network_interfaces.assert_not_called()
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_attach_conflict_fails(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test main fails when target interface already has a different TLS policy"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": ["data1.eth0"],
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        mock_blade.get_tls_policies.return_value = get_response
+
+        iface = Mock()
+        iface.name = "data1.eth0"
+        ni_response = Mock()
+        ni_response.status_code = 200
+        ni_response.items = [iface]
+        mock_blade.get_network_interfaces.return_value = ni_response
+
+        member = Mock()
+        member.member = Mock()
+        member.member.name = "data1.eth0"
+        member.policy = Mock()
+        member.policy.name = "other-tls"
+        conflict_response = Mock()
+        conflict_response.status_code = 200
+        conflict_response.items = [member]
+        mock_blade.get_tls_policies_network_interfaces.return_value = conflict_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "other-tls" in msg
+        mock_blade.post_tls_policies.assert_not_called()
+        mock_blade.post_tls_policies_network_interfaces.assert_not_called()
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_api_version_too_old(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test failure when API version is too old"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=True)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.10"]
+        mock_get_system.return_value = mock_blade
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_module.fail_json.assert_called_once()
+        assert (
+            "FlashBlade REST version not supported"
+            in mock_module.fail_json.call_args[1]["msg"]
+        )
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.TlsPolicyPost")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_create_attach_second_interface_fails_reports_first_succeeded(
+        self,
+        mock_ansible_module,
+        mock_get_system,
+        mock_policy_post,
+        mock_loose_version,
+    ):
+        """Test create-attach loop fails fast on 2nd interface and reports the 1st as already attached"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "present",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": ["data1.eth0", "data2.eth0", "data3.eth0"],
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        mock_blade.get_tls_policies.return_value = get_response
+
+        iface1 = Mock()
+        iface1.name = "data1.eth0"
+        iface2 = Mock()
+        iface2.name = "data2.eth0"
+        iface3 = Mock()
+        iface3.name = "data3.eth0"
+        ni_response = Mock()
+        ni_response.status_code = 200
+        ni_response.items = [iface1, iface2, iface3]
+        mock_blade.get_network_interfaces.return_value = ni_response
+
+        conflict_response = Mock()
+        conflict_response.status_code = 200
+        conflict_response.items = []
+        mock_blade.get_tls_policies_network_interfaces.return_value = conflict_response
+
+        ok = Mock()
+        ok.status_code = 200
+        mock_blade.post_tls_policies.return_value = ok
+
+        fail = Mock()
+        fail.status_code = 500
+        fail.errors = []
+        mock_blade.post_tls_policies_network_interfaces.side_effect = [ok, fail]
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # First attach for data1 succeeded, second for data2 failed, third never attempted.
+        assert mock_blade.post_tls_policies_network_interfaces.call_count == 2
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "Failed to attach TLS policy tls1 to interface data2.eth0" in msg
+        assert "Already attached: ['data1.eth0']" in msg
+
+    @patch("plugins.modules.purefb_tls_policy.LooseVersion")
+    @patch("plugins.modules.purefb_tls_policy.get_system")
+    @patch("plugins.modules.purefb_tls_policy.AnsibleModule")
+    @patch("plugins.modules.purefb_tls_policy.HAS_PYPURECLIENT", True)
+    def test_main_delete_after_detach_partial_failure_message(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test delete failure after successful detach reports the detached interfaces"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.exit_json = Mock(side_effect=SystemExit)
+        mock_module.fail_json = Mock(side_effect=SystemExit)
+        mock_module.params = {
+            "name": "tls1",
+            "state": "absent",
+            "enabled": None,
+            "appliance_certificate": None,
+            "client_certificates_required": None,
+            "trusted_client_certificate_authority": None,
+            "verify_client_certificate_trust": None,
+            "min_tls_version": None,
+            "enabled_tls_ciphers": None,
+            "disabled_tls_ciphers": None,
+            "network_interfaces": None,
+        }
+        mock_module.check_mode = False
+        mock_ansible_module.return_value = mock_module
+
+        mock_blade = Mock()
+        mock_blade.get_versions.return_value.items = ["2.17"]
+        mock_get_system.return_value = mock_blade
+
+        existing = Mock()
+        existing.name = "tls1"
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        mock_blade.get_tls_policies.return_value = get_response
+
+        m1 = Mock()
+        m1.member = Mock()
+        m1.member.name = "data1.eth0"
+        attached_response = Mock()
+        attached_response.status_code = 200
+        attached_response.items = [m1]
+        mock_blade.get_tls_policies_network_interfaces.return_value = attached_response
+
+        detach_ok = Mock()
+        detach_ok.status_code = 200
+        mock_blade.delete_tls_policies_network_interfaces.return_value = detach_ok
+
+        delete_fail = Mock()
+        delete_fail.status_code = 500
+        delete_fail.errors = []
+        mock_blade.delete_tls_policies.return_value = delete_fail
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_blade.delete_tls_policies_network_interfaces.assert_called_once()
+        mock_blade.delete_tls_policies.assert_called_once()
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "Failed to delete TLS policy" in msg
+        assert "already been detached" in msg
+        assert "data1.eth0" in msg


### PR DESCRIPTION
##### SUMMARY

Adds `purefb_tls_policy` to manage FlashBlade TLS policies and the network interfaces they are applied to. Covers full CRUD, mutual-TLS options gated on REST 2.18, idempotent read-diff-write update, pre-validated interface attach/detach, and clear-to-reset semantics for the reference fields.

Key behaviors:
- `network_interfaces` reconciles against current attachments - attaches missing, detaches extras. Omit to leave untouched; `[]` to detach all.
- `_validate_attachable` pre-checks target interfaces exist and are not bound to a different TLS policy (with a "detach the existing policy before re-attaching" hint).
- Mutual-TLS params (`client_certificates_required`, `trusted_client_certificate_authority`, `verify_client_certificate_trust`) are gated on REST `2.18` 
- `appliance_certificate: global` resets to the built-in appliance cert. `trusted_client_certificate_authority: ""` clears the CA reference (verified live; `ReferenceWritable(name="")` serializes to `{"name": ""}` and `None` would drop the field entirely).
- `enabled_tls_ciphers` / `disabled_tls_ciphers` are passed through as-is. No client-side overlap or dedup validation — verified live that the backend accepts overlapping and duplicate entries without complaint, and imposing an Ansible-side rule would risk rejecting configs the backend considers valid.


**per-interface loop for attach/detach**

@sdodsley 
>Despite `member_names` being typed as an array in the OpenAPI schema, `POST/DELETE /tls-policies/network-interfaces` only accept one member per call in practice - batched calls fail with `Cannot process more than one Member at a time.` The API descriptions confirm this: both read "Apply/Remove a TLS policy to/from a network interface"

>All four call sites (`create_policy` attach, `_reconcile_interfaces` attach + detach, `delete_policy` detach) loop one interface at a time and fail-fast on the first error - no rollback of prior successes, no best-effort continuation to the next item. The error message names the failing interface and lists the ones that had already succeeded, so the operator knows the exact partial state and can re-run to converge. Idempotent on re-run because `_reconcile_interfaces` diffs desired vs. current state. 

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
purefb_tls_policy

##### ADDITIONAL INFORMATION

- Requires Purity//FB REST `2.17`; mutual-TLS params require `2.18`.