### PR TITLE
purefb_userpolicy: fix add_policy silently failing to persist on REST 2.17+

### DIFF
--- a/changelogs/fragments/574_fix_userpolicy_add_context_post.yaml
+++ b/changelogs/fragments/574_fix_userpolicy_add_context_post.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - purefb_userpolicy - Fix adding a policy to an existing user silently failing to persist on REST 2.17+ while still reporting changed, due to a stray second non-context POST

--- a/plugins/modules/purefb_userpolicy.py
+++ b/plugins/modules/purefb_userpolicy.py
@@ -155,22 +155,23 @@ def add_policy(module, blade):
             )
         if not list(res.items):
             if not module.check_mode:
-                changed = True
                 if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     res = blade.post_object_store_access_policies_object_store_users(
                         member_names=[username],
                         policy_names=[policy],
                         context_names=[module.params["context"]],
                     )
+                else:
                     res = blade.post_object_store_access_policies_object_store_users(
                         member_names=[username], policy_names=[policy]
                     )
-                    if res.status_code != 200:
-                        module.fail_json(
-                            msg="Failed to add policy {0}. Error: {1}".format(
-                                policy, get_error_message(res)
-                            )
+                if res.status_code != 200:
+                    module.fail_json(
+                        msg="Failed to add policy {0} to account user {1}. Error: {2}".format(
+                            policy, username, get_error_message(res)
                         )
+                    )
+                changed = True
                 if CONTEXT_API_VERSION in api_version and module.params["context"]:
                     user_policies = list(
                         blade.get_object_store_access_policies_object_store_users(
@@ -186,12 +187,6 @@ def add_policy(module, blade):
                     )
                 for user_policy in user_policies:
                     user_policy_list.append(user_policy.policy.name)
-                if res.status_code != 200:
-                    module.fail_json(
-                        msg="Failed to add policy {0} to account user {1}. Error: {2}".format(
-                            policy, username, get_error_message(res)
-                        )
-                    )
     module.exit_json(changed=changed, policy_list=user_policy_list)
 
 

--- a/tests/unit/plugins/modules/test_purefb_userpolicy.py
+++ b/tests/unit/plugins/modules/test_purefb_userpolicy.py
@@ -127,7 +127,7 @@ class TestPurefbUserpolicyAddPolicy:
 
         post = blade.post_object_store_access_policies_object_store_users
         assert post.call_count == 1
-        _, kwargs = post.call_args
+        kwargs = post.call_args[1]
         assert kwargs.get("context_names") == ["array1"]
         assert kwargs.get("member_names") == ["myaccount/myuser"]
         assert kwargs.get("policy_names") == ["myaccount/second-policy"]

--- a/tests/unit/plugins/modules/test_purefb_userpolicy.py
+++ b/tests/unit/plugins/modules/test_purefb_userpolicy.py
@@ -1,0 +1,152 @@
+# Copyright: (c) 2026, Pure Storage Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefb_userpolicy module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+import multiprocessing
+import ctypes
+from unittest.mock import Mock, patch, MagicMock
+
+# Mock multiprocessing context for Windows
+if sys.platform == "win32":
+    original_get_context = multiprocessing.get_context
+
+    def mock_get_context(method=None):
+        if method == "fork":
+            return original_get_context("spawn")
+        return original_get_context(method)
+
+    multiprocessing.get_context = mock_get_context
+
+    # Mock ctypes LoadLibrary to prevent Windows errors
+    original_load_library = ctypes.cdll.LoadLibrary
+
+    def mock_load_library(name):
+        if name is None or not isinstance(name, str):
+            return MagicMock()
+        try:
+            return original_load_library(name)
+        except (OSError, TypeError):
+            return MagicMock()
+
+    ctypes.cdll.LoadLibrary = mock_load_library
+
+# Mock external dependencies before importing module
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flashblade"] = MagicMock()
+sys.modules["urllib3"] = MagicMock()
+sys.modules["distro"] = MagicMock()
+# Mock Unix-specific modules for Windows compatibility
+sys.modules["grp"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["syslog"] = MagicMock()
+# Mock termios with required constants
+mock_termios = MagicMock()
+mock_termios.TCSAFLUSH = 2
+sys.modules["termios"] = mock_termios
+sys.modules["tty"] = MagicMock()
+
+# Mock ansible_collections module structure
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.purefb"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.common"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.version"] = (
+    MagicMock()
+)
+
+from plugins.modules.purefb_userpolicy import add_policy
+
+
+def _make_module(context="array1"):
+    module = Mock()
+    module.check_mode = False
+    module.exit_json = Mock(side_effect=SystemExit)
+    module.fail_json = Mock(side_effect=SystemExit)
+    module.params = {
+        "name": "myuser",
+        "account": "myaccount",
+        "policy": ["myaccount/second-policy"],
+        "context": context,
+        "state": "present",
+    }
+    return module
+
+
+def _make_blade(already_assigned=False):
+    """Blade mock. API 2.24 (>= 2.17 CONTEXT_API_VERSION), so the context path is active."""
+    blade = Mock()
+    blade.get_versions.return_value.items = ["2.17", "2.24"]
+    # Existing membership check: empty => not yet assigned; non-empty => already there
+    existing = [Mock()] if already_assigned else []
+    blade.get_object_store_users_object_store_access_policies.return_value.items = (
+        existing
+    )
+    # Successful write
+    blade.post_object_store_access_policies_object_store_users.return_value.status_code = (
+        200
+    )
+    # Re-read after write (post-add policy list)
+    blade.get_object_store_access_policies_object_store_users.return_value.items = []
+    return blade
+
+
+class TestPurefbUserpolicyAddPolicy:
+    """Regression tests for add_policy (issue #574)."""
+
+    @patch("plugins.modules.purefb_userpolicy._check_valid_policy", return_value=True)
+    def test_add_issues_single_context_scoped_post(self, _valid):
+        """On API >= 2.17 the add must issue exactly ONE context-scoped POST.
+
+        Previously a second, non-context POST ran unconditionally (no else) and
+        overwrote the checked result, so the context write was never verified and
+        the membership silently failed to persist while still reporting changed.
+        """
+        module = _make_module(context="array1")
+        blade = _make_blade(already_assigned=False)
+
+        try:
+            add_policy(module, blade)
+        except SystemExit:
+            pass
+
+        post = blade.post_object_store_access_policies_object_store_users
+        assert post.call_count == 1
+        _, kwargs = post.call_args
+        assert kwargs.get("context_names") == ["array1"]
+        assert kwargs.get("member_names") == ["myaccount/myuser"]
+        assert kwargs.get("policy_names") == ["myaccount/second-policy"]
+
+        module.exit_json.assert_called_once()
+        assert module.exit_json.call_args[1]["changed"] is True
+        module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefb_userpolicy._check_valid_policy", return_value=True)
+    def test_add_is_idempotent_when_already_assigned(self, _valid):
+        """If the policy is already assigned, no POST is issued and changed is False."""
+        module = _make_module(context="array1")
+        blade = _make_blade(already_assigned=True)
+
+        try:
+            add_policy(module, blade)
+        except SystemExit:
+            pass
+
+        blade.post_object_store_access_policies_object_store_users.assert_not_called()
+        module.exit_json.assert_called_once()
+        assert module.exit_json.call_args[1]["changed"] is False


### PR DESCRIPTION
##### SUMMARY
Fixes #574.

On REST API 2.17+, `main()` auto-populates `context` with the local array name when the user does not supply one, so `add_policy()` always takes the context branch. That branch issued **two** POSTs — a context-scoped one immediately followed by a non-context one with **no `else`** — and the second overwrote the `res` that gets status-checked. The context-scoped write was therefore never verified, so adding a policy to an existing object-store user reported `changed: true` but the membership never persisted, and re-runs were never idempotent. (Initial assignment via `purefb_s3user` uses a different path and is unaffected.)

The fix mirrors the correct single-`else` pattern already used by `remove_policy()`: issue **one** POST branched on `context`, verify its status, and only then set `changed`. The redundant second status check is dropped.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_userpolicy

##### ADDITIONAL INFORMATION
Adds a regression unit test (`test_purefb_userpolicy.py`) asserting exactly one context-scoped POST on add, and idempotency (no POST, `changed=false`) when the policy is already assigned.

```paste below
# black
$ black --check plugins/modules/purefb_userpolicy.py tests/unit/plugins/modules/test_purefb_userpolicy.py
All done! ✨ 🍰 ✨

# unit tests
$ python3 -m pytest tests/unit -q
328 passed

# sanity
$ ansible-test sanity --test validate-modules plugins/modules/purefb_userpolicy.py
(exit 0)
```
