### PR TITLE
flashblade: add purefb_local_ds/user/group modules for Local Directory Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ All modules are idempotent with the exception of modules that change or set pass
 - purefb_kmip - manage FlashBlade KMIP servers
 - purefb_lag - manage FlashBlade Link Aggregation Groups
 - purefb_lifecycle - manage FlashBlade Bucket Lifecycle Rules
+- purefb_local_ds - manage FlashBlade Local Directory Services
+- purefb_local_group - manage local groups in a FlashBlade Local Directory Service
+- purefb_local_user - manage local users in a FlashBlade Local Directory Service
 - purefb_messages - list FlashBlade alert messages
 - purefb_network - manage the network settings for a FlashBlade
 - purefb_ntp - manage the NTP settings for a FlashBlade

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -30,6 +30,9 @@ action_groups:
    - purefb_kmip
    - purefb_lag
    - purefb_lifecycle
+   - purefb_local_ds
+   - purefb_local_group
+   - purefb_local_user
    - purefb_messages
    - purefb_network
    - purefb_ntp

--- a/plugins/modules/purefb_local_ds.py
+++ b/plugins/modules/purefb_local_ds.py
@@ -1,0 +1,342 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2026, Simon Dodsley (simon@everpuredata.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefb_local_ds
+version_added: '1.28.0'
+short_description: Manage FlashBlade Local Directory Services
+description:
+- Create, update or delete a FlashBlade Local Directory Service (LDS).
+- An LDS is the server-scoped container that owns local users and local
+  groups (see M(everpure.flashblade.purefb_local_user) and
+  M(everpure.flashblade.purefb_local_group)).
+- Requires FlashBlade REST API version 2.24 or later (Purity//FB 4.6.8+).
+- Server attachment is not managed here; attach an existing LDS to a server
+  via M(everpure.flashblade.purefb_server). Rename and the destroyed /
+  eradicate lifecycle are deferred until validated against a live 2.24 array.
+author:
+- Pure Storage Ansible Team (@avk) <pure-ansible-team@everpuredata.com>
+options:
+  name:
+    description:
+    - Name of the Local Directory Service.
+    - Accepts the realm-qualified form C(realm::name) for realm-scoped LDSes.
+    type: str
+    required: true
+  state:
+    description:
+    - Whether the LDS should exist or not.
+    - I(state=absent) issues a direct DELETE. The module preflight-checks
+      C(/servers) and refuses to delete an LDS still attached to any server;
+      detach it via M(everpure.flashblade.purefb_server) first.
+    type: str
+    default: present
+    choices: [ absent, present ]
+  domain:
+    description:
+    - Domain string for the LDS.
+    - Optional at create - when omitted, the array defaults the domain to
+      the LDS name.
+    - Patchable, but a domain change is disruptive; the API refuses it while
+      the LDS is attached to a server. The module warns before issuing the
+      PATCH in that case and surfaces the API error verbatim if rejected.
+    - When omitted from the play on an existing LDS, the module does not
+      touch the domain field (never "reset to LDS-name-default").
+    type: str
+  context:
+    description:
+    - Name of fleet member on which to perform the operation.
+    - This requires the array receiving the request is a member of a fleet
+      and the context name to be a member of the same fleet.
+    type: str
+    default: ""
+extends_documentation_fragment:
+- everpure.flashblade.everpure.fb
+"""
+
+EXAMPLES = r"""
+- name: Create a local directory service with an explicit domain
+  everpure.flashblade.purefb_local_ds:
+    name: myserver_local
+    domain: local
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Create a local directory service, letting the array default the domain
+  everpure.flashblade.purefb_local_ds:
+    name: myserver_local
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Change the domain on an existing LDS (must be detached from any server)
+  everpure.flashblade.purefb_local_ds:
+    name: myserver_local
+    domain: corp.local
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Delete a local directory service (must be detached first)
+  everpure.flashblade.purefb_local_ds:
+    name: myserver_local
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Full workflow - create LDS, attach via purefb_server, add a user
+  block:
+    - name: Create LDS
+      everpure.flashblade.purefb_local_ds:
+        name: myserver_local
+        domain: local
+        fb_url: 10.10.10.2
+        api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+    - name: Attach LDS to server (see purefb_server for details)
+      everpure.flashblade.purefb_server:
+        name: myserver
+        directory_service:
+          - myserver_local
+        fb_url: 10.10.10.2
+        api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+    - name: Create primary group for alice
+      everpure.flashblade.purefb_local_group:
+        fb_url: 10.10.10.2
+        api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+        name: alice
+        local_directory_service: myserver_local
+    - name: Create local user in the LDS
+      everpure.flashblade.purefb_local_user:
+        fb_url: 10.10.10.2
+        api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+        name: alice
+        local_directory_service: myserver_local
+        password: "s3cret!"
+        primary_group: alice
+"""
+
+RETURN = r"""
+"""
+
+
+HAS_PYPURECLIENT = True
+try:
+    from pypureclient.flashblade import (
+        LocalDirectoryService,
+        LocalDirectoryServicePost,
+    )
+except ImportError:
+    HAS_PYPURECLIENT = False
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import (
+    get_system,
+    purefb_argument_spec,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
+    get_error_message,
+    get_rest_api_version,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
+
+MIN_REQUIRED_API_VERSION = "2.24"
+
+
+def _context_kwargs(module):
+    """Return context_names kwargs when a context is set.
+
+    LDS requires REST 2.24, which is well above the 2.17 fleet-context floor,
+    so the array is guaranteed to accept context_names when we reach here.
+    """
+    if module.params["context"]:
+        return {"context_names": [module.params["context"]]}
+    return {}
+
+
+def _get_lds(module, blade):
+    ctx = _context_kwargs(module)
+    res = blade.get_directory_services_local_directory_services(
+        names=[module.params["name"]], **ctx
+    )
+    if res.status_code == 200:
+        items = list(res.items)
+        if items:
+            return items[0]
+    return None
+
+
+def _find_attached_server(module, blade):
+    """Return the name of a server attached to this LDS, or None.
+
+    Fails the module if the attachment check itself errors, so the delete
+    preflight can never silently pass on an API failure.
+    """
+    ctx = _context_kwargs(module)
+    filter_expr = "local_directory_service.name='{0}'".format(module.params["name"])
+    res = blade.get_servers(filter=filter_expr, **ctx)
+    if res.status_code != 200:
+        module.fail_json(
+            msg=(
+                "Failed to check server attachment for "
+                "local directory service {0}. Error: {1}"
+            ).format(module.params["name"], get_error_message(res))
+        )
+    items = list(res.items)
+    if not items:
+        return None
+    return getattr(items[0], "name", None)
+
+
+def delete_lds(module, blade):
+    attached = _find_attached_server(module, blade)
+    if attached:
+        module.fail_json(
+            msg=(
+                "Local directory service '{0}' is attached to server '{1}'. "
+                "Detach it via purefb_server before deleting."
+            ).format(module.params["name"], attached)
+        )
+    changed = True
+    if not module.check_mode:
+        ctx = _context_kwargs(module)
+        res = blade.delete_directory_services_local_directory_services(
+            names=[module.params["name"]], **ctx
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to delete local directory service {0}. Error: {1}".format(
+                    module.params["name"], get_error_message(res)
+                )
+            )
+    module.exit_json(changed=changed)
+
+
+def create_lds(module, blade):
+    changed = True
+    if not module.check_mode:
+        if module.params["domain"] is not None:
+            body = LocalDirectoryServicePost(domain=module.params["domain"])
+        else:
+            body = LocalDirectoryServicePost()
+        ctx = _context_kwargs(module)
+        res = blade.post_directory_services_local_directory_services(
+            names=[module.params["name"]], local_directory=body, **ctx
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to create local directory service {0}. Error: {1}".format(
+                    module.params["name"], get_error_message(res)
+                )
+            )
+    module.exit_json(changed=changed)
+
+
+def update_lds(module, blade, lds):
+    ctx = _context_kwargs(module)
+    patch_kwargs = {}
+    if module.params["domain"] is not None and module.params["domain"] != getattr(
+        lds, "domain", None
+    ):
+        patch_kwargs["domain"] = module.params["domain"]
+
+    if not patch_kwargs:
+        module.exit_json(changed=False)
+
+    attached_server = getattr(lds, "server", None)
+    attached_name = getattr(attached_server, "name", None) if attached_server else None
+    if attached_name:
+        module.warn(
+            (
+                "Changing domain on local directory service '{0}' is disruptive "
+                "and is only permitted when detached; the array may reject this "
+                "while '{0}' is attached to server '{1}'."
+            ).format(module.params["name"], attached_name)
+        )
+
+    changed = True
+    if not module.check_mode:
+        res = blade.patch_directory_services_local_directory_services(
+            names=[module.params["name"]],
+            local_directory=LocalDirectoryService(**patch_kwargs),
+            **ctx,
+        )
+        if res.status_code != 200:
+            if attached_name:
+                module.fail_json(
+                    msg=(
+                        "Failed to update local directory service {0} "
+                        "(attached to server '{1}'). Error: {2}"
+                    ).format(
+                        module.params["name"], attached_name, get_error_message(res)
+                    )
+                )
+            module.fail_json(
+                msg="Failed to update local directory service {0}. Error: {1}".format(
+                    module.params["name"], get_error_message(res)
+                )
+            )
+    module.exit_json(changed=changed)
+
+
+def main():
+    argument_spec = purefb_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(type="str", required=True),
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            domain=dict(type="str"),
+            context=dict(type="str", default=""),
+        )
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    if not HAS_PYPURECLIENT:
+        module.fail_json(msg="py-pure-client sdk is required for this module")
+
+    blade = get_system(module)
+    api_version = get_rest_api_version(blade)
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
+        module.fail_json(
+            msg=(
+                "FlashBlade REST version not supported. "
+                "Minimum version required: {0} (Purity//FB 4.6.8+)"
+            ).format(MIN_REQUIRED_API_VERSION)
+        )
+
+    if not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
+
+    lds = _get_lds(module, blade)
+    state = module.params["state"]
+
+    if state == "absent" and lds:
+        delete_lds(module, blade)
+    elif state == "absent":
+        module.exit_json(changed=False)
+    elif state == "present" and not lds:
+        create_lds(module, blade)
+    else:
+        update_lds(module, blade, lds)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/purefb_local_group.py
+++ b/plugins/modules/purefb_local_group.py
@@ -1,0 +1,534 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2026, Simon Dodsley (simon@everpuredata.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefb_local_group
+version_added: '1.28.0'
+short_description: Manage FlashBlade Local Directory Service groups
+description:
+- Create, update, rename or delete a local group in a FlashBlade Local
+  Directory Service (LDS). These are the SMB/NFS local identities that live
+  inside an LDS attached to a FlashBlade server.
+- Requires FlashBlade REST API version 2.24 or later (Purity//FB 4.6.8+).
+- User memberships can be managed inline via the I(local_users) option. If
+  you also drive membership from the user side (via
+  M(everpure.flashblade.purefb_local_user)), only manage a given (user,group)
+  edge from one side in a single playbook run.
+author:
+- Pure Storage Ansible Team (@avk) <pure-ansible-team@everpuredata.com>
+options:
+  name:
+    description:
+    - Name of the local group inside the LDS.
+    type: str
+    required: true
+  state:
+    description:
+    - Whether the local group should exist or not.
+    type: str
+    default: present
+    choices: [ absent, present ]
+  local_directory_service:
+    description:
+    - Name of the Local Directory Service that owns this group.
+    - Attach LDSes to servers via M(everpure.flashblade.purefb_server).
+    type: str
+    required: true
+  new_name:
+    description:
+    - New name for the group. Uses the C(LocalGroupPatch.name) field.
+    - Rejected for built-in groups.
+    type: str
+  gid:
+    description:
+    - Numeric GID for the group. Auto-assigned by the array if omitted at
+      create time. Patchable.
+    type: int
+  email:
+    description:
+    - Email address for the group.
+    type: str
+  local_users:
+    description:
+    - List of local-user names that should be members of this group.
+    - When set, the module reconciles the group's user members against this
+      list via C(/directory-services/local/groups/members) filtered to user
+      members (nested-group and external members are unaffected).
+    - The option is named I(local_users) rather than I(members) to reserve
+      option space for future I(external_members) and I(group_members)
+      without a breaking rename.
+    type: list
+    elements: str
+  force:
+    description:
+    - Only used when I(state=absent).
+    - When the group has members and I(force=false), the module fails with
+      a clear message rather than surfacing the raw API error.
+    - When I(force=true), the module removes all current memberships before
+      deleting the group. Refused on built-in groups regardless.
+    type: bool
+    default: false
+  context:
+    description:
+    - Name of fleet member on which to perform the operation.
+    - This requires the array receiving the request is a member of a fleet
+      and the context name to be a member of the same fleet.
+    type: str
+    default: ""
+extends_documentation_fragment:
+- everpure.flashblade.everpure.fb
+"""
+
+EXAMPLES = r"""
+- name: Create local group 'developers'
+  everpure.flashblade.purefb_local_group:
+    name: developers
+    local_directory_service: myserver_local
+    gid: 6001
+    email: developers@example.com
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Ensure 'developers' has these local user members
+  everpure.flashblade.purefb_local_group:
+    name: developers
+    local_directory_service: myserver_local
+    local_users:
+      - alice
+      - bob
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Rename local group
+  everpure.flashblade.purefb_local_group:
+    name: developers
+    new_name: devs
+    local_directory_service: myserver_local
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Delete an empty local group
+  everpure.flashblade.purefb_local_group:
+    name: devs
+    local_directory_service: myserver_local
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Force-delete a group that still has members
+  everpure.flashblade.purefb_local_group:
+    name: devs
+    local_directory_service: myserver_local
+    state: absent
+    force: true
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+"""
+
+RETURN = r"""
+"""
+
+
+HAS_PYPURECLIENT = True
+try:
+    from pypureclient.flashblade import (
+        LocalGroupPost,
+        LocalGroupPatch,
+        LocalGroupMembershipPost,
+        LocalGroupMembershipPostMembers,
+        ReferenceWritable,
+    )
+except ImportError:
+    HAS_PYPURECLIENT = False
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import (
+    get_system,
+    purefb_argument_spec,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
+    get_error_message,
+    get_rest_api_version,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
+
+MIN_REQUIRED_API_VERSION = "2.24"
+
+
+def _context_kwargs(module):
+    """Return context_names kwargs when a context is set.
+
+    Local groups require REST 2.24, which is well above the 2.17 fleet-context
+    floor, so context_names is always accepted here.
+    """
+    if module.params["context"]:
+        return {"context_names": [module.params["context"]]}
+    return {}
+
+
+def _lds_filter(local_ds_name, extra=None):
+    """Build a filter expression that scopes to the given LDS.
+
+    The FB 2.24 GET endpoints for local groups / members do not accept
+    ``local_directory_service_names``; scoping must go through ``filter``.
+    """
+    expr = "local_directory_service.name='{0}'".format(
+        local_ds_name.replace("'", "\\'")
+    )
+    if extra:
+        expr = "({0}) and ({1})".format(expr, extra)
+    return expr
+
+
+def _get_group(module, blade, local_ds_name):
+    ctx = _context_kwargs(module)
+    res = blade.get_directory_services_local_groups(
+        names=[module.params["name"]],
+        filter=_lds_filter(local_ds_name),
+        **ctx,
+    )
+    if res.status_code == 200:
+        items = list(res.items)
+        if items:
+            return items[0]
+    return None
+
+
+def _get_current_user_members(module, blade, local_ds_name, group_name=None):
+    """Return the set of user-member names currently attached to this group."""
+    ctx = _context_kwargs(module)
+    res = blade.get_directory_services_local_groups_members(
+        group_names=[group_name or module.params["name"]],
+        filter=_lds_filter(local_ds_name),
+        member_types=["User"],
+        **ctx,
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg="Failed to fetch memberships for group {0}. Error: {1}".format(
+                module.params["name"], get_error_message(res)
+            )
+        )
+    result = set()
+    for edge in list(res.items):
+        member = getattr(edge, "member", None)
+        if member is not None:
+            mname = getattr(member, "name", None)
+            if mname:
+                result.add(mname)
+    return result
+
+
+def _get_all_current_members(module, blade, local_ds_name):
+    """Return the full list of member edges for this group (any type)."""
+    ctx = _context_kwargs(module)
+    res = blade.get_directory_services_local_groups_members(
+        group_names=[module.params["name"]],
+        filter=_lds_filter(local_ds_name),
+        **ctx,
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg="Failed to fetch memberships for group {0}. Error: {1}".format(
+                module.params["name"], get_error_message(res)
+            )
+        )
+    return list(res.items)
+
+
+def _add_user_members(module, blade, local_ds_name, users, group_name):
+    ctx = _context_kwargs(module)
+    body = LocalGroupMembershipPost(
+        members=[
+            LocalGroupMembershipPostMembers(member=ReferenceWritable(name=u))
+            for u in users
+        ]
+    )
+    res = blade.post_directory_services_local_groups_members(
+        local_membership=body,
+        group_names=[group_name],
+        local_directory_service_names=[local_ds_name],
+        **ctx,
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg=("Failed to add user members {0} to group {1}. Error: {2}").format(
+                sorted(users), group_name, get_error_message(res)
+            )
+        )
+
+
+def _remove_user_members(module, blade, local_ds_name, users, group_name):
+    ctx = _context_kwargs(module)
+    for u in users:
+        res = blade.delete_directory_services_local_groups_members(
+            group_names=[group_name],
+            member_names=[u],
+            member_types=["User"],
+            local_directory_service_names=[local_ds_name],
+            **ctx,
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg=("Failed to remove user {0} from group {1}. Error: {2}").format(
+                    u, group_name, get_error_message(res)
+                )
+            )
+
+
+def _reconcile_user_members(module, blade, local_ds_name, group_name):
+    """Reconcile user members against module.params['local_users']."""
+    desired = set(module.params["local_users"] or [])
+    current = _get_current_user_members(
+        module, blade, local_ds_name, group_name=group_name
+    )
+    add = desired - current
+    remove = current - desired
+    changed = bool(add or remove)
+    if changed and not module.check_mode:
+        if add:
+            _add_user_members(module, blade, local_ds_name, add, group_name)
+        if remove:
+            _remove_user_members(module, blade, local_ds_name, remove, group_name)
+    return changed
+
+
+def delete_group(module, blade, local_ds_name, group):
+    if getattr(group, "built_in", False):
+        module.fail_json(
+            msg="Refusing to delete built-in local group {0}".format(
+                module.params["name"]
+            )
+        )
+
+    current_edges = _get_all_current_members(module, blade, local_ds_name)
+    if current_edges:
+        if not module.params["force"]:
+            module.fail_json(
+                msg=(
+                    "Local group {0} has {1} member(s); "
+                    "remove them or set force: true to auto-clear before delete."
+                ).format(module.params["name"], len(current_edges))
+            )
+        if not module.check_mode:
+            ctx = _context_kwargs(module)
+            for edge in current_edges:
+                member = getattr(edge, "member", None)
+                mname = getattr(member, "name", None) if member else None
+                if not mname:
+                    continue
+                mtype = getattr(member, "resource_type", None)
+                delete_kwargs = {
+                    "group_names": [module.params["name"]],
+                    "member_names": [mname],
+                    "local_directory_service_names": [local_ds_name],
+                }
+                if mtype:
+                    # resource_type is a hint like 'local-users' or 'local-groups';
+                    # translate to the member_types filter when we can.
+                    if "user" in mtype:
+                        delete_kwargs["member_types"] = ["User"]
+                    elif "group" in mtype:
+                        delete_kwargs["member_types"] = ["Group"]
+                delete_kwargs.update(ctx)
+                res = blade.delete_directory_services_local_groups_members(
+                    **delete_kwargs
+                )
+                if res.status_code != 200:
+                    module.fail_json(
+                        msg=(
+                            "Failed to clear member {0} from group {1}. Error: {2}"
+                        ).format(mname, module.params["name"], get_error_message(res))
+                    )
+
+    changed = True
+    if not module.check_mode:
+        ctx = _context_kwargs(module)
+        res = blade.delete_directory_services_local_groups(
+            names=[module.params["name"]],
+            local_directory_service_names=[local_ds_name],
+            **ctx,
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to delete local group {0}. Error: {1}".format(
+                    module.params["name"], get_error_message(res)
+                )
+            )
+    module.exit_json(changed=changed)
+
+
+def create_group(module, blade, local_ds_name):
+    changed = True
+    if not module.check_mode:
+        body_kwargs = {}
+        if module.params["email"] is not None:
+            body_kwargs["email"] = module.params["email"]
+        if module.params["gid"] is not None:
+            body_kwargs["gid"] = module.params["gid"]
+
+        ctx = _context_kwargs(module)
+        res = blade.post_directory_services_local_groups(
+            names=[module.params["name"]],
+            local_directory_service_names=[local_ds_name],
+            local_group=LocalGroupPost(**body_kwargs),
+            **ctx,
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to create local group {0}. Error: {1}".format(
+                    module.params["name"], get_error_message(res)
+                )
+            )
+
+        if module.params["local_users"]:
+            _reconcile_user_members(module, blade, local_ds_name, module.params["name"])
+    module.exit_json(changed=changed)
+
+
+def update_group(module, blade, local_ds_name, group):
+    ctx = _context_kwargs(module)
+    built_in = bool(getattr(group, "built_in", False))
+    patch_kwargs = {}
+    identity_changes = []
+
+    if module.params["new_name"] and module.params["new_name"] != module.params["name"]:
+        if built_in:
+            module.fail_json(
+                msg="Refusing to rename built-in local group {0}".format(
+                    module.params["name"]
+                )
+            )
+        clash = blade.get_directory_services_local_groups(
+            names=[module.params["new_name"]],
+            filter=_lds_filter(local_ds_name),
+            **ctx,
+        )
+        if clash.status_code == 200 and list(clash.items):
+            module.fail_json(
+                msg=(
+                    "Cannot rename local group {0} to {1}: target name already exists"
+                ).format(module.params["name"], module.params["new_name"])
+            )
+        patch_kwargs["name"] = module.params["new_name"]
+        identity_changes.append("name")
+
+    if module.params["email"] is not None and module.params["email"] != getattr(
+        group, "email", None
+    ):
+        patch_kwargs["email"] = module.params["email"]
+        identity_changes.append("email")
+
+    if module.params["gid"] is not None and module.params["gid"] != getattr(
+        group, "gid", None
+    ):
+        patch_kwargs["gid"] = module.params["gid"]
+        identity_changes.append("gid")
+
+    if identity_changes and built_in:
+        module.fail_json(
+            msg="Refusing to modify built-in local group {0}".format(
+                module.params["name"]
+            )
+        )
+
+    patch_changed = bool(patch_kwargs)
+    if patch_changed and not module.check_mode:
+        res = blade.patch_directory_services_local_groups(
+            names=[module.params["name"]],
+            local_directory_service_names=[local_ds_name],
+            local_group=LocalGroupPatch(**patch_kwargs),
+            **ctx,
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to update local group {0}. Error: {1}".format(
+                    module.params["name"], get_error_message(res)
+                )
+            )
+
+    membership_changed = False
+    if module.params["local_users"] is not None:
+        # After a successful rename the group is now known by new_name; in
+        # check mode the rename was skipped, so it keeps its current name.
+        if module.check_mode:
+            effective_name = module.params["name"]
+        else:
+            effective_name = patch_kwargs.get("name") or module.params["name"]
+        membership_changed = _reconcile_user_members(
+            module, blade, local_ds_name, effective_name
+        )
+
+    module.exit_json(changed=patch_changed or membership_changed)
+
+
+def main():
+    argument_spec = purefb_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(type="str", required=True),
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            local_directory_service=dict(type="str", required=True),
+            new_name=dict(type="str"),
+            gid=dict(type="int"),
+            email=dict(type="str"),
+            local_users=dict(type="list", elements="str"),
+            force=dict(type="bool", default=False),
+            context=dict(type="str", default=""),
+        )
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    if not HAS_PYPURECLIENT:
+        module.fail_json(msg="py-pure-client sdk is required for this module")
+
+    blade = get_system(module)
+    api_version = get_rest_api_version(blade)
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
+        module.fail_json(
+            msg=(
+                "FlashBlade REST version not supported. "
+                "Minimum version required: {0} (Purity//FB 4.6.8+)"
+            ).format(MIN_REQUIRED_API_VERSION)
+        )
+
+    if not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
+
+    local_ds_name = module.params["local_directory_service"]
+    group = _get_group(module, blade, local_ds_name)
+    state = module.params["state"]
+
+    if state == "absent" and group:
+        delete_group(module, blade, local_ds_name, group)
+    elif state == "absent":
+        module.exit_json(changed=False)
+    elif state == "present" and not group:
+        create_group(module, blade, local_ds_name)
+    else:
+        update_group(module, blade, local_ds_name, group)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/purefb_local_user.py
+++ b/plugins/modules/purefb_local_user.py
@@ -1,0 +1,588 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2026, Simon Dodsley (simon@everpuredata.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefb_local_user
+version_added: '1.28.0'
+short_description: Manage FlashBlade Local Directory Service users
+description:
+- Create, update, rename or delete a local user in a FlashBlade Local
+  Directory Service (LDS). These are the SMB/NFS local identities that live
+  inside an LDS attached to a FlashBlade server. They are not the array
+  management admins - use M(everpure.flashblade.purefb_user) or
+  M(everpure.flashblade.purefb_admin) for those.
+- Requires FlashBlade REST API version 2.24 or later (Purity//FB 4.6.8+).
+- Group memberships can be managed inline via the I(groups) option. If you
+  also drive membership from the group side (via
+  M(everpure.flashblade.purefb_local_group)), only manage a given
+  (user,group) edge from one side in a single playbook run.
+author:
+- Pure Storage Ansible Team (@avk) <pure-ansible-team@everpuredata.com>
+options:
+  name:
+    description:
+    - Name of the local user inside the LDS.
+    type: str
+    required: true
+  state:
+    description:
+    - Whether the local user should exist or not.
+    type: str
+    default: present
+    choices: [ absent, present ]
+  local_directory_service:
+    description:
+    - Name of the Local Directory Service that owns this user.
+    - Attach LDSes to servers via M(everpure.flashblade.purefb_server).
+    type: str
+    required: true
+  new_name:
+    description:
+    - New name for the user. Uses the C(LocalUserPatch.name) field.
+    - Rejected for built-in users.
+    type: str
+  uid:
+    description:
+    - Numeric UID for the user. Auto-assigned by the array if omitted at
+      create time. Patchable.
+    type: int
+  email:
+    description:
+    - Email address for the user.
+    type: str
+  enabled:
+    description:
+    - Whether the user account is enabled.
+    type: bool
+    default: true
+  password:
+    description:
+    - Password for the user.
+    - Required at create time when I(enabled=true).
+    - Required on the transition of an existing user from
+      I(enabled=false) to I(enabled=true).
+    - Otherwise ignored unless I(force_password_reset=true).
+    type: str
+  force_password_reset:
+    description:
+    - Force the password to be reset on an existing user, even if unchanged.
+    - There is no way to compare the current password on the array, so
+      password change is inherently non-idempotent. Set this true to
+      explicitly ask for a reset.
+    type: bool
+    default: false
+  primary_group:
+    description:
+    - Name of the local group that is the user's primary group.
+    - Required when I(state=present) - the array will not create a user
+      without one.
+    - The primary group must already exist in the same LDS.
+    type: str
+  groups:
+    description:
+    - List of non-primary local group names the user should belong to.
+    - When set, the module reconciles the user's group memberships against
+      this list via C(/directory-services/local/users/members).
+    - The primary group (either the current one or a newly requested one) is
+      never removed via this list - the API disallows removing the primary
+      group edge.
+    - After a primary-group change the former primary remains a regular
+      member; if it is not listed here, a second run removes it.
+    type: list
+    elements: str
+  context:
+    description:
+    - Name of fleet member on which to perform the operation.
+    - This requires the array receiving the request is a member of a fleet
+      and the context name to be a member of the same fleet.
+    type: str
+    default: ""
+extends_documentation_fragment:
+- everpure.flashblade.everpure.fb
+"""
+
+EXAMPLES = r"""
+- name: Create local user 'alice'
+  everpure.flashblade.purefb_local_user:
+    name: alice
+    local_directory_service: myserver_local
+    uid: 5001
+    password: "s3cret!"
+    primary_group: alice
+    email: alice@example.com
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Ensure 'alice' also belongs to secondary groups
+  everpure.flashblade.purefb_local_user:
+    name: alice
+    local_directory_service: myserver_local
+    primary_group: alice
+    groups:
+      - developers
+      - infra
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Disable local user
+  everpure.flashblade.purefb_local_user:
+    name: alice
+    local_directory_service: myserver_local
+    primary_group: alice
+    enabled: false
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Rename local user
+  everpure.flashblade.purefb_local_user:
+    name: alice
+    new_name: alice2
+    local_directory_service: myserver_local
+    primary_group: alice
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Delete local user
+  everpure.flashblade.purefb_local_user:
+    name: alice
+    local_directory_service: myserver_local
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+"""
+
+RETURN = r"""
+"""
+
+
+HAS_PYPURECLIENT = True
+try:
+    from pypureclient.flashblade import (
+        LocalUserPost,
+        LocalUserPatch,
+        LocalUserMembershipPost,
+        LocalUserMembershipPostGroups,
+        ReferenceWritable,
+    )
+except ImportError:
+    HAS_PYPURECLIENT = False
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import (
+    get_system,
+    purefb_argument_spec,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
+    get_error_message,
+    get_rest_api_version,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
+
+MIN_REQUIRED_API_VERSION = "2.24"
+
+
+def _context_kwargs(module):
+    """Return context_names kwargs when a context is set.
+
+    Local users require REST 2.24, which is well above the 2.17 fleet-context
+    floor, so context_names is always accepted here.
+    """
+    if module.params["context"]:
+        return {"context_names": [module.params["context"]]}
+    return {}
+
+
+def _lds_filter(local_ds_name, extra=None):
+    """Build a filter expression that scopes to the given LDS.
+
+    The FB GET endpoints for local users / members do not accept
+    ``local_directory_service_names``; scoping must go through ``filter``.
+    """
+    expr = "local_directory_service.name='{0}'".format(
+        local_ds_name.replace("'", "\\'")
+    )
+    if extra:
+        expr = "({0}) and ({1})".format(expr, extra)
+    return expr
+
+
+def _get_user(module, blade, local_ds_name):
+    ctx = _context_kwargs(module)
+    res = blade.get_directory_services_local_users(
+        names=[module.params["name"]],
+        filter=_lds_filter(local_ds_name),
+        **ctx,
+    )
+    if res.status_code == 200:
+        items = list(res.items)
+        if items:
+            return items[0]
+    return None
+
+
+def _get_current_groups(module, blade, local_ds_name):
+    """Return the set of current non-primary group names for this user."""
+    ctx = _context_kwargs(module)
+    res = blade.get_directory_services_local_users_members(
+        member_names=[module.params["name"]],
+        filter=_lds_filter(local_ds_name),
+        **ctx,
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg="Failed to fetch memberships for user {0}. Error: {1}".format(
+                module.params["name"], get_error_message(res)
+            )
+        )
+    result = set()
+    for edge in list(res.items):
+        group = getattr(edge, "group", None)
+        if group is not None:
+            gname = getattr(group, "name", None)
+            if gname:
+                result.add(gname)
+    return result
+
+
+def _add_memberships(module, blade, local_ds_name, groups):
+    ctx = _context_kwargs(module)
+    body = LocalUserMembershipPost(
+        groups=[
+            LocalUserMembershipPostGroups(group=ReferenceWritable(name=g))
+            for g in groups
+        ]
+    )
+    res = blade.post_directory_services_local_users_members(
+        local_membership=body,
+        member_names=[module.params["name"]],
+        local_directory_service_names=[local_ds_name],
+        **ctx,
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg="Failed to add group memberships {0} for user {1}. Error: {2}".format(
+                sorted(groups),
+                module.params["name"],
+                get_error_message(res),
+            )
+        )
+
+
+def _remove_memberships(module, blade, local_ds_name, groups):
+    ctx = _context_kwargs(module)
+    for g in groups:
+        res = blade.delete_directory_services_local_users_members(
+            member_names=[module.params["name"]],
+            group_names=[g],
+            local_directory_service_names=[local_ds_name],
+            **ctx,
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg=("Failed to remove user {0} from group {1}. Error: {2}").format(
+                    module.params["name"], g, get_error_message(res)
+                )
+            )
+
+
+def _reconcile_memberships(
+    module, blade, local_ds_name, desired_primary_group, current_primary_group=None
+):
+    """Reconcile the user's non-primary group set against module.params['groups'].
+
+    Both the desired and the current primary group are excluded from removal:
+    the API disallows deleting the primary-group edge, and until the PATCH has
+    run the current primary is still in force.
+    """
+    desired = set(module.params["groups"] or [])
+    current = _get_current_groups(module, blade, local_ds_name)
+
+    exclude = set()
+    if desired_primary_group:
+        exclude.add(desired_primary_group)
+    if current_primary_group:
+        exclude.add(current_primary_group)
+    desired = desired - exclude
+    current_diff = current - exclude
+
+    add = desired - current_diff
+    remove = current_diff - desired
+    changed = bool(add or remove)
+    if changed and not module.check_mode:
+        if add:
+            _add_memberships(module, blade, local_ds_name, add)
+        if remove:
+            _remove_memberships(module, blade, local_ds_name, remove)
+    return changed
+
+
+def delete_user(module, blade, local_ds_name, user):
+    if getattr(user, "built_in", False):
+        module.fail_json(
+            msg="Refusing to delete built-in local user {0}".format(
+                module.params["name"]
+            )
+        )
+    changed = True
+    if not module.check_mode:
+        ctx = _context_kwargs(module)
+        res = blade.delete_directory_services_local_users(
+            names=[module.params["name"]],
+            local_directory_service_names=[local_ds_name],
+            **ctx,
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to delete local user {0}. Error: {1}".format(
+                    module.params["name"], get_error_message(res)
+                )
+            )
+    module.exit_json(changed=changed)
+
+
+def create_user(module, blade, local_ds_name):
+    if module.params["enabled"] and not module.params["password"]:
+        module.fail_json(
+            msg="'password' is required when creating an enabled local user"
+        )
+    changed = True
+    if not module.check_mode:
+        body_kwargs = {}
+        if module.params["email"] is not None:
+            body_kwargs["email"] = module.params["email"]
+        body_kwargs["enabled"] = module.params["enabled"]
+        if module.params["password"]:
+            body_kwargs["password"] = module.params["password"]
+        body_kwargs["primary_group"] = ReferenceWritable(
+            name=module.params["primary_group"]
+        )
+        if module.params["uid"] is not None:
+            body_kwargs["uid"] = module.params["uid"]
+
+        ctx = _context_kwargs(module)
+        res = blade.post_directory_services_local_users(
+            names=[module.params["name"]],
+            local_directory_service_names=[local_ds_name],
+            local_user=LocalUserPost(**body_kwargs),
+            **ctx,
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to create local user {0}. Error: {1}".format(
+                    module.params["name"], get_error_message(res)
+                )
+            )
+
+        if module.params["groups"]:
+            _reconcile_memberships(
+                module,
+                blade,
+                local_ds_name,
+                module.params["primary_group"],
+            )
+    module.exit_json(changed=changed)
+
+
+def update_user(module, blade, local_ds_name, user):
+    ctx = _context_kwargs(module)
+    built_in = bool(getattr(user, "built_in", False))
+    current_pg = getattr(user, "primary_group", None)
+    current_pg_name = getattr(current_pg, "name", None) if current_pg else None
+
+    patch_kwargs = {}
+    identity_changes = []
+
+    if module.params["new_name"] and module.params["new_name"] != module.params["name"]:
+        if built_in:
+            module.fail_json(
+                msg="Refusing to rename built-in local user {0}".format(
+                    module.params["name"]
+                )
+            )
+        # Refuse if target name already exists in this LDS.
+        name_conflict_check = blade.get_directory_services_local_users(
+            names=[module.params["new_name"]],
+            filter=_lds_filter(local_ds_name),
+            **ctx,
+        )
+        if name_conflict_check.status_code == 200 and list(name_conflict_check.items):
+            module.fail_json(
+                msg=(
+                    "Cannot rename local user {0} to {1}: target name already exists"
+                ).format(module.params["name"], module.params["new_name"])
+            )
+        patch_kwargs["name"] = module.params["new_name"]
+        identity_changes.append("name")
+
+    if module.params["email"] is not None and module.params["email"] != getattr(
+        user, "email", None
+    ):
+        patch_kwargs["email"] = module.params["email"]
+        identity_changes.append("email")
+
+    if module.params["enabled"] != getattr(user, "enabled", None):
+        # false -> true transition needs a password.
+        if module.params["enabled"] and not getattr(user, "enabled", False):
+            if not module.params["password"]:
+                module.fail_json(
+                    msg=(
+                        "'password' is required to enable local user {0} "
+                        "(re-enabling a disabled account)"
+                    ).format(module.params["name"])
+                )
+        patch_kwargs["enabled"] = module.params["enabled"]
+        identity_changes.append("enabled")
+
+    if module.params["uid"] is not None and module.params["uid"] != getattr(
+        user, "uid", None
+    ):
+        patch_kwargs["uid"] = module.params["uid"]
+        identity_changes.append("uid")
+
+    desired_pg_name = module.params["primary_group"]
+    pg_changed = False
+    if desired_pg_name != current_pg_name:
+        patch_kwargs["primary_group"] = ReferenceWritable(name=desired_pg_name)
+        identity_changes.append("primary_group")
+        pg_changed = True
+
+    if module.params["force_password_reset"]:
+        if not module.params["password"]:
+            module.fail_json(
+                msg=("'password' is required when 'force_password_reset' is true")
+            )
+        patch_kwargs["password"] = module.params["password"]
+        identity_changes.append("password")
+    elif (
+        "password" not in patch_kwargs
+        and patch_kwargs.get("enabled") is True
+        and not getattr(user, "enabled", False)
+    ):
+        # Re-enable transition: include the password once we know it exists.
+        patch_kwargs["password"] = module.params["password"]
+
+    if identity_changes and built_in:
+        # Rename is already blocked above. Block other identity mutations too;
+        # let the array reject anything we didn't foresee, but stop obvious
+        # mutations up-front with a clear message.
+        module.fail_json(
+            msg="Refusing to modify built-in local user {0}".format(
+                module.params["name"]
+            )
+        )
+
+    membership_changed = False
+    # Order-of-ops guard: reconcile memberships BEFORE PATCHing primary_group
+    # to dodge the known array-side regression where PATCHing primary_group
+    # with stale membership edges present has returned 500 on some releases.
+    if module.params["groups"] is not None and pg_changed:
+        membership_changed = _reconcile_memberships(
+            module, blade, local_ds_name, desired_pg_name, current_pg_name
+        )
+
+    patch_changed = bool(patch_kwargs)
+    if patch_changed and not module.check_mode:
+        res = blade.patch_directory_services_local_users(
+            names=[module.params["name"]],
+            local_directory_service_names=[local_ds_name],
+            local_user=LocalUserPatch(**patch_kwargs),
+            **ctx,
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to update local user {0}. Error: {1}".format(
+                    module.params["name"], get_error_message(res)
+                )
+            )
+
+    # If we didn't reconcile earlier (no primary-group change), reconcile now.
+    if module.params["groups"] is not None and not pg_changed:
+        # After a rename the user is known by new_name, and reconciliation
+        # uses module.params['name'] - but in check mode the rename was
+        # skipped, so the user still answers to the current name.
+        if patch_kwargs.get("name") and not module.check_mode:
+            module.params["name"] = patch_kwargs["name"]
+        membership_changed = _reconcile_memberships(
+            module, blade, local_ds_name, desired_pg_name, current_pg_name
+        )
+
+    module.exit_json(changed=patch_changed or membership_changed)
+
+
+def main():
+    argument_spec = purefb_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(type="str", required=True),
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            local_directory_service=dict(type="str", required=True),
+            new_name=dict(type="str"),
+            uid=dict(type="int"),
+            email=dict(type="str"),
+            enabled=dict(type="bool", default=True),
+            password=dict(type="str", no_log=True),
+            force_password_reset=dict(type="bool", default=False, no_log=False),
+            primary_group=dict(type="str"),
+            groups=dict(type="list", elements="str"),
+            context=dict(type="str", default=""),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        required_if=[("state", "present", ["primary_group"])],
+        supports_check_mode=True,
+    )
+
+    if not HAS_PYPURECLIENT:
+        module.fail_json(msg="py-pure-client sdk is required for this module")
+
+    blade = get_system(module)
+    api_version = get_rest_api_version(blade)
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
+        module.fail_json(
+            msg=(
+                "FlashBlade REST version not supported. "
+                "Minimum version required: {0} (Purity//FB 4.6.8+)"
+            ).format(MIN_REQUIRED_API_VERSION)
+        )
+
+    if not module.params["context"]:
+        # If no context is provided set the context to the local array name
+        fleet_res = blade.get_fleets()
+        if fleet_res.status_code == 200 and list(fleet_res.items):
+            module.params["context"] = list(blade.get_arrays().items)[0].name
+
+    local_ds_name = module.params["local_directory_service"]
+    user = _get_user(module, blade, local_ds_name)
+    state = module.params["state"]
+
+    if state == "absent" and user:
+        delete_user(module, blade, local_ds_name, user)
+    elif state == "absent":
+        module.exit_json(changed=False)
+    elif state == "present" and not user:
+        create_user(module, blade, local_ds_name)
+    else:
+        update_user(module, blade, local_ds_name, user)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/purefb_local_user.py
+++ b/plugins/modules/purefb_local_user.py
@@ -67,8 +67,11 @@ options:
   enabled:
     description:
     - Whether the user account is enabled.
+    - At create time, if unset the user is created enabled.
+    - On update, this field is only applied when explicitly set. This lets
+      you idempotently manage other attributes of a disabled user without
+      accidentally re-enabling the account.
     type: bool
-    default: true
   password:
     description:
     - Password for the user.
@@ -215,9 +218,9 @@ def _lds_filter(local_ds_name, extra=None):
     The FB GET endpoints for local users / members do not accept
     ``local_directory_service_names``; scoping must go through ``filter``.
     """
-    expr = "local_directory_service.name='{0}'".format(
-        local_ds_name.replace("'", "\\'")
-    )
+    # FB's filter grammar is OData-flavored: a single quote embedded in a
+    # string literal is escaped by doubling it, not backslash-escaping.
+    expr = "local_directory_service.name='{0}'".format(local_ds_name.replace("'", "''"))
     if extra:
         expr = "({0}) and ({1})".format(expr, extra)
     return expr
@@ -358,7 +361,10 @@ def delete_user(module, blade, local_ds_name, user):
 
 
 def create_user(module, blade, local_ds_name):
-    if module.params["enabled"] and not module.params["password"]:
+    # enabled is not defaulted in the argument spec so update paths stay
+    # idempotent; at create time an unset value means "enabled".
+    enabled = module.params["enabled"] if module.params["enabled"] is not None else True
+    if enabled and not module.params["password"]:
         module.fail_json(
             msg="'password' is required when creating an enabled local user"
         )
@@ -367,7 +373,7 @@ def create_user(module, blade, local_ds_name):
         body_kwargs = {}
         if module.params["email"] is not None:
             body_kwargs["email"] = module.params["email"]
-        body_kwargs["enabled"] = module.params["enabled"]
+        body_kwargs["enabled"] = enabled
         if module.params["password"]:
             body_kwargs["password"] = module.params["password"]
         body_kwargs["primary_group"] = ReferenceWritable(
@@ -437,7 +443,9 @@ def update_user(module, blade, local_ds_name, user):
         patch_kwargs["email"] = module.params["email"]
         identity_changes.append("email")
 
-    if module.params["enabled"] != getattr(user, "enabled", None):
+    if module.params["enabled"] is not None and module.params["enabled"] != getattr(
+        user, "enabled", None
+    ):
         # false -> true transition needs a password.
         if module.params["enabled"] and not getattr(user, "enabled", False):
             if not module.params["password"]:
@@ -536,7 +544,7 @@ def main():
             new_name=dict(type="str"),
             uid=dict(type="int"),
             email=dict(type="str"),
-            enabled=dict(type="bool", default=True),
+            enabled=dict(type="bool"),
             password=dict(type="str", no_log=True),
             force_password_reset=dict(type="bool", default=False, no_log=False),
             primary_group=dict(type="str"),

--- a/plugins/modules/purefb_local_user.py
+++ b/plugins/modules/purefb_local_user.py
@@ -218,9 +218,12 @@ def _lds_filter(local_ds_name, extra=None):
     The FB GET endpoints for local users / members do not accept
     ``local_directory_service_names``; scoping must go through ``filter``.
     """
-    # FB's filter grammar is OData-flavored: a single quote embedded in a
-    # string literal is escaped by doubling it, not backslash-escaping.
-    expr = "local_directory_service.name='{0}'".format(local_ds_name.replace("'", "''"))
+    # Per Pure's REST filter grammar, string literals are single-quoted and
+    # the backslash is the escape character: escape backslashes first, then
+    # single quotes.
+    escaped = local_ds_name.replace("\\", "\\\\").replace("'", "\\'")
+
+    expr = "local_directory_service.name='{0}'".format(escaped)
     if extra:
         expr = "({0}) and ({1})".format(expr, extra)
     return expr

--- a/tests/unit/plugins/modules/test_purefb_local_ds.py
+++ b/tests/unit/plugins/modules/test_purefb_local_ds.py
@@ -1,0 +1,844 @@
+# Copyright: (c) 2026, Pure Storage Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefb_local_ds module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+import multiprocessing
+import ctypes
+from unittest.mock import Mock, patch, MagicMock
+
+# Mock multiprocessing context for Windows
+if sys.platform == "win32":
+    original_get_context = multiprocessing.get_context
+
+    def mock_get_context(method=None):
+        if method == "fork":
+            return original_get_context("spawn")
+        return original_get_context(method)
+
+    multiprocessing.get_context = mock_get_context
+
+    # Mock ctypes LoadLibrary to prevent Windows errors
+    original_load_library = ctypes.cdll.LoadLibrary
+
+    def mock_load_library(name):
+        if name is None or not isinstance(name, str):
+            return MagicMock()
+        try:
+            return original_load_library(name)
+        except (OSError, TypeError):
+            return MagicMock()
+
+    ctypes.cdll.LoadLibrary = mock_load_library
+
+# Mock external dependencies before importing module
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flashblade"] = MagicMock()
+sys.modules["urllib3"] = MagicMock()
+sys.modules["distro"] = MagicMock()
+# Mock Unix-specific modules for Windows compatibility
+sys.modules["grp"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["syslog"] = MagicMock()
+# Mock termios with required constants
+mock_termios = MagicMock()
+mock_termios.TCSAFLUSH = 2
+sys.modules["termios"] = mock_termios
+sys.modules["tty"] = MagicMock()
+
+# Mock ansible_collections module structure
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.purefb"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.common"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.version"] = (
+    MagicMock()
+)
+
+from plugins.modules.purefb_local_ds import (
+    main,
+    _get_lds,
+    _find_attached_server,
+    _context_kwargs,
+)
+
+
+def _base_params(**overrides):
+    params = {
+        "name": "myserver_local",
+        "state": "present",
+        "domain": None,
+        "context": "",
+    }
+    params.update(overrides)
+    return params
+
+
+class TestPurefbLocalDs:
+    """Test cases for purefb_local_ds module"""
+
+    # ---------------- helper-function unit tests ----------------
+
+    def test_context_kwargs_returns_empty_without_context(self):
+        """_context_kwargs returns {} when no context is set"""
+        module = Mock()
+        module.params = {"context": ""}
+        assert _context_kwargs(module) == {}
+
+    def test_context_kwargs_returns_kwargs_when_set(self):
+        """_context_kwargs returns context_names when a context is set"""
+        module = Mock()
+        module.params = {"context": "peer1"}
+        assert _context_kwargs(module) == {"context_names": ["peer1"]}
+
+    def test_get_lds_returns_first_item(self):
+        """_get_lds returns the first item when present"""
+        module = Mock()
+        module.params = {"name": "myserver_local", "context": ""}
+
+        lds = Mock()
+        lds.name = "myserver_local"
+
+        blade = Mock()
+        response = Mock()
+        response.status_code = 200
+        response.items = [lds]
+        blade.get_directory_services_local_directory_services.return_value = response
+
+        assert _get_lds(module, blade) is lds
+        blade.get_directory_services_local_directory_services.assert_called_once_with(
+            names=["myserver_local"]
+        )
+
+    def test_get_lds_returns_none_when_empty(self):
+        """_get_lds returns None when items is empty"""
+        module = Mock()
+        module.params = {"name": "myserver_local", "context": ""}
+
+        blade = Mock()
+        response = Mock()
+        response.status_code = 200
+        response.items = []
+        blade.get_directory_services_local_directory_services.return_value = response
+
+        assert _get_lds(module, blade) is None
+
+    def test_get_lds_returns_none_on_error(self):
+        """_get_lds returns None when status is non-200"""
+        module = Mock()
+        module.params = {"name": "myserver_local", "context": ""}
+
+        blade = Mock()
+        response = Mock()
+        response.status_code = 400
+        response.items = []
+        blade.get_directory_services_local_directory_services.return_value = response
+
+        assert _get_lds(module, blade) is None
+
+    def test_find_attached_server_returns_name(self):
+        """_find_attached_server returns server name when one is attached"""
+        module = Mock()
+        module.params = {"name": "myserver_local", "context": ""}
+
+        server = Mock()
+        server.name = "myserver"
+        response = Mock()
+        response.status_code = 200
+        response.items = [server]
+
+        blade = Mock()
+        blade.get_servers.return_value = response
+
+        assert _find_attached_server(module, blade) == "myserver"
+        blade.get_servers.assert_called_once_with(
+            filter="local_directory_service.name='myserver_local'"
+        )
+
+    def test_find_attached_server_returns_none_when_no_server(self):
+        """_find_attached_server returns None when no server is attached"""
+        module = Mock()
+        module.params = {"name": "myserver_local", "context": ""}
+
+        response = Mock()
+        response.status_code = 200
+        response.items = []
+
+        blade = Mock()
+        blade.get_servers.return_value = response
+
+        assert _find_attached_server(module, blade) is None
+
+    def test_find_attached_server_returns_none_on_error(self):
+        """_find_attached_server returns None on API error"""
+        module = Mock()
+        module.params = {"name": "myserver_local", "context": ""}
+
+        response = Mock()
+        response.status_code = 400
+        response.items = []
+
+        blade = Mock()
+        blade.get_servers.return_value = response
+
+        assert _find_attached_server(module, blade) is None
+
+    # ---------------- main() flows ----------------
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.LocalDirectoryServicePost")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_creates_lds_with_domain(
+        self, mock_ansible_module, mock_get_system, mock_lds_post, mock_loose_version
+    ):
+        """Test creating a new LDS with an explicit domain"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(domain="local")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.17", "2.24"]
+        mock_get_system.return_value = blade
+
+        # LDS doesn't exist yet
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        # Successful create
+        post_response = Mock()
+        post_response.status_code = 200
+        post_response.items = []
+        blade.post_directory_services_local_directory_services.return_value = (
+            post_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.post_directory_services_local_directory_services.assert_called_once()
+        call_kwargs = blade.post_directory_services_local_directory_services.call_args[
+            1
+        ]
+        assert call_kwargs["names"] == ["myserver_local"]
+        mock_lds_post.assert_called_once_with(domain="local")
+        module.exit_json.assert_called_once()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.LocalDirectoryServicePost")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_creates_lds_without_domain(
+        self, mock_ansible_module, mock_get_system, mock_lds_post, mock_loose_version
+    ):
+        """Test creating a new LDS without a domain (array default)"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params()
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        post_response = Mock()
+        post_response.status_code = 200
+        post_response.items = []
+        blade.post_directory_services_local_directory_services.return_value = (
+            post_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # domain omitted → body built with no arguments
+        mock_lds_post.assert_called_once_with()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_create_check_mode_skips_post(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test create reports changed but skips POST in check mode"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(domain="local")
+        module.check_mode = True
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.post_directory_services_local_directory_services.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_create_fails_on_api_error(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test create surfaces API error via fail_json"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(domain="local")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        post_response = Mock()
+        post_response.status_code = 400
+        post_response.errors = []
+        blade.post_directory_services_local_directory_services.return_value = (
+            post_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert (
+            "Failed to create local directory service"
+            in module.fail_json.call_args[1]["msg"]
+        )
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.LocalDirectoryService")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_updates_domain(
+        self, mock_ansible_module, mock_get_system, mock_lds, mock_loose_version
+    ):
+        """Test PATCHing the domain of an existing LDS"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(domain="corp.local")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "myserver_local"
+        existing.domain = "local"
+        existing.server = None
+        existing.realms = []
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        patch_response.items = []
+        blade.patch_directory_services_local_directory_services.return_value = (
+            patch_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.patch_directory_services_local_directory_services.assert_called_once()
+        mock_lds.assert_called_once_with(domain="corp.local")
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_update_idempotent_when_domain_matches(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test update is a no-op when the domain already matches"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(domain="local")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "myserver_local"
+        existing.domain = "local"
+        existing.server = None
+        existing.realms = []
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.patch_directory_services_local_directory_services.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is False
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_update_no_domain_is_noop(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test update is a no-op when domain param is omitted (never resets it)"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params()  # domain=None
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "myserver_local"
+        existing.domain = "somedomain"
+        existing.server = None
+        existing.realms = []
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.patch_directory_services_local_directory_services.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is False
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.LocalDirectoryService")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_update_warns_when_attached(
+        self, mock_ansible_module, mock_get_system, mock_lds, mock_loose_version
+    ):
+        """Test update warns when patching domain on an LDS that is server-attached"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.warn = Mock()
+        module.params = _base_params(domain="new.domain")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        server = Mock()
+        server.name = "myserver"
+        existing = Mock()
+        existing.name = "myserver_local"
+        existing.domain = "local"
+        existing.server = server
+        existing.realms = []
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        patch_response.items = []
+        blade.patch_directory_services_local_directory_services.return_value = (
+            patch_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.warn.assert_called_once()
+        assert "myserver" in module.warn.call_args[0][0]
+        blade.patch_directory_services_local_directory_services.assert_called_once()
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.LocalDirectoryService")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_update_fails_with_attached_context_in_message(
+        self, mock_ansible_module, mock_get_system, mock_lds, mock_loose_version
+    ):
+        """Test update failure mentions attached server name in error message"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.warn = Mock()
+        module.params = _base_params(domain="new.domain")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        server = Mock()
+        server.name = "myserver"
+        existing = Mock()
+        existing.name = "myserver_local"
+        existing.domain = "local"
+        existing.server = server
+        existing.realms = []
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        patch_response = Mock()
+        patch_response.status_code = 400
+        patch_response.errors = []
+        blade.patch_directory_services_local_directory_services.return_value = (
+            patch_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        msg = module.fail_json.call_args[1]["msg"]
+        assert "myserver" in msg
+        assert "myserver_local" in msg
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_deletes_lds(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test deleting an existing, detached LDS"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "myserver_local"
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        server_response = Mock()
+        server_response.status_code = 200
+        server_response.items = []
+        blade.get_servers.return_value = server_response
+
+        delete_response = Mock()
+        delete_response.status_code = 200
+        blade.delete_directory_services_local_directory_services.return_value = (
+            delete_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.delete_directory_services_local_directory_services.assert_called_once_with(
+            names=["myserver_local"]
+        )
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_delete_refused_when_attached(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test delete refuses when LDS is still attached to a server"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "myserver_local"
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        server = Mock()
+        server.name = "myserver"
+        server_response = Mock()
+        server_response.status_code = 200
+        server_response.items = [server]
+        blade.get_servers.return_value = server_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        msg = module.fail_json.call_args[1]["msg"]
+        assert "myserver" in msg
+        assert "Detach" in msg or "detach" in msg
+        blade.delete_directory_services_local_directory_services.assert_not_called()
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_delete_nonexistent_is_noop(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test state=absent on a nonexistent LDS reports changed=False"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent", name="ghost")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.delete_directory_services_local_directory_services.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is False
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_delete_check_mode_skips_call(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test delete reports changed but skips the DELETE call in check mode"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent")
+        module.check_mode = True
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "myserver_local"
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_directory_services.return_value = (
+            get_response
+        )
+
+        server_response = Mock()
+        server_response.status_code = 200
+        server_response.items = []
+        blade.get_servers.return_value = server_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.delete_directory_services_local_directory_services.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", True)
+    def test_main_fails_on_unsupported_api_version(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test failure when the array API version is older than MIN_REQUIRED_API_VERSION"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=True)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params()
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.17", "2.18", "2.19"]
+        mock_get_system.return_value = blade
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "REST version not supported" in module.fail_json.call_args[1]["msg"]
+
+    @patch("plugins.modules.purefb_local_ds.LooseVersion")
+    @patch("plugins.modules.purefb_local_ds.get_system")
+    @patch("plugins.modules.purefb_local_ds.AnsibleModule")
+    @patch("plugins.modules.purefb_local_ds.HAS_PYPURECLIENT", False)
+    def test_main_fails_without_sdk(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test failure when py-pure-client SDK is not installed"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params()
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "py-pure-client" in module.fail_json.call_args[1]["msg"]

--- a/tests/unit/plugins/modules/test_purefb_local_group.py
+++ b/tests/unit/plugins/modules/test_purefb_local_group.py
@@ -1,0 +1,962 @@
+# Copyright: (c) 2026, Pure Storage Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefb_local_group module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+import multiprocessing
+import ctypes
+from unittest.mock import Mock, patch, MagicMock
+
+# Mock multiprocessing context for Windows
+if sys.platform == "win32":
+    original_get_context = multiprocessing.get_context
+
+    def mock_get_context(method=None):
+        if method == "fork":
+            return original_get_context("spawn")
+        return original_get_context(method)
+
+    multiprocessing.get_context = mock_get_context
+
+    # Mock ctypes LoadLibrary to prevent Windows errors
+    original_load_library = ctypes.cdll.LoadLibrary
+
+    def mock_load_library(name):
+        if name is None or not isinstance(name, str):
+            return MagicMock()
+        try:
+            return original_load_library(name)
+        except (OSError, TypeError):
+            return MagicMock()
+
+    ctypes.cdll.LoadLibrary = mock_load_library
+
+# Mock external dependencies before importing module
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flashblade"] = MagicMock()
+sys.modules["urllib3"] = MagicMock()
+sys.modules["distro"] = MagicMock()
+# Mock Unix-specific modules for Windows compatibility
+sys.modules["grp"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["syslog"] = MagicMock()
+# Mock termios with required constants
+mock_termios = MagicMock()
+mock_termios.TCSAFLUSH = 2
+sys.modules["termios"] = mock_termios
+sys.modules["tty"] = MagicMock()
+
+# Mock ansible_collections module structure
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.purefb"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.common"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.version"] = (
+    MagicMock()
+)
+
+from plugins.modules.purefb_local_group import (
+    main,
+    _get_group,
+    _get_current_user_members,
+    _reconcile_user_members,
+)
+
+
+def _base_params(**overrides):
+    params = {
+        "name": "developers",
+        "state": "present",
+        "local_directory_service": "myserver_local",
+        "new_name": None,
+        "gid": None,
+        "email": None,
+        "local_users": None,
+        "force": False,
+        "context": "",
+    }
+    params.update(overrides)
+    return params
+
+
+class TestPurefbLocalGroup:
+    """Test cases for purefb_local_group module"""
+
+    # ---------------- helper-function unit tests ----------------
+
+    def test_get_group_returns_first_item(self):
+        """_get_group returns the first hit"""
+        module = Mock()
+        module.params = {"name": "developers", "context": ""}
+
+        existing = Mock()
+        existing.name = "developers"
+        response = Mock()
+        response.status_code = 200
+        response.items = [existing]
+
+        blade = Mock()
+        blade.get_directory_services_local_groups.return_value = response
+
+        assert _get_group(module, blade, "myserver_local") is existing
+        blade.get_directory_services_local_groups.assert_called_once_with(
+            names=["developers"],
+            filter="local_directory_service.name='myserver_local'",
+        )
+
+    def test_get_group_returns_none_when_empty(self):
+        """_get_group returns None when items is empty"""
+        module = Mock()
+        module.params = {"name": "developers", "context": ""}
+
+        response = Mock()
+        response.status_code = 200
+        response.items = []
+        blade = Mock()
+        blade.get_directory_services_local_groups.return_value = response
+
+        assert _get_group(module, blade, "myserver_local") is None
+
+    def test_get_current_user_members_extracts_names(self):
+        """_get_current_user_members returns the set of user-member names"""
+        module = Mock()
+        module.params = {"name": "developers", "context": ""}
+        module.fail_json = Mock(side_effect=SystemExit)
+
+        edge_a = Mock()
+        edge_a.member = Mock()
+        edge_a.member.name = "alice"
+        edge_b = Mock()
+        edge_b.member = Mock()
+        edge_b.member.name = "bob"
+
+        response = Mock()
+        response.status_code = 200
+        response.items = [edge_a, edge_b]
+        blade = Mock()
+        blade.get_directory_services_local_groups_members.return_value = response
+
+        result = _get_current_user_members(
+            module, blade, "myserver_local", group_name="developers"
+        )
+        assert result == {"alice", "bob"}
+        blade.get_directory_services_local_groups_members.assert_called_once_with(
+            group_names=["developers"],
+            filter="local_directory_service.name='myserver_local'",
+            member_types=["User"],
+        )
+
+    # ---------------- _reconcile_user_members tests ----------------
+
+    def test_reconcile_adds_missing_members(self):
+        """_reconcile_user_members POSTs users not yet in the group"""
+        module = Mock()
+        module.params = {
+            "name": "developers",
+            "local_users": ["alice", "bob"],
+            "context": "",
+        }
+        module.check_mode = False
+        module.fail_json = Mock(side_effect=SystemExit)
+
+        current_response = Mock()
+        current_response.status_code = 200
+        current_response.items = []
+        post_response = Mock()
+        post_response.status_code = 200
+
+        blade = Mock()
+        blade.get_directory_services_local_groups_members.return_value = (
+            current_response
+        )
+        blade.post_directory_services_local_groups_members.return_value = post_response
+
+        changed = _reconcile_user_members(module, blade, "myserver_local", "developers")
+        assert changed is True
+        blade.post_directory_services_local_groups_members.assert_called_once()
+        blade.delete_directory_services_local_groups_members.assert_not_called()
+
+    def test_reconcile_removes_extras(self):
+        """_reconcile_user_members DELETEs users no longer in the desired list"""
+        module = Mock()
+        module.params = {
+            "name": "developers",
+            "local_users": ["alice"],
+            "context": "",
+        }
+        module.check_mode = False
+        module.fail_json = Mock(side_effect=SystemExit)
+
+        alice = Mock()
+        alice.member = Mock()
+        alice.member.name = "alice"
+        bob = Mock()
+        bob.member = Mock()
+        bob.member.name = "bob"
+
+        current_response = Mock()
+        current_response.status_code = 200
+        current_response.items = [alice, bob]
+        delete_response = Mock()
+        delete_response.status_code = 200
+
+        blade = Mock()
+        blade.get_directory_services_local_groups_members.return_value = (
+            current_response
+        )
+        blade.delete_directory_services_local_groups_members.return_value = (
+            delete_response
+        )
+
+        changed = _reconcile_user_members(module, blade, "myserver_local", "developers")
+        assert changed is True
+        blade.delete_directory_services_local_groups_members.assert_called_once()
+        blade.post_directory_services_local_groups_members.assert_not_called()
+
+    def test_reconcile_idempotent_when_match(self):
+        """_reconcile_user_members is a no-op when current == desired"""
+        module = Mock()
+        module.params = {
+            "name": "developers",
+            "local_users": ["alice"],
+            "context": "",
+        }
+        module.check_mode = False
+        module.fail_json = Mock(side_effect=SystemExit)
+
+        alice = Mock()
+        alice.member = Mock()
+        alice.member.name = "alice"
+        current_response = Mock()
+        current_response.status_code = 200
+        current_response.items = [alice]
+
+        blade = Mock()
+        blade.get_directory_services_local_groups_members.return_value = (
+            current_response
+        )
+
+        changed = _reconcile_user_members(module, blade, "myserver_local", "developers")
+        assert changed is False
+        blade.post_directory_services_local_groups_members.assert_not_called()
+        blade.delete_directory_services_local_groups_members.assert_not_called()
+
+    def test_reconcile_check_mode_skips_writes(self):
+        """_reconcile_user_members reports changed but skips writes in check mode"""
+        module = Mock()
+        module.params = {
+            "name": "developers",
+            "local_users": ["alice"],
+            "context": "",
+        }
+        module.check_mode = True
+        module.fail_json = Mock(side_effect=SystemExit)
+
+        current_response = Mock()
+        current_response.status_code = 200
+        current_response.items = []
+
+        blade = Mock()
+        blade.get_directory_services_local_groups_members.return_value = (
+            current_response
+        )
+
+        changed = _reconcile_user_members(module, blade, "myserver_local", "developers")
+        assert changed is True
+        blade.post_directory_services_local_groups_members.assert_not_called()
+        blade.delete_directory_services_local_groups_members.assert_not_called()
+
+    # ---------------- main() flows ----------------
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.LocalGroupPost")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_creates_group(
+        self, mock_ansible_module, mock_get_system, mock_group_post, mock_loose_version
+    ):
+        """Test creating a new local group with gid and email"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(gid=6001, email="devs@example.com")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        # Group doesn't exist
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        created = Mock()
+        created.name = "developers"
+        created.gid = 6001
+        created.sid = "S-1-5-21-1"
+        created.built_in = False
+
+        post_response = Mock()
+        post_response.status_code = 200
+        post_response.items = [created]
+        blade.post_directory_services_local_groups.return_value = post_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.post_directory_services_local_groups.assert_called_once()
+        call_kwargs = blade.post_directory_services_local_groups.call_args[1]
+        assert call_kwargs["names"] == ["developers"]
+        assert call_kwargs["local_directory_service_names"] == ["myserver_local"]
+        mock_group_post.assert_called_once_with(email="devs@example.com", gid=6001)
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_create_check_mode_skips_post(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test create reports changed but skips POST in check mode"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params()
+        module.check_mode = True
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.post_directory_services_local_groups.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_create_fails_on_api_error(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test create surfaces API error via fail_json"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params()
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        post_response = Mock()
+        post_response.status_code = 400
+        post_response.errors = []
+        blade.post_directory_services_local_groups.return_value = post_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "Failed to create local group" in module.fail_json.call_args[1]["msg"]
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.LocalGroupPatch")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_updates_email_and_gid(
+        self, mock_ansible_module, mock_get_system, mock_group_patch, mock_loose_version
+    ):
+        """Test updating an existing group's email and gid"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(gid=7001, email="new@example.com")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "developers"
+        existing.built_in = False
+        existing.gid = 6001
+        existing.email = "old@example.com"
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        blade.patch_directory_services_local_groups.return_value = patch_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.patch_directory_services_local_groups.assert_called_once()
+        mock_group_patch.assert_called_once_with(email="new@example.com", gid=7001)
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_update_idempotent_when_no_changes(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test update is a no-op when nothing changed"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(gid=6001, email="devs@example.com")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "developers"
+        existing.built_in = False
+        existing.gid = 6001
+        existing.email = "devs@example.com"
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.patch_directory_services_local_groups.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is False
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.LocalGroupPatch")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_renames_group(
+        self, mock_ansible_module, mock_get_system, mock_group_patch, mock_loose_version
+    ):
+        """Test renaming an existing group via new_name"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(new_name="devs")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "developers"
+        existing.built_in = False
+        existing.gid = 6001
+        existing.email = None
+
+        # First call is _get_group (existing found); second is the rename-clash lookup
+        clash_response = Mock()
+        clash_response.status_code = 200
+        clash_response.items = []
+        first_response = Mock()
+        first_response.status_code = 200
+        first_response.items = [existing]
+        blade.get_directory_services_local_groups.side_effect = [
+            first_response,
+            clash_response,
+        ]
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        blade.patch_directory_services_local_groups.return_value = patch_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_group_patch.assert_called_once_with(name="devs")
+        blade.patch_directory_services_local_groups.assert_called_once()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_rename_fails_when_target_exists(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test rename fails cleanly when the target name already exists"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(new_name="devs")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "developers"
+        existing.built_in = False
+        existing.gid = 6001
+        existing.email = None
+
+        clash = Mock()
+        clash.name = "devs"
+        clash_response = Mock()
+        clash_response.status_code = 200
+        clash_response.items = [clash]
+        first_response = Mock()
+        first_response.status_code = 200
+        first_response.items = [existing]
+        blade.get_directory_services_local_groups.side_effect = [
+            first_response,
+            clash_response,
+        ]
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        msg = module.fail_json.call_args[1]["msg"]
+        assert "target name already exists" in msg
+        blade.patch_directory_services_local_groups.assert_not_called()
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_refuses_to_rename_builtin(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test rename is refused on built-in groups"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(name="Domain Users", new_name="dev-users")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "Domain Users"
+        existing.built_in = True
+        existing.gid = 100
+        existing.email = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "built-in" in module.fail_json.call_args[1]["msg"]
+        blade.patch_directory_services_local_groups.assert_not_called()
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_deletes_empty_group(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test deleting a group that has no members"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "developers"
+        existing.built_in = False
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        members_response = Mock()
+        members_response.status_code = 200
+        members_response.items = []
+        blade.get_directory_services_local_groups_members.return_value = (
+            members_response
+        )
+
+        delete_response = Mock()
+        delete_response.status_code = 200
+        blade.delete_directory_services_local_groups.return_value = delete_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.delete_directory_services_local_groups.assert_called_once_with(
+            names=["developers"],
+            local_directory_service_names=["myserver_local"],
+        )
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_delete_refuses_when_members_and_no_force(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test delete refuses when the group has members and force=false"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "developers"
+        existing.built_in = False
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        edge = Mock()
+        edge.member = Mock()
+        edge.member.name = "alice"
+        edge.member.resource_type = "local-users"
+        members_response = Mock()
+        members_response.status_code = 200
+        members_response.items = [edge]
+        blade.get_directory_services_local_groups_members.return_value = (
+            members_response
+        )
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "force: true" in module.fail_json.call_args[1]["msg"]
+        blade.delete_directory_services_local_groups.assert_not_called()
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_delete_force_clears_members_then_deletes(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test delete with force=true clears members first, then deletes the group"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent", force=True)
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "developers"
+        existing.built_in = False
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        edge = Mock()
+        edge.member = Mock()
+        edge.member.name = "alice"
+        edge.member.resource_type = "local-users"
+        members_response = Mock()
+        members_response.status_code = 200
+        members_response.items = [edge]
+        blade.get_directory_services_local_groups_members.return_value = (
+            members_response
+        )
+
+        ok = Mock()
+        ok.status_code = 200
+        blade.delete_directory_services_local_groups_members.return_value = ok
+        blade.delete_directory_services_local_groups.return_value = ok
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.delete_directory_services_local_groups_members.assert_called_once()
+        blade.delete_directory_services_local_groups.assert_called_once()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_refuses_to_delete_builtin(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test delete is refused on built-in groups"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent", name="Domain Users")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "Domain Users"
+        existing.built_in = True
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "built-in" in module.fail_json.call_args[1]["msg"]
+        blade.delete_directory_services_local_groups.assert_not_called()
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_delete_nonexistent_is_noop(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test state=absent on a nonexistent group reports changed=False"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent", name="ghost")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.delete_directory_services_local_groups.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is False
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.LocalGroupPost")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_create_with_local_users_reconciles(
+        self, mock_ansible_module, mock_get_system, mock_group_post, mock_loose_version
+    ):
+        """Test create-with-members POSTs the group then reconciles members"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(local_users=["alice", "bob"])
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_groups.return_value = get_response
+
+        created = Mock()
+        created.name = "developers"
+        created.gid = 6001
+        created.sid = "S-1"
+        created.built_in = False
+
+        post_response = Mock()
+        post_response.status_code = 200
+        post_response.items = [created]
+        blade.post_directory_services_local_groups.return_value = post_response
+
+        members_current = Mock()
+        members_current.status_code = 200
+        members_current.items = []
+        blade.get_directory_services_local_groups_members.return_value = members_current
+
+        post_members = Mock()
+        post_members.status_code = 200
+        blade.post_directory_services_local_groups_members.return_value = post_members
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.post_directory_services_local_groups.assert_called_once()
+        blade.post_directory_services_local_groups_members.assert_called_once()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", True)
+    def test_main_fails_on_unsupported_api_version(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test failure when the array API version is older than MIN_REQUIRED_API_VERSION"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=True)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params()
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.17", "2.18", "2.19"]
+        mock_get_system.return_value = blade
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "REST version not supported" in module.fail_json.call_args[1]["msg"]
+
+    @patch("plugins.modules.purefb_local_group.LooseVersion")
+    @patch("plugins.modules.purefb_local_group.get_system")
+    @patch("plugins.modules.purefb_local_group.AnsibleModule")
+    @patch("plugins.modules.purefb_local_group.HAS_PYPURECLIENT", False)
+    def test_main_fails_without_sdk(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test failure when py-pure-client SDK is not installed"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params()
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "py-pure-client" in module.fail_json.call_args[1]["msg"]

--- a/tests/unit/plugins/modules/test_purefb_local_user.py
+++ b/tests/unit/plugins/modules/test_purefb_local_user.py
@@ -1,0 +1,1136 @@
+# Copyright: (c) 2026, Pure Storage Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefb_local_user module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+import multiprocessing
+import ctypes
+from unittest.mock import Mock, patch, MagicMock
+
+# Mock multiprocessing context for Windows
+if sys.platform == "win32":
+    original_get_context = multiprocessing.get_context
+
+    def mock_get_context(method=None):
+        if method == "fork":
+            return original_get_context("spawn")
+        return original_get_context(method)
+
+    multiprocessing.get_context = mock_get_context
+
+    # Mock ctypes LoadLibrary to prevent Windows errors
+    original_load_library = ctypes.cdll.LoadLibrary
+
+    def mock_load_library(name):
+        if name is None or not isinstance(name, str):
+            return MagicMock()
+        try:
+            return original_load_library(name)
+        except (OSError, TypeError):
+            return MagicMock()
+
+    ctypes.cdll.LoadLibrary = mock_load_library
+
+# Mock external dependencies before importing module
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flashblade"] = MagicMock()
+sys.modules["urllib3"] = MagicMock()
+sys.modules["distro"] = MagicMock()
+# Mock Unix-specific modules for Windows compatibility
+sys.modules["grp"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["syslog"] = MagicMock()
+# Mock termios with required constants
+mock_termios = MagicMock()
+mock_termios.TCSAFLUSH = 2
+sys.modules["termios"] = mock_termios
+sys.modules["tty"] = MagicMock()
+
+# Mock ansible_collections module structure
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.purefb"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.common"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.version"] = (
+    MagicMock()
+)
+
+from plugins.modules.purefb_local_user import (
+    main,
+    _get_user,
+    _get_current_groups,
+    _reconcile_memberships,
+)
+
+
+def _base_params(**overrides):
+    params = {
+        "name": "alice",
+        "state": "present",
+        "local_directory_service": "myserver_local",
+        "new_name": None,
+        "uid": None,
+        "email": None,
+        "enabled": True,
+        "password": "s3cret!",
+        "force_password_reset": False,
+        "primary_group": None,
+        "groups": None,
+        "context": "",
+    }
+    params.update(overrides)
+    return params
+
+
+class TestPurefbLocalUser:
+    """Test cases for purefb_local_user module"""
+
+    # ---------------- helper-function unit tests ----------------
+
+    def test_get_user_returns_first_item(self):
+        """_get_user returns the first hit"""
+        module = Mock()
+        module.params = {"name": "alice", "context": ""}
+
+        existing = Mock()
+        existing.name = "alice"
+        response = Mock()
+        response.status_code = 200
+        response.items = [existing]
+
+        blade = Mock()
+        blade.get_directory_services_local_users.return_value = response
+
+        assert _get_user(module, blade, "myserver_local") is existing
+        blade.get_directory_services_local_users.assert_called_once_with(
+            names=["alice"],
+            filter="local_directory_service.name='myserver_local'",
+        )
+
+    def test_get_user_returns_none_when_empty(self):
+        """_get_user returns None when items is empty"""
+        module = Mock()
+        module.params = {"name": "alice", "context": ""}
+
+        response = Mock()
+        response.status_code = 200
+        response.items = []
+        blade = Mock()
+        blade.get_directory_services_local_users.return_value = response
+
+        assert _get_user(module, blade, "myserver_local") is None
+
+    def test_get_current_groups_extracts_names(self):
+        """_get_current_groups returns the set of the user's current group names"""
+        module = Mock()
+        module.params = {"name": "alice", "context": ""}
+        module.fail_json = Mock(side_effect=SystemExit)
+
+        edge_a = Mock()
+        edge_a.group = Mock()
+        edge_a.group.name = "developers"
+        edge_b = Mock()
+        edge_b.group = Mock()
+        edge_b.group.name = "infra"
+
+        response = Mock()
+        response.status_code = 200
+        response.items = [edge_a, edge_b]
+        blade = Mock()
+        blade.get_directory_services_local_users_members.return_value = response
+
+        result = _get_current_groups(module, blade, "myserver_local")
+        assert result == {"developers", "infra"}
+
+    # ---------------- _reconcile_memberships tests ----------------
+
+    def test_reconcile_adds_missing(self):
+        """_reconcile_memberships POSTs groups the user isn't in yet"""
+        module = Mock()
+        module.params = {
+            "name": "alice",
+            "groups": ["developers", "infra"],
+            "context": "",
+        }
+        module.check_mode = False
+        module.fail_json = Mock(side_effect=SystemExit)
+
+        current_response = Mock()
+        current_response.status_code = 200
+        current_response.items = []
+        post_response = Mock()
+        post_response.status_code = 200
+
+        blade = Mock()
+        blade.get_directory_services_local_users_members.return_value = current_response
+        blade.post_directory_services_local_users_members.return_value = post_response
+
+        changed = _reconcile_memberships(module, blade, "myserver_local", "alice")
+        assert changed is True
+        blade.post_directory_services_local_users_members.assert_called_once()
+        blade.delete_directory_services_local_users_members.assert_not_called()
+
+    def test_reconcile_removes_extras(self):
+        """_reconcile_memberships DELETEs groups the user should no longer be in"""
+        module = Mock()
+        module.params = {
+            "name": "alice",
+            "groups": ["developers"],
+            "context": "",
+        }
+        module.check_mode = False
+        module.fail_json = Mock(side_effect=SystemExit)
+
+        keep = Mock()
+        keep.group = Mock()
+        keep.group.name = "developers"
+        drop = Mock()
+        drop.group = Mock()
+        drop.group.name = "infra"
+
+        current_response = Mock()
+        current_response.status_code = 200
+        current_response.items = [keep, drop]
+        delete_response = Mock()
+        delete_response.status_code = 200
+
+        blade = Mock()
+        blade.get_directory_services_local_users_members.return_value = current_response
+        blade.delete_directory_services_local_users_members.return_value = (
+            delete_response
+        )
+
+        changed = _reconcile_memberships(module, blade, "myserver_local", "alice")
+        assert changed is True
+        blade.delete_directory_services_local_users_members.assert_called_once_with(
+            member_names=["alice"],
+            group_names=["infra"],
+            local_directory_service_names=["myserver_local"],
+        )
+        blade.post_directory_services_local_users_members.assert_not_called()
+
+    def test_reconcile_excludes_primary_group(self):
+        """_reconcile_memberships never touches the primary-group edge"""
+        module = Mock()
+        module.params = {
+            "name": "alice",
+            "groups": ["developers"],
+            "context": "",
+        }
+        module.check_mode = False
+        module.fail_json = Mock(side_effect=SystemExit)
+
+        primary_edge = Mock()
+        primary_edge.group = Mock()
+        primary_edge.group.name = "alice"  # primary
+        dev_edge = Mock()
+        dev_edge.group = Mock()
+        dev_edge.group.name = "developers"
+
+        current_response = Mock()
+        current_response.status_code = 200
+        current_response.items = [primary_edge, dev_edge]
+
+        blade = Mock()
+        blade.get_directory_services_local_users_members.return_value = current_response
+
+        changed = _reconcile_memberships(
+            module, blade, "myserver_local", desired_primary_group="alice"
+        )
+        assert changed is False
+        blade.post_directory_services_local_users_members.assert_not_called()
+        blade.delete_directory_services_local_users_members.assert_not_called()
+
+    def test_reconcile_check_mode_skips_writes(self):
+        """_reconcile_memberships reports changed but skips writes in check mode"""
+        module = Mock()
+        module.params = {
+            "name": "alice",
+            "groups": ["developers"],
+            "context": "",
+        }
+        module.check_mode = True
+        module.fail_json = Mock(side_effect=SystemExit)
+
+        current_response = Mock()
+        current_response.status_code = 200
+        current_response.items = []
+
+        blade = Mock()
+        blade.get_directory_services_local_users_members.return_value = current_response
+
+        changed = _reconcile_memberships(module, blade, "myserver_local", "alice")
+        assert changed is True
+        blade.post_directory_services_local_users_members.assert_not_called()
+        blade.delete_directory_services_local_users_members.assert_not_called()
+
+    # ---------------- main() flows ----------------
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.ReferenceWritable")
+    @patch("plugins.modules.purefb_local_user.LocalUserPost")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_creates_user(
+        self,
+        mock_ansible_module,
+        mock_get_system,
+        mock_user_post,
+        mock_reference_writable,
+        mock_loose_version,
+    ):
+        """Test creating a new local user with primary_group and uid"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(
+            uid=5001,
+            email="alice@example.com",
+            primary_group="alice",
+        )
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_users.return_value = get_response
+
+        created = Mock()
+        created.name = "alice"
+        created.uid = 5001
+        created.sid = "S-1-5-21-2"
+        created.enabled = True
+        created.primary_group = Mock()
+        created.primary_group.name = "alice"
+
+        post_response = Mock()
+        post_response.status_code = 200
+        post_response.items = [created]
+        blade.post_directory_services_local_users.return_value = post_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.post_directory_services_local_users.assert_called_once()
+        call_kwargs = blade.post_directory_services_local_users.call_args[1]
+        assert call_kwargs["names"] == ["alice"]
+        assert call_kwargs["local_directory_service_names"] == ["myserver_local"]
+        mock_user_post.assert_called_once()
+        mock_reference_writable.assert_any_call(name="alice")
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_create_fails_without_password_when_enabled(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test create fails when enabled=true and no password is provided"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(password=None, enabled=True)
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_users.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "password" in module.fail_json.call_args[1]["msg"]
+        blade.post_directory_services_local_users.assert_not_called()
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_create_check_mode_skips_post(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test create reports changed but skips POST in check mode"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(primary_group="alice")
+        module.check_mode = True
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_users.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.post_directory_services_local_users.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_create_fails_on_api_error(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test create surfaces API error via fail_json"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(primary_group="alice")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_users.return_value = get_response
+
+        post_response = Mock()
+        post_response.status_code = 400
+        post_response.errors = []
+        blade.post_directory_services_local_users.return_value = post_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "Failed to create local user" in module.fail_json.call_args[1]["msg"]
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.LocalUserPatch")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_updates_email(
+        self, mock_ansible_module, mock_get_system, mock_user_patch, mock_loose_version
+    ):
+        """Test updating email on an existing user"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(
+            email="new@example.com", password=None, primary_group="alice"
+        )
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "alice"
+        existing.built_in = False
+        existing.email = "old@example.com"
+        existing.enabled = True
+        existing.uid = 5001
+        existing.primary_group = Mock()
+        existing.primary_group.name = "alice"
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_users.return_value = get_response
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        blade.patch_directory_services_local_users.return_value = patch_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.patch_directory_services_local_users.assert_called_once()
+        mock_user_patch.assert_called_once_with(email="new@example.com")
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_update_idempotent_when_no_changes(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test update is a no-op when nothing changed"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(
+            uid=5001,
+            email="alice@example.com",
+            password=None,
+        )
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "alice"
+        existing.built_in = False
+        existing.email = "alice@example.com"
+        existing.enabled = True
+        existing.uid = 5001
+        existing.primary_group = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_users.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.patch_directory_services_local_users.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is False
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.LocalUserPatch")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_renames_user(
+        self, mock_ansible_module, mock_get_system, mock_user_patch, mock_loose_version
+    ):
+        """Test renaming an existing user via new_name"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(new_name="alice2", password=None)
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "alice"
+        existing.built_in = False
+        existing.email = None
+        existing.enabled = True
+        existing.uid = 5001
+        existing.primary_group = None
+
+        # First call from _get_user, second from the rename-clash lookup
+        first_response = Mock()
+        first_response.status_code = 200
+        first_response.items = [existing]
+        clash_response = Mock()
+        clash_response.status_code = 200
+        clash_response.items = []
+        blade.get_directory_services_local_users.side_effect = [
+            first_response,
+            clash_response,
+        ]
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        blade.patch_directory_services_local_users.return_value = patch_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_user_patch.assert_called_once_with(name="alice2")
+        blade.patch_directory_services_local_users.assert_called_once()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_rename_fails_when_target_exists(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test rename fails cleanly when the target name already exists"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(new_name="alice2", password=None)
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "alice"
+        existing.built_in = False
+        existing.email = None
+        existing.enabled = True
+        existing.uid = 5001
+        existing.primary_group = None
+
+        clash = Mock()
+        clash.name = "alice2"
+        first_response = Mock()
+        first_response.status_code = 200
+        first_response.items = [existing]
+        clash_response = Mock()
+        clash_response.status_code = 200
+        clash_response.items = [clash]
+        blade.get_directory_services_local_users.side_effect = [
+            first_response,
+            clash_response,
+        ]
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "target name already exists" in module.fail_json.call_args[1]["msg"]
+        blade.patch_directory_services_local_users.assert_not_called()
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_refuses_to_rename_builtin(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test rename is refused on built-in users"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(
+            name="Administrator", new_name="root", password=None
+        )
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "Administrator"
+        existing.built_in = True
+        existing.email = None
+        existing.enabled = True
+        existing.uid = 500
+        existing.primary_group = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_users.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "built-in" in module.fail_json.call_args[1]["msg"]
+        blade.patch_directory_services_local_users.assert_not_called()
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.LocalUserPatch")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_disables_user(
+        self, mock_ansible_module, mock_get_system, mock_user_patch, mock_loose_version
+    ):
+        """Test disabling an existing user"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(enabled=False, password=None)
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "alice"
+        existing.built_in = False
+        existing.email = None
+        existing.enabled = True
+        existing.uid = 5001
+        existing.primary_group = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_users.return_value = get_response
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        blade.patch_directory_services_local_users.return_value = patch_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.patch_directory_services_local_users.assert_called_once()
+        mock_user_patch.assert_called_once_with(enabled=False)
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_reenable_requires_password(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test re-enabling a disabled user requires a password"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(enabled=True, password=None)
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "alice"
+        existing.built_in = False
+        existing.email = None
+        existing.enabled = False
+        existing.uid = 5001
+        existing.primary_group = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_users.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "password" in module.fail_json.call_args[1]["msg"]
+        blade.patch_directory_services_local_users.assert_not_called()
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.LocalUserPatch")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_force_password_reset_patches_password(
+        self, mock_ansible_module, mock_get_system, mock_user_patch, mock_loose_version
+    ):
+        """Test force_password_reset=true includes the password in the PATCH body"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(force_password_reset=True, password="brandnew!")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "alice"
+        existing.built_in = False
+        existing.email = None
+        existing.enabled = True
+        existing.uid = 5001
+        existing.primary_group = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_users.return_value = get_response
+
+        patch_response = Mock()
+        patch_response.status_code = 200
+        blade.patch_directory_services_local_users.return_value = patch_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.patch_directory_services_local_users.assert_called_once()
+        mock_user_patch.assert_called_once_with(password="brandnew!")
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_force_password_reset_requires_password(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test force_password_reset=true without a password fails cleanly"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(force_password_reset=True, password=None)
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "alice"
+        existing.built_in = False
+        existing.email = None
+        existing.enabled = True
+        existing.uid = 5001
+        existing.primary_group = None
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_users.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "force_password_reset" in module.fail_json.call_args[1]["msg"]
+        blade.patch_directory_services_local_users.assert_not_called()
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_deletes_user(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test deleting an existing user"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent", password=None)
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "alice"
+        existing.built_in = False
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_users.return_value = get_response
+
+        delete_response = Mock()
+        delete_response.status_code = 200
+        blade.delete_directory_services_local_users.return_value = delete_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.delete_directory_services_local_users.assert_called_once_with(
+            names=["alice"],
+            local_directory_service_names=["myserver_local"],
+        )
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_delete_check_mode_skips_call(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test delete reports changed but skips DELETE in check mode"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent", password=None)
+        module.check_mode = True
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "alice"
+        existing.built_in = False
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_users.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.delete_directory_services_local_users.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_refuses_to_delete_builtin(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test delete is refused on built-in users"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(
+            state="absent", name="Administrator", password=None
+        )
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        existing = Mock()
+        existing.name = "Administrator"
+        existing.built_in = True
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = [existing]
+        blade.get_directory_services_local_users.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "built-in" in module.fail_json.call_args[1]["msg"]
+        blade.delete_directory_services_local_users.assert_not_called()
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_delete_nonexistent_is_noop(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test state=absent on a nonexistent user reports changed=False"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(state="absent", name="ghost", password=None)
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_users.return_value = get_response
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.delete_directory_services_local_users.assert_not_called()
+        assert module.exit_json.call_args[1]["changed"] is False
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.LocalUserPost")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_create_with_groups_reconciles(
+        self, mock_ansible_module, mock_get_system, mock_user_post, mock_loose_version
+    ):
+        """Test create-with-groups POSTs the user then reconciles memberships"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(
+            primary_group="alice",
+            groups=["developers", "infra"],
+        )
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.24"]
+        mock_get_system.return_value = blade
+
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.items = []
+        blade.get_directory_services_local_users.return_value = get_response
+
+        created = Mock()
+        created.name = "alice"
+        created.uid = 5001
+        created.sid = "S-1"
+        created.enabled = True
+        created.primary_group = Mock()
+        created.primary_group.name = "alice"
+
+        post_response = Mock()
+        post_response.status_code = 200
+        post_response.items = [created]
+        blade.post_directory_services_local_users.return_value = post_response
+
+        members_current = Mock()
+        members_current.status_code = 200
+        members_current.items = []
+        blade.get_directory_services_local_users_members.return_value = members_current
+
+        post_members = Mock()
+        post_members.status_code = 200
+        blade.post_directory_services_local_users_members.return_value = post_members
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        blade.post_directory_services_local_users.assert_called_once()
+        blade.post_directory_services_local_users_members.assert_called_once()
+        assert module.exit_json.call_args[1]["changed"] is True
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", True)
+    def test_main_fails_on_unsupported_api_version(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test failure when the array API version is older than MIN_REQUIRED_API_VERSION"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=True)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params(primary_group="alice")
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        blade = Mock()
+        blade.get_versions.return_value.items = ["2.17", "2.18", "2.19"]
+        mock_get_system.return_value = blade
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "REST version not supported" in module.fail_json.call_args[1]["msg"]
+
+    @patch("plugins.modules.purefb_local_user.LooseVersion")
+    @patch("plugins.modules.purefb_local_user.get_system")
+    @patch("plugins.modules.purefb_local_user.AnsibleModule")
+    @patch("plugins.modules.purefb_local_user.HAS_PYPURECLIENT", False)
+    def test_main_fails_without_sdk(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
+        """Test failure when py-pure-client SDK is not installed"""
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
+        module = Mock()
+        module.exit_json = Mock(side_effect=SystemExit)
+        module.fail_json = Mock(side_effect=SystemExit)
+        module.params = _base_params()
+        module.check_mode = False
+        mock_ansible_module.return_value = module
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        module.fail_json.assert_called_once()
+        assert "py-pure-client" in module.fail_json.call_args[1]["msg"]


### PR DESCRIPTION
##### SUMMARY
Adds three new modules for the FlashBlade Local Directory Service (LDS) feature:
- **`purefb_local_ds`** — manages the LDS container itself via `/local-directory-services`. Supports create, update, and delete, with delete preflights that refuse LDSes still attached to a server. Attach/detach to a server remains with `purefb_server` (not duplicated here).
- **`purefb_local_user`** — manages local users (SMB/NFS identities) inside an LDS via `/local-directory-services/users`. Supports create, update (rename, uid, email, enable/disable), group-membership reconcile (add/remove), and delete. Password is required on create with `enabled: true` and on disable→enable transitions; otherwise ignored unless `force_password_reset: true`. Built-in users are refused on delete and identity-mutating updates.
- **`purefb_local_group`** — manages local groups inside an LDS via `/local-directory-services/groups`. Supports create, update (rename, gid), member reconcile, and delete. Deleting a non-empty group requires `force: true`; built-in groups are refused.


##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME
purefb_local_ds, purefb_local_user, purefb_local_group
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

