### PR TITLE
guard snapshot policy rules access in info module

### DIFF
--- a/changelogs/fragments/576_fix_info_snapshot_policy_rules.yaml
+++ b/changelogs/fragments/576_fix_info_snapshot_policy_rules.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - purefb_info - Fix AttributeError in `snapshot_policies` subset when a policy has no rules, or when an older py-pure-client returns a policy object without a `rules` attribute

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -802,12 +802,13 @@ def generate_policies_dict(blade):
             "policy_type": policy.policy_type,
             "rules": {},
         }
-        if policy.rules:
+        rules = getattr(policy, "rules", None)
+        if rules:
             policies_info[policy_name]["rules"] = {
-                "at": getattr(policy.rules[0], "at", None),
-                "every": getattr(policy.rules[0], "every", None),
-                "keep_for": getattr(policy.rules[0], "keep_for", None),
-                "time_zone": getattr(policy.rules[0], "time_zone", None),
+                "at": getattr(rules[0], "at", None),
+                "every": getattr(rules[0], "every", None),
+                "keep_for": getattr(rules[0], "keep_for", None),
+                "time_zone": getattr(rules[0], "time_zone", None),
             }
     return policies_info
 


### PR DESCRIPTION
##### SUMMARY
purefb_info: guard snapshot policy rules access generate_policies_dict accessed policy.rules directly, unlike every other field in the same dict which uses getattr(..., None). The pypureclient models raise AttributeError (instead of returning None) for a declared-but-unset field, and on older py-pure-client releases get_policies() returns policy objects that do not expose rules at all. Either case makes the snapshot_policies subset crash with "AttributeError: object has no attribute rules".

Resolve rules via getattr so the accessor is safe on every py-pure-client version and when a policy simply has no rules.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_info.py