### PR TITLE
Add purefb_mgmt_auth_policy module for management authentication policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ All modules are idempotent with the exception of modules that change or set pass
 - purefb_local_group - manage local groups in a FlashBlade Local Directory Service
 - purefb_local_user - manage local users in a FlashBlade Local Directory Service
 - purefb_messages - list FlashBlade alert messages
+- purefb_mgmt_auth_policy - manage FlashBlade management authentication policies and their members
 - purefb_mgmt_policy - manage FlashBlade management access policies and their rules
 - purefb_mgmt_role - manage FlashBlade custom management roles, permissions, and policy attachment
 - purefb_network - manage the network settings for a FlashBlade

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -34,6 +34,7 @@ action_groups:
    - purefb_local_group
    - purefb_local_user
    - purefb_messages
+   - purefb_mgmt_auth_policy
    - purefb_mgmt_policy
    - purefb_mgmt_role
    - purefb_network

--- a/plugins/modules/purefb_mgmt_auth_policy.py
+++ b/plugins/modules/purefb_mgmt_auth_policy.py
@@ -1,0 +1,740 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2026, Simon Dodsley (simon@everpuredata.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: purefb_mgmt_auth_policy
+version_added: '1.28.0'
+short_description: Manage FlashBlade Management Authentication Policies and their members
+description:
+- Create, update, or delete a FlashBlade Management Authentication Policy.
+- Management authentication policies define which authentication factors
+  (password, SSH key/certificate/FIDO2 key) admins must or may present.
+  Currently the SSH interface is supported.
+- Reconcile the declarative list of members (admins and/or the array) the
+  policy is attached to.
+- A member can be attached to at most one management authentication policy
+  at a time; the array does not move members between policies implicitly.
+author:
+- Pure Storage Ansible Team (@avk) <pure-ansible-team@everpuredata.com>
+notes:
+- Changing an attached policy affects subsequent SSH logins for its members
+  (existing sessions are unaffected). Misconfiguration can lock
+  administrators out of SSH access - review changes with check mode first.
+- The built-in C(default-authentication-policy) is not protected by the
+  array; it can be modified or deleted like any other policy and is the
+  fallback for members without an explicit policy. Change it with care.
+- Moving a member between policies (I(replace_existing=true)) is not
+  atomic on the array; the member is briefly unattached during the move,
+  and if the move fails midway it is left without a policy until the
+  task is re-run.
+- Deletion safety is enforced by this module, not by the array - the
+  array will delete a policy that still has members attached, silently
+  detaching them.
+- When I(state=absent), configuration and membership options are ignored.
+options:
+  name:
+    description:
+    - Name of the management authentication policy.
+    type: str
+    required: true
+  state:
+    description:
+    - Whether the policy should exist.
+    default: present
+    choices: [ absent, present ]
+    type: str
+  enabled:
+    description:
+    - Whether the policy is active. Members of a disabled policy fall back
+      to the platform default authentication behavior.
+    - Omit to leave unchanged on an existing policy; defaults to C(true)
+      when creating a new policy.
+    type: bool
+  ssh_allowed_methods:
+    description:
+    - Authentication methods where any one method is sufficient for SSH
+      login.
+    - Mutually exclusive with I(ssh_required_methods) - a policy uses one
+      mode or the other. Supplying this list switches the policy to allowed
+      mode and clears any required methods.
+    - C(default) permits whatever methods the FlashBlade supports for the
+      interface and version.
+    - Omit to leave the current SSH configuration unchanged.
+    type: list
+    elements: str
+    choices: [ password, key, default ]
+  ssh_required_methods:
+    description:
+    - Authentication methods that must all be presented for SSH login.
+    - Mutually exclusive with I(ssh_allowed_methods) - a policy uses one
+      mode or the other. Supplying this list switches the policy to required
+      mode and clears any allowed methods.
+    - C(default) is not valid as a required method.
+    - Omit to leave the current SSH configuration unchanged.
+    type: list
+    elements: str
+    choices: [ password, key ]
+  members:
+    description:
+    - Declarative list of members the policy is attached to.
+    - Setting the list will attach missing members and detach any member
+      not listed here.
+    - Omit (or set to C(null)) to leave current membership untouched.
+    - Provide an empty list to detach every member from the policy.
+    - Attaching a member that is attached to a different policy fails
+      unless I(replace_existing=true).
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+        - Name of the member (a local admin name, or the FlashBlade array
+          name for I(type=array)).
+        type: str
+        required: true
+      type:
+        description:
+        - Type of the member.
+        type: str
+        required: true
+        choices: [ admin, array ]
+  replace_existing:
+    description:
+    - Whether a member currently attached to a different management
+      authentication policy may be detached from it and attached to this
+      policy (detach-then-attach).
+    - When C(false) a conflicting assignment fails the task, naming the
+      conflicting policy.
+    type: bool
+    default: false
+  context:
+    description:
+    - Name of fleet member on which to perform the operation.
+    - This requires the array receiving the request is a member of a fleet
+      and the context name to be a member of the same fleet.
+    type: str
+    default: ""
+extends_documentation_fragment:
+- everpure.flashblade.everpure.fb
+"""
+
+EXAMPLES = r"""
+- name: Create a policy allowing password or key
+  everpure.flashblade.purefb_mgmt_auth_policy:
+    name: ssh-flexible
+    ssh_allowed_methods:
+      - password
+      - key
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Create an MFA policy (password AND key) attached to two admins
+  everpure.flashblade.purefb_mgmt_auth_policy:
+    name: ssh-mfa
+    ssh_required_methods:
+      - password
+      - key
+    members:
+      - name: alice
+        type: admin
+      - name: bob
+        type: admin
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Switch an existing policy from required to allowed mode
+  everpure.flashblade.purefb_mgmt_auth_policy:
+    name: ssh-mfa
+    ssh_allowed_methods:
+      - key
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Attach the array baseline, moving it from its current policy
+  everpure.flashblade.purefb_mgmt_auth_policy:
+    name: ssh-mfa
+    members:
+      - name: my-flashblade
+        type: array
+    replace_existing: true
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Detach every member from a policy
+  everpure.flashblade.purefb_mgmt_auth_policy:
+    name: ssh-mfa
+    members: []
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+
+- name: Delete a policy (fails while members are attached)
+  everpure.flashblade.purefb_mgmt_auth_policy:
+    name: ssh-mfa
+    state: absent
+    fb_url: 10.10.10.2
+    api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
+"""
+
+RETURN = r"""
+"""
+
+HAS_PYPURECLIENT = True
+try:
+    from pypureclient.flashblade import (
+        ManagementAuthenticationPolicy,
+        ManagementAuthenticationPolicyConfig,
+        ManagementAuthenticationPolicyPost,
+    )
+except ImportError:
+    HAS_PYPURECLIENT = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import (
+    get_system,
+    purefb_argument_spec,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
+    get_error_message,
+    get_rest_api_version,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
+
+MIN_MGMT_AUTH_API_VERSION = "2.22"
+CONTEXT_API_VERSION = "2.17"
+# Product design exempts these users from authentication-policy membership;
+# the module must never attach or detach them.
+PROTECTED_ADMINS = frozenset(["ir", "pureeng"])
+# Module member type -> REST member_types value.
+MEMBER_TYPE_API = {"admin": "admins", "array": "arrays"}
+MEMBER_TYPE_MODULE = {"admins": "admin", "arrays": "array"}
+
+
+def _ctx(module, api_version):
+    """Return the context_names kwargs dict when the array supports it."""
+    if not module.params.get("context"):
+        return {}
+    if LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version):
+        return {"context_names": [module.params["context"]]}
+    return {}
+
+
+def _validate_methods(module):
+    """Reject invalid SSH method lists before any API call.
+
+    The argument spec enforces per-list choices ('default' is only a choice
+    of ssh_allowed_methods) and mutual exclusion; this adds the rules the
+    spec cannot express.
+    """
+    for param in ("ssh_allowed_methods", "ssh_required_methods"):
+        methods = module.params[param]
+        if methods is None:
+            continue
+        if not methods:
+            module.fail_json(
+                msg=(
+                    "{0} must contain at least one method. To switch modes "
+                    "supply the new mode's non-empty list; the other mode is "
+                    "cleared automatically."
+                ).format(param)
+            )
+        if len(set(methods)) != len(methods):
+            module.fail_json(msg="Duplicate method in {0}".format(param))
+
+
+def _validate_members(module):
+    members = module.params["members"]
+    if not members:
+        return
+    seen = set()
+    arrays = 0
+    for member in members:
+        key = (member["type"], member["name"])
+        if key in seen:
+            module.fail_json(
+                msg="Duplicate member (name={0}, type={1}) in members".format(
+                    member["name"], member["type"]
+                )
+            )
+        seen.add(key)
+        if member["type"] == "array":
+            arrays += 1
+        elif member["name"].lower() in PROTECTED_ADMINS:
+            module.fail_json(
+                msg=(
+                    "Admin {0} is exempt from management authentication "
+                    "policies and cannot be attached."
+                ).format(member["name"])
+            )
+    if arrays > 1:
+        module.fail_json(msg="members may contain at most one array member")
+
+
+def _get_policy(module, blade, ctx_kwargs):
+    """The policy object, or None when it does not exist.
+
+    A missing policy is itself a 400 here ("Management authentication
+    policy does not exist."), so only that error reads as None - any
+    other failure fails the task rather than masquerading as "absent"
+    (which would let state=absent report ok on a transient error).
+    """
+    res = blade.get_management_authentication_policies(
+        names=[module.params["name"]], **ctx_kwargs
+    )
+    if res.status_code == 200:
+        items = list(res.items)
+        return items[0] if items else None
+    error = get_error_message(res)
+    if error and "policy does not exist" in str(error).lower():
+        return None
+    module.fail_json(
+        msg="Failed to read policy {0}. Error: {1}".format(module.params["name"], error)
+    )
+
+
+def _get_members(module, blade, ctx_kwargs):
+    """Current membership as a set of (module_type, member_name)."""
+    res = blade.get_management_authentication_policies_members(
+        policy_names=[module.params["name"]], **ctx_kwargs
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg="Failed to list members of policy {0}. Error: {1}".format(
+                module.params["name"], get_error_message(res)
+            )
+        )
+    return set(
+        (MEMBER_TYPE_MODULE[item.member.resource_type], item.member.name)
+        for item in res.items
+    )
+
+
+def _get_member_current_policy(module, blade, member_type, member_name, ctx_kwargs):
+    """Name of the policy the member is attached to, or None.
+
+    A failed lookup fails the task - treating it as "no conflict" would
+    silently skip the preflight this call exists for.
+    """
+    res = blade.get_management_authentication_policies_members(
+        member_names=[member_name],
+        member_types=[MEMBER_TYPE_API[member_type]],
+        **ctx_kwargs,
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg=("Failed to look up current policy for {0} {1}. Error: {2}").format(
+                member_type, member_name, get_error_message(res)
+            )
+        )
+    items = list(res.items)
+    return items[0].policy.name if items else None
+
+
+def _desired_ssh_config(module):
+    """Desired (mode, methods-set) from the params, or None when omitted."""
+    if module.params["ssh_allowed_methods"] is not None:
+        return ("allowed", set(module.params["ssh_allowed_methods"]))
+    if module.params["ssh_required_methods"] is not None:
+        return ("required", set(module.params["ssh_required_methods"]))
+    return None
+
+
+def _current_ssh_config(existing):
+    """Current (mode, methods-set) of a policy.
+
+    The array reports the inactive mode as an empty list, so exactly one
+    mode is non-empty on a configured policy.
+    """
+    allowed = set(getattr(existing.ssh, "allowed_methods", None) or [])
+    required = set(getattr(existing.ssh, "required_methods", None) or [])
+    if required:
+        return ("required", required)
+    return ("allowed", allowed)
+
+
+def _build_ssh_config(mode, methods):
+    """SSH config body with the opposite mode explicitly cleared.
+
+    PATCH replaces the ssh object wholesale (verified on REST 2.28: an
+    omitted list is cleared too), but the explicit empty list keeps the
+    request self-describing and version-safe.
+    """
+    if mode == "allowed":
+        return ManagementAuthenticationPolicyConfig(
+            allowed_methods=sorted(methods), required_methods=[]
+        )
+    return ManagementAuthenticationPolicyConfig(
+        allowed_methods=[], required_methods=sorted(methods)
+    )
+
+
+def _warn_if_live(module, blade, ctx_kwargs):
+    """Warn when changing authentication requirements on an attached policy."""
+    if _get_members(module, blade, ctx_kwargs):
+        module.warn(
+            "Policy {0} is attached to one or more members. The new "
+            "authentication requirements apply to their subsequent SSH "
+            "logins.".format(module.params["name"])
+        )
+
+
+def _validate_members_exist(module, blade, members, ctx_kwargs):
+    """Fail when a desired member does not exist.
+
+    The members relationship GET returns 200 with no items for a
+    nonexistent member - indistinguishable from "no policy attached" - so
+    existence has to come from the admins/arrays endpoints. Runs in check
+    mode too, so check mode catches a mistyped member name.
+    """
+    for member_type, member_name in sorted(members):
+        if member_type == "admin":
+            res = blade.get_admins(names=[member_name], **ctx_kwargs)
+            if res.status_code != 200:
+                # A missing admin is a 400 "Admin does not exist." here;
+                # passing the array's error through keeps a transient
+                # failure from masquerading as a missing member.
+                module.fail_json(
+                    msg=(
+                        "Member admin {0} does not exist or could not be "
+                        "verified. Error: {1}"
+                    ).format(member_name, get_error_message(res))
+                )
+        else:
+            res = blade.get_arrays(**ctx_kwargs)
+            if res.status_code != 200:
+                module.fail_json(
+                    msg=(
+                        "Member array {0} could not be verified. " "Error: {1}"
+                    ).format(member_name, get_error_message(res))
+                )
+            if not any(array.name == member_name for array in res.items):
+                module.fail_json(
+                    msg="Member array {0} does not exist.".format(member_name)
+                )
+
+
+def _find_member_conflicts(module, blade, members, ctx_kwargs):
+    """Read-only lookup of members attached to a different policy.
+
+    Returns a list of (member_type, member_name, other_policy_name).
+    """
+    conflicts = []
+    for member_type, member_name in sorted(members):
+        other = _get_member_current_policy(
+            module, blade, member_type, member_name, ctx_kwargs
+        )
+        if other and other != module.params["name"]:
+            conflicts.append((member_type, member_name, other))
+    return conflicts
+
+
+def _fail_on_member_conflicts(module, conflicts):
+    if conflicts and not module.params["replace_existing"]:
+        module.fail_json(
+            msg=(
+                "Cannot attach members already attached to another "
+                "management authentication policy: {0}. Set "
+                "replace_existing=true to move them."
+            ).format(
+                ", ".join(
+                    "{0} {1} (attached to {2})".format(mtype, mname, other)
+                    for mtype, mname, other in conflicts
+                )
+            )
+        )
+
+
+def reconcile_members(module, blade, ctx_kwargs):
+    """Diff desired members against actual; attach/detach to converge.
+
+    Returns True if any change was made (or would be made in check-mode).
+    """
+    desired_list = module.params["members"]
+    if desired_list is None:
+        return False
+
+    desired = set((member["type"], member["name"]) for member in desired_list)
+    current = _get_members(module, blade, ctx_kwargs)
+
+    to_add = desired - current
+    to_remove = set(
+        member
+        for member in current - desired
+        # Never detach exempt users, even if the array reports them.
+        if not (member[0] == "admin" and member[1].lower() in PROTECTED_ADMINS)
+    )
+
+    # Existence and conflict checks run in check mode too so that check
+    # mode fails exactly where a real run would.
+    _validate_members_exist(module, blade, to_add, ctx_kwargs)
+    conflicts = _find_member_conflicts(module, blade, to_add, ctx_kwargs)
+    _fail_on_member_conflicts(module, conflicts)
+
+    if not to_add and not to_remove:
+        return False
+
+    if module.check_mode:
+        return True
+
+    for member_type, member_name in sorted(to_remove):
+        res = blade.delete_management_authentication_policies_members(
+            policy_names=[module.params["name"]],
+            member_names=[member_name],
+            member_types=[MEMBER_TYPE_API[member_type]],
+            **ctx_kwargs,
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg=("Failed to detach {0} {1} from policy {2}. Error: {3}").format(
+                    member_type,
+                    member_name,
+                    module.params["name"],
+                    get_error_message(res),
+                )
+            )
+
+    # Attach each member as a tight detach->attach pair. The array offers
+    # no atomic move (member-side POSTs refuse an attached member just
+    # like the policy-side one), so a moved member is unavoidably
+    # unattached between its own two calls - but only between those two,
+    # and a failure orphans at most that one member.
+    conflict_by_member = {(mtype, mname): other for mtype, mname, other in conflicts}
+    for member_type, member_name in sorted(to_add):
+        other = conflict_by_member.get((member_type, member_name))
+        if other:
+            res = blade.delete_management_authentication_policies_members(
+                policy_names=[other],
+                member_names=[member_name],
+                member_types=[MEMBER_TYPE_API[member_type]],
+                **ctx_kwargs,
+            )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg=("Failed to detach {0} {1} from policy {2}. Error: {3}").format(
+                        member_type, member_name, other, get_error_message(res)
+                    )
+                )
+        res = blade.post_management_authentication_policies_members(
+            policy_names=[module.params["name"]],
+            member_names=[member_name],
+            member_types=[MEMBER_TYPE_API[member_type]],
+            **ctx_kwargs,
+        )
+        if res.status_code != 200:
+            orphan_note = ""
+            if other:
+                orphan_note = (
+                    " {0} {1} is currently attached to no policy; re-run "
+                    "the task to attach it."
+                ).format(member_type, member_name)
+            module.fail_json(
+                msg=("Failed to attach {0} {1} to policy {2}. Error: {3}{4}").format(
+                    member_type,
+                    member_name,
+                    module.params["name"],
+                    get_error_message(res),
+                    orphan_note,
+                )
+            )
+
+    return True
+
+
+def delete_policy(module, blade, ctx_kwargs):
+    """Guarded delete.
+
+    The array allows deleting an attached policy, so the members check
+    must live client-side.
+    """
+    if _get_members(module, blade, ctx_kwargs):
+        module.fail_json(
+            msg=(
+                "Authentication policy {0} has attached members. Detach "
+                "members first (members: [] with state: present)."
+            ).format(module.params["name"])
+        )
+    if not module.check_mode:
+        res = blade.delete_management_authentication_policies(
+            names=[module.params["name"]], **ctx_kwargs
+        )
+        if res.status_code != 200:
+            module.fail_json(
+                msg="Failed to delete policy {0}. Error: {1}".format(
+                    module.params["name"], get_error_message(res)
+                )
+            )
+    module.exit_json(changed=True)
+
+
+def create_policy(module, blade, ctx_kwargs):
+    desired_ssh = _desired_ssh_config(module)
+    if desired_ssh is None:
+        module.fail_json(
+            msg=(
+                "Creating a policy requires ssh_allowed_methods or "
+                "ssh_required_methods."
+            )
+        )
+    enabled = module.params["enabled"]
+    if enabled is None:
+        enabled = True
+
+    # Preflight member existence and conflicts before the policy POST so
+    # a refused attach cannot leave a half-created policy behind, and so
+    # check mode fails exactly where a real run would.
+    if module.params["members"]:
+        desired_members = set(
+            (member["type"], member["name"]) for member in module.params["members"]
+        )
+        _validate_members_exist(module, blade, desired_members, ctx_kwargs)
+        _fail_on_member_conflicts(
+            module,
+            _find_member_conflicts(module, blade, desired_members, ctx_kwargs),
+        )
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    res = blade.post_management_authentication_policies(
+        names=[module.params["name"]],
+        policy=ManagementAuthenticationPolicyPost(
+            enabled=enabled,
+            ssh=_build_ssh_config(*desired_ssh),
+        ),
+        **ctx_kwargs,
+    )
+    if res.status_code != 200:
+        module.fail_json(
+            msg="Failed to create policy {0}. Error: {1}".format(
+                module.params["name"], get_error_message(res)
+            )
+        )
+    reconcile_members(module, blade, ctx_kwargs)
+    module.exit_json(changed=True)
+
+
+def update_policy(module, blade, ctx_kwargs, existing):
+    changed = False
+
+    patch_kwargs = {}
+    if (
+        module.params["enabled"] is not None
+        and module.params["enabled"] != existing.enabled
+    ):
+        patch_kwargs["enabled"] = module.params["enabled"]
+
+    desired_ssh = _desired_ssh_config(module)
+    if desired_ssh is not None and desired_ssh != _current_ssh_config(existing):
+        patch_kwargs["ssh"] = _build_ssh_config(*desired_ssh)
+
+    if patch_kwargs:
+        changed = True
+        _warn_if_live(module, blade, ctx_kwargs)
+        if not module.check_mode:
+            res = blade.patch_management_authentication_policies(
+                names=[module.params["name"]],
+                policy=ManagementAuthenticationPolicy(**patch_kwargs),
+                **ctx_kwargs,
+            )
+            if res.status_code != 200:
+                module.fail_json(
+                    msg="Failed to update policy {0}. Error: {1}".format(
+                        module.params["name"], get_error_message(res)
+                    )
+                )
+
+    if reconcile_members(module, blade, ctx_kwargs):
+        changed = True
+
+    module.exit_json(changed=changed)
+
+
+def main():
+    argument_spec = purefb_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(type="str", required=True),
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            enabled=dict(type="bool"),
+            ssh_allowed_methods=dict(
+                type="list",
+                elements="str",
+                choices=["password", "key", "default"],
+            ),
+            ssh_required_methods=dict(
+                type="list",
+                elements="str",
+                choices=["password", "key"],
+            ),
+            members=dict(
+                type="list",
+                elements="dict",
+                options=dict(
+                    name=dict(type="str", required=True),
+                    type=dict(
+                        type="str",
+                        required=True,
+                        choices=["admin", "array"],
+                    ),
+                ),
+            ),
+            replace_existing=dict(type="bool", default=False),
+            context=dict(type="str", default=""),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec,
+        mutually_exclusive=[["ssh_allowed_methods", "ssh_required_methods"]],
+        supports_check_mode=True,
+    )
+
+    if not HAS_PYPURECLIENT:
+        module.fail_json(msg="py-pure-client sdk is required for this module")
+
+    state = module.params["state"]
+    if state == "present":
+        _validate_methods(module)
+        _validate_members(module)
+
+    blade = get_system(module)
+    api_version = get_rest_api_version(blade)
+    if LooseVersion(MIN_MGMT_AUTH_API_VERSION) > LooseVersion(api_version):
+        module.fail_json(
+            msg=(
+                "FlashBlade REST version {0} does not support management "
+                "authentication policies (requires {1}+)."
+            ).format(api_version, MIN_MGMT_AUTH_API_VERSION)
+        )
+    ctx_kwargs = _ctx(module, api_version)
+
+    existing = _get_policy(module, blade, ctx_kwargs)
+
+    if state == "absent":
+        if existing is None:
+            module.exit_json(changed=False)
+        delete_policy(module, blade, ctx_kwargs)
+    else:
+        if existing is None:
+            create_policy(module, blade, ctx_kwargs)
+        else:
+            update_policy(module, blade, ctx_kwargs, existing)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -40,6 +40,8 @@ plugins/modules/purefb_local_group.py import-2.7
 plugins/modules/purefb_local_user.py compile-2.7
 plugins/modules/purefb_local_user.py import-2.7
 plugins/modules/purefb_messages.py import-2.7
+plugins/modules/purefb_mgmt_auth_policy.py compile-2.7
+plugins/modules/purefb_mgmt_auth_policy.py import-2.7
 plugins/modules/purefb_mgmt_policy.py compile-2.7
 plugins/modules/purefb_mgmt_policy.py import-2.7
 plugins/modules/purefb_mgmt_role.py compile-2.7

--- a/tests/unit/plugins/modules/test_purefb_mgmt_auth_policy.py
+++ b/tests/unit/plugins/modules/test_purefb_mgmt_auth_policy.py
@@ -1,0 +1,1115 @@
+# Copyright: (c) 2026, Pure Storage Ansible Team <pure-ansible-team@everpuredata.com>
+# GNU General Public License v3.0+ (see COPYING.GPLv3 or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for purefb_mgmt_auth_policy module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+import multiprocessing
+import ctypes
+from unittest.mock import Mock, patch, MagicMock
+
+# Mock multiprocessing context for Windows
+if sys.platform == "win32":
+    original_get_context = multiprocessing.get_context
+
+    def mock_get_context(method=None):
+        if method == "fork":
+            return original_get_context("spawn")
+        return original_get_context(method)
+
+    multiprocessing.get_context = mock_get_context
+
+    # Mock ctypes LoadLibrary to prevent Windows errors
+    original_load_library = ctypes.cdll.LoadLibrary
+
+    def mock_load_library(name):
+        if name is None or not isinstance(name, str):
+            return MagicMock()
+        try:
+            return original_load_library(name)
+        except (OSError, TypeError):
+            return MagicMock()
+
+    ctypes.cdll.LoadLibrary = mock_load_library
+
+# Mock external dependencies before importing module
+sys.modules["pypureclient"] = MagicMock()
+sys.modules["pypureclient.flashblade"] = MagicMock()
+sys.modules["urllib3"] = MagicMock()
+sys.modules["distro"] = MagicMock()
+# Mock Unix-specific modules for Windows compatibility
+sys.modules["grp"] = MagicMock()
+sys.modules["fcntl"] = MagicMock()
+sys.modules["pwd"] = MagicMock()
+sys.modules["syslog"] = MagicMock()
+# Mock termios with required constants
+mock_termios = MagicMock()
+mock_termios.TCSAFLUSH = 2
+sys.modules["termios"] = mock_termios
+sys.modules["tty"] = MagicMock()
+
+# Mock ansible_collections module structure
+sys.modules["ansible_collections"] = MagicMock()
+sys.modules["ansible_collections.everpure"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins"] = MagicMock()
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.purefb"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.common"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.version"] = (
+    MagicMock()
+)
+
+from plugins.modules.purefb_mgmt_auth_policy import (
+    main,
+    _ctx,
+    _validate_methods,
+    _validate_members,
+    _get_policy,
+    _get_members,
+    _get_member_current_policy,
+    _desired_ssh_config,
+    _current_ssh_config,
+    _build_ssh_config,
+    _warn_if_live,
+    reconcile_members,
+    create_policy,
+    update_policy,
+    delete_policy,
+)
+
+
+def _base_params(**overrides):
+    """Return a full params dict with sane defaults, patched by overrides."""
+    params = {
+        "name": "ssh-mfa",
+        "state": "present",
+        "enabled": None,
+        "ssh_allowed_methods": None,
+        "ssh_required_methods": None,
+        "members": None,
+        "replace_existing": False,
+        "context": "",
+    }
+    params.update(overrides)
+    return params
+
+
+def _mock_module(**overrides):
+    """Mock AnsibleModule with SystemExit-raising exit/fail hooks."""
+    module = Mock()
+    module.params = _base_params(**overrides)
+    module.check_mode = False
+    module.fail_json = Mock(side_effect=SystemExit)
+    module.exit_json = Mock(side_effect=SystemExit)
+    module.warn = Mock()
+    return module
+
+
+def _mock_policy(enabled=True, allowed=None, required=None):
+    """Mock policy object as returned by the get endpoint (inactive mode
+    reads back as an empty list, mirroring the array)."""
+    policy = Mock()
+    policy.name = "ssh-mfa"
+    policy.enabled = enabled
+    policy.ssh = Mock()
+    policy.ssh.allowed_methods = allowed if allowed is not None else []
+    policy.ssh.required_methods = required if required is not None else []
+    return policy
+
+
+def _member_item(policy_name, resource_type, member_name):
+    item = Mock()
+    item.policy = Mock()
+    item.policy.name = policy_name
+    item.member = Mock()
+    item.member.resource_type = resource_type
+    item.member.name = member_name
+    return item
+
+
+def _ok_response(items=None):
+    response = Mock()
+    response.status_code = 200
+    response.items = items if items is not None else []
+    return response
+
+
+def _members_side_effect(policy_members, member_policy_map):
+    """Route the shared members GET: policy_names filter returns the
+    policy's members; member_names filter answers conflict lookups."""
+
+    def _side_effect(**kwargs):
+        if "policy_names" in kwargs:
+            return _ok_response(list(policy_members))
+        name = kwargs["member_names"][0]
+        rtype = kwargs["member_types"][0]
+        attached_to = member_policy_map.get(name)
+        if attached_to is None:
+            return _ok_response([])
+        return _ok_response([_member_item(attached_to, rtype, name)])
+
+    return _side_effect
+
+
+def _members_exist(mock_blade, arrays=("fb1",)):
+    """Stub the existence lookups: every admin exists, plus the given arrays."""
+    mock_blade.get_admins.return_value = _ok_response([Mock()])
+    items = []
+    for name in arrays:
+        array = Mock()
+        array.name = name
+        items.append(array)
+    mock_blade.get_arrays.return_value = _ok_response(items)
+
+
+class TestPurefbMgmtAuthPolicy:
+    """Test cases for purefb_mgmt_auth_policy module"""
+
+    # ==== _ctx ====
+
+    def test_ctx_empty_when_context_unset(self):
+        """Test _ctx returns {} when context is empty string"""
+        mock_module = Mock()
+        mock_module.params = {"context": ""}
+        assert _ctx(mock_module, "2.22") == {}
+
+    @patch("plugins.modules.purefb_mgmt_auth_policy.LooseVersion")
+    def test_ctx_returns_context_names_when_supported(self, mock_loose_version):
+        """Test _ctx returns context_names dict when API supports it"""
+        mock_loose_version.return_value.__le__ = Mock(return_value=True)
+        mock_module = Mock()
+        mock_module.params = {"context": "fleet1"}
+        assert _ctx(mock_module, "2.22") == {"context_names": ["fleet1"]}
+
+    @patch("plugins.modules.purefb_mgmt_auth_policy.LooseVersion")
+    def test_ctx_silently_drops_context_when_api_too_old(self, mock_loose_version):
+        """Test _ctx returns {} when API is too old, even if context is set"""
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
+        mock_module = Mock()
+        mock_module.params = {"context": "fleet1"}
+        assert _ctx(mock_module, "2.16") == {}
+
+    # ==== method validation ====
+    # Choice enforcement ('default' only in allowed) and the allowed/required
+    # mutual exclusion live in the argument spec, so helpers only cover the
+    # rules the spec cannot express.
+
+    def test_validate_methods_noop_when_omitted(self):
+        """Test _validate_methods passes when neither method list is supplied"""
+        mock_module = _mock_module()
+        _validate_methods(mock_module)
+        mock_module.fail_json.assert_not_called()
+
+    def test_validate_methods_rejects_empty_list(self):
+        """Test _validate_methods rejects an explicit empty method list"""
+        mock_module = _mock_module(ssh_allowed_methods=[])
+        try:
+            _validate_methods(mock_module)
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "at least one method" in mock_module.fail_json.call_args[1]["msg"]
+
+    def test_validate_methods_rejects_duplicates(self):
+        """Test _validate_methods rejects a duplicated method"""
+        mock_module = _mock_module(ssh_required_methods=["password", "password"])
+        try:
+            _validate_methods(mock_module)
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "Duplicate method" in mock_module.fail_json.call_args[1]["msg"]
+
+    def test_validate_methods_accepts_valid_list(self):
+        """Test _validate_methods passes a valid required list"""
+        mock_module = _mock_module(ssh_required_methods=["password", "key"])
+        _validate_methods(mock_module)
+        mock_module.fail_json.assert_not_called()
+
+    # ==== member validation ====
+
+    def test_validate_members_noop_when_omitted(self):
+        """Test _validate_members passes when members is omitted"""
+        mock_module = _mock_module()
+        _validate_members(mock_module)
+        mock_module.fail_json.assert_not_called()
+
+    def test_validate_members_rejects_duplicates(self):
+        """Test _validate_members rejects duplicate (name, type) entries"""
+        mock_module = _mock_module(
+            members=[
+                {"name": "alice", "type": "admin"},
+                {"name": "alice", "type": "admin"},
+            ]
+        )
+        try:
+            _validate_members(mock_module)
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "Duplicate member" in mock_module.fail_json.call_args[1]["msg"]
+
+    def test_validate_members_rejects_multiple_arrays(self):
+        """Test _validate_members rejects more than one array member"""
+        mock_module = _mock_module(
+            members=[
+                {"name": "fb1", "type": "array"},
+                {"name": "fb2", "type": "array"},
+            ]
+        )
+        try:
+            _validate_members(mock_module)
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "at most one array" in mock_module.fail_json.call_args[1]["msg"]
+
+    def test_validate_members_rejects_protected_admins(self):
+        """Test _validate_members rejects exempt users, case-insensitively"""
+        for name in ("ir", "Pureeng"):
+            mock_module = _mock_module(members=[{"name": name, "type": "admin"}])
+            try:
+                _validate_members(mock_module)
+            except SystemExit:
+                pass
+            mock_module.fail_json.assert_called_once()
+            assert "exempt" in mock_module.fail_json.call_args[1]["msg"]
+
+    def test_validate_members_accepts_valid_list(self):
+        """Test _validate_members passes admins plus one array"""
+        mock_module = _mock_module(
+            members=[
+                {"name": "alice", "type": "admin"},
+                {"name": "fb1", "type": "array"},
+            ]
+        )
+        _validate_members(mock_module)
+        mock_module.fail_json.assert_not_called()
+
+    # ==== ssh config helpers ====
+
+    def test_desired_ssh_config_allowed_mode(self):
+        """Test _desired_ssh_config maps the allowed list"""
+        mock_module = _mock_module(ssh_allowed_methods=["password", "key"])
+        assert _desired_ssh_config(mock_module) == ("allowed", {"password", "key"})
+
+    def test_desired_ssh_config_required_mode(self):
+        """Test _desired_ssh_config maps the required list"""
+        mock_module = _mock_module(ssh_required_methods=["key"])
+        assert _desired_ssh_config(mock_module) == ("required", {"key"})
+
+    def test_desired_ssh_config_none_when_omitted(self):
+        """Test _desired_ssh_config returns None when neither list is set"""
+        mock_module = _mock_module()
+        assert _desired_ssh_config(mock_module) is None
+
+    def test_current_ssh_config_reads_modes(self):
+        """Test _current_ssh_config picks the non-empty mode"""
+        assert _current_ssh_config(_mock_policy(required=["key", "password"])) == (
+            "required",
+            {"key", "password"},
+        )
+        assert _current_ssh_config(_mock_policy(allowed=["default"])) == (
+            "allowed",
+            {"default"},
+        )
+
+    @patch(
+        "plugins.modules.purefb_mgmt_auth_policy.ManagementAuthenticationPolicyConfig"
+    )
+    def test_build_ssh_config_clears_opposite_mode(self, mock_config_cls):
+        """Test _build_ssh_config always sends the opposite list as []"""
+        _build_ssh_config("allowed", {"key", "password"})
+        assert mock_config_cls.call_args[1] == {
+            "allowed_methods": ["key", "password"],
+            "required_methods": [],
+        }
+        _build_ssh_config("required", {"password"})
+        assert mock_config_cls.call_args[1] == {
+            "allowed_methods": [],
+            "required_methods": ["password"],
+        }
+
+    # ==== read helpers ====
+
+    def test_get_policy_found(self):
+        """Test _get_policy returns the policy object"""
+        mock_module = _mock_module()
+        policy = _mock_policy()
+        mock_blade = Mock()
+        mock_blade.get_management_authentication_policies.return_value = _ok_response(
+            [policy]
+        )
+        assert _get_policy(mock_module, mock_blade, {}) is policy
+
+    @patch("plugins.modules.purefb_mgmt_auth_policy.get_error_message")
+    def test_get_policy_not_found(self, mock_gem):
+        """Test _get_policy returns None only for the not-found 400"""
+        mock_gem.return_value = "Management authentication policy does not exist."
+        mock_module = _mock_module()
+        error = Mock()
+        error.status_code = 400
+        mock_blade = Mock()
+        mock_blade.get_management_authentication_policies.return_value = error
+        assert _get_policy(mock_module, mock_blade, {}) is None
+        mock_module.fail_json.assert_not_called()
+
+    @patch("plugins.modules.purefb_mgmt_auth_policy.get_error_message")
+    def test_get_policy_transient_error_fails(self, mock_gem):
+        """Test _get_policy fails loudly on errors other than not-found,
+        instead of letting state=absent report ok on a transient error"""
+        mock_gem.return_value = "Internal server error"
+        mock_module = _mock_module()
+        error = Mock()
+        error.status_code = 500
+        mock_blade = Mock()
+        mock_blade.get_management_authentication_policies.return_value = error
+        try:
+            _get_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "Failed to read policy" in msg
+        assert "Internal server error" in msg
+
+    def test_get_members_maps_resource_types(self):
+        """Test _get_members maps API resource types to module member types"""
+        mock_module = _mock_module()
+        mock_blade = Mock()
+        mock_blade.get_management_authentication_policies_members.return_value = (
+            _ok_response(
+                [
+                    _member_item("ssh-mfa", "admins", "alice"),
+                    _member_item("ssh-mfa", "arrays", "fb1"),
+                ]
+            )
+        )
+        assert _get_members(mock_module, mock_blade, {}) == {
+            ("admin", "alice"),
+            ("array", "fb1"),
+        }
+
+    def test_get_members_error_fails(self):
+        """Test _get_members fails the task when the list call errors"""
+        mock_module = _mock_module()
+        error = Mock()
+        error.status_code = 400
+        error.errors = []
+        mock_blade = Mock()
+        mock_blade.get_management_authentication_policies_members.return_value = error
+        try:
+            _get_members(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+
+    def test_get_member_current_policy(self):
+        """Test _get_member_current_policy returns the attached policy or None"""
+        mock_module = _mock_module()
+        mock_blade = Mock()
+        mock_blade.get_management_authentication_policies_members.return_value = (
+            _ok_response([_member_item("other-policy", "admins", "alice")])
+        )
+        assert (
+            _get_member_current_policy(mock_module, mock_blade, "admin", "alice", {})
+            == "other-policy"
+        )
+        mock_blade.get_management_authentication_policies_members.return_value = (
+            _ok_response([])
+        )
+        assert (
+            _get_member_current_policy(mock_module, mock_blade, "admin", "bob", {})
+            is None
+        )
+
+    def test_get_member_current_policy_lookup_error_fails(self):
+        """Test a failed conflict lookup fails loudly instead of reading as
+        'no conflict'"""
+        mock_module = _mock_module()
+        mock_blade = Mock()
+        error = Mock()
+        error.status_code = 400
+        error.errors = []
+        mock_blade.get_management_authentication_policies_members.return_value = error
+        try:
+            _get_member_current_policy(mock_module, mock_blade, "admin", "alice", {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert (
+            "Failed to look up current policy"
+            in mock_module.fail_json.call_args[1]["msg"]
+        )
+
+    # ==== reconcile_members ====
+
+    def test_reconcile_members_noop_when_omitted(self):
+        """Test reconcile_members does nothing when members is omitted"""
+        mock_module = _mock_module()
+        mock_blade = Mock()
+        assert reconcile_members(mock_module, mock_blade, {}) is False
+        mock_blade.get_management_authentication_policies_members.assert_not_called()
+
+    def test_reconcile_members_converged(self):
+        """Test reconcile_members reports no change when membership matches"""
+        mock_module = _mock_module(members=[{"name": "alice", "type": "admin"}])
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect(
+                [_member_item("ssh-mfa", "admins", "alice")], {"alice": "ssh-mfa"}
+            )
+        )
+        assert reconcile_members(mock_module, mock_blade, {}) is False
+        mock_blade.post_management_authentication_policies_members.assert_not_called()
+        mock_blade.delete_management_authentication_policies_members.assert_not_called()
+
+    def test_reconcile_members_attaches_missing_member(self):
+        """Test reconcile_members POSTs a missing member with mapped type"""
+        mock_module = _mock_module(members=[{"name": "fb1", "type": "array"}])
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        mock_blade.post_management_authentication_policies_members.return_value = (
+            _ok_response()
+        )
+        assert reconcile_members(mock_module, mock_blade, {}) is True
+        call = mock_blade.post_management_authentication_policies_members.call_args[1]
+        assert call["policy_names"] == ["ssh-mfa"]
+        assert call["member_names"] == ["fb1"]
+        assert call["member_types"] == ["arrays"]
+
+    def test_reconcile_members_empty_list_detaches_all(self):
+        """Test members: [] detaches every current member"""
+        mock_module = _mock_module(members=[])
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect(
+                [
+                    _member_item("ssh-mfa", "admins", "alice"),
+                    _member_item("ssh-mfa", "arrays", "fb1"),
+                ],
+                {},
+            )
+        )
+        mock_blade.delete_management_authentication_policies_members.return_value = (
+            _ok_response()
+        )
+        assert reconcile_members(mock_module, mock_blade, {}) is True
+        assert (
+            mock_blade.delete_management_authentication_policies_members.call_count == 2
+        )
+
+    def test_reconcile_members_never_detaches_protected_admins(self):
+        """Test exempt users are not detached even when absent from the list"""
+        mock_module = _mock_module(members=[])
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([_member_item("ssh-mfa", "admins", "ir")], {})
+        )
+        assert reconcile_members(mock_module, mock_blade, {}) is False
+        mock_blade.delete_management_authentication_policies_members.assert_not_called()
+
+    def test_reconcile_members_conflict_fails_by_default(self):
+        """Test attaching a member owned by another policy fails with its name"""
+        mock_module = _mock_module(members=[{"name": "alice", "type": "admin"}])
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {"alice": "other-policy"})
+        )
+        try:
+            reconcile_members(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "other-policy" in msg
+        assert "replace_existing" in msg
+        mock_blade.post_management_authentication_policies_members.assert_not_called()
+
+    def test_reconcile_members_replace_existing_moves_member(self):
+        """Test replace_existing detaches from the old policy, then attaches"""
+        mock_module = _mock_module(
+            members=[{"name": "alice", "type": "admin"}], replace_existing=True
+        )
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {"alice": "other-policy"})
+        )
+        mock_blade.delete_management_authentication_policies_members.return_value = (
+            _ok_response()
+        )
+        mock_blade.post_management_authentication_policies_members.return_value = (
+            _ok_response()
+        )
+        assert reconcile_members(mock_module, mock_blade, {}) is True
+        detach = mock_blade.delete_management_authentication_policies_members.call_args[
+            1
+        ]
+        assert detach["policy_names"] == ["other-policy"]
+        assert detach["member_names"] == ["alice"]
+        mock_blade.post_management_authentication_policies_members.assert_called_once()
+        # A successful move is silent; the orphan note appears only in the
+        # failure message when the attach half fails.
+        mock_module.warn.assert_not_called()
+
+    def test_reconcile_members_move_failure_orphans_only_one_member(self):
+        """Test per-member pairing: a failed move stops before touching the
+        next mover and names the orphaned member"""
+        mock_module = _mock_module(
+            members=[
+                {"name": "alice", "type": "admin"},
+                {"name": "bob", "type": "admin"},
+            ],
+            replace_existing=True,
+        )
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {"alice": "other-policy", "bob": "other-policy"})
+        )
+        mock_blade.delete_management_authentication_policies_members.return_value = (
+            _ok_response()
+        )
+        error = Mock()
+        error.status_code = 400
+        error.errors = []
+        mock_blade.post_management_authentication_policies_members.return_value = error
+        try:
+            reconcile_members(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        # alice (sorted first) was detached and her attach failed; bob's
+        # move must not have started.
+        assert (
+            mock_blade.delete_management_authentication_policies_members.call_count == 1
+        )
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "alice" in msg
+        assert "attached to no policy" in msg
+
+    def test_reconcile_members_check_mode_reports_without_writes(self):
+        """Test check mode reports a pending change without POST/DELETE"""
+        mock_module = _mock_module(members=[{"name": "alice", "type": "admin"}])
+        mock_module.check_mode = True
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        assert reconcile_members(mock_module, mock_blade, {}) is True
+        mock_blade.post_management_authentication_policies_members.assert_not_called()
+        mock_blade.delete_management_authentication_policies_members.assert_not_called()
+
+    def test_reconcile_members_check_mode_still_fails_on_conflict(self):
+        """Test check mode fails on a conflict exactly like a real run"""
+        mock_module = _mock_module(members=[{"name": "alice", "type": "admin"}])
+        mock_module.check_mode = True
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {"alice": "other-policy"})
+        )
+        try:
+            reconcile_members(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+
+    def test_reconcile_members_attach_error_fails(self):
+        """Test a failed attach surfaces the API error"""
+        mock_module = _mock_module(members=[{"name": "alice", "type": "admin"}])
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        error = Mock()
+        error.status_code = 400
+        error.errors = []
+        mock_blade.post_management_authentication_policies_members.return_value = error
+        try:
+            reconcile_members(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "Failed to attach" in mock_module.fail_json.call_args[1]["msg"]
+
+    def test_reconcile_members_fails_on_nonexistent_admin(self):
+        """Test a mistyped admin name fails before any write, even in check mode"""
+        mock_module = _mock_module(members=[{"name": "ghost", "type": "admin"}])
+        mock_module.check_mode = True
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        error = Mock()
+        error.status_code = 400
+        mock_blade.get_admins.return_value = error
+        try:
+            reconcile_members(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "does not exist" in mock_module.fail_json.call_args[1]["msg"]
+        mock_blade.post_management_authentication_policies_members.assert_not_called()
+
+    def test_reconcile_members_fails_on_unknown_array(self):
+        """Test an array member name that is not this array fails"""
+        mock_module = _mock_module(members=[{"name": "fb2", "type": "array"}])
+        mock_blade = Mock()
+        _members_exist(mock_blade, arrays=("fb1",))
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        try:
+            reconcile_members(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "does not exist" in mock_module.fail_json.call_args[1]["msg"]
+
+    # ==== create_policy ====
+
+    def test_create_policy_requires_a_method_mode(self):
+        """Test create fails when neither method list is supplied"""
+        mock_module = _mock_module()
+        mock_blade = Mock()
+        try:
+            create_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert (
+            "ssh_allowed_methods or ssh_required_methods"
+            in mock_module.fail_json.call_args[1]["msg"]
+        )
+        mock_blade.post_management_authentication_policies.assert_not_called()
+
+    @patch("plugins.modules.purefb_mgmt_auth_policy.ManagementAuthenticationPolicyPost")
+    def test_create_policy_defaults_enabled_true(self, mock_post_cls):
+        """Test create defaults enabled to true and POSTs the policy"""
+        mock_module = _mock_module(ssh_allowed_methods=["password"])
+        mock_blade = Mock()
+        mock_blade.post_management_authentication_policies.return_value = _ok_response()
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        try:
+            create_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        assert mock_post_cls.call_args[1]["enabled"] is True
+        mock_blade.post_management_authentication_policies.assert_called_once()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    def test_create_policy_check_mode_skips_post(self):
+        """Test create in check mode reports changed without POSTing"""
+        mock_module = _mock_module(ssh_required_methods=["password", "key"])
+        mock_module.check_mode = True
+        mock_blade = Mock()
+        try:
+            create_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_blade.post_management_authentication_policies.assert_not_called()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    def test_create_policy_attaches_members(self):
+        """Test create reconciles members after the POST"""
+        mock_module = _mock_module(
+            ssh_allowed_methods=["key"],
+            members=[{"name": "alice", "type": "admin"}],
+        )
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.post_management_authentication_policies.return_value = _ok_response()
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        mock_blade.post_management_authentication_policies_members.return_value = (
+            _ok_response()
+        )
+        try:
+            create_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_blade.post_management_authentication_policies_members.assert_called_once()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    def test_create_policy_preflights_conflict_before_post(self):
+        """Test a member conflict fails create before the policy POST"""
+        mock_module = _mock_module(
+            ssh_allowed_methods=["key"],
+            members=[{"name": "alice", "type": "admin"}],
+        )
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {"alice": "other-policy"})
+        )
+        try:
+            create_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "other-policy" in mock_module.fail_json.call_args[1]["msg"]
+        mock_blade.post_management_authentication_policies.assert_not_called()
+
+    def test_create_policy_check_mode_fails_on_conflict(self):
+        """Test check-mode create fails on a member conflict like a real run"""
+        mock_module = _mock_module(
+            ssh_allowed_methods=["key"],
+            members=[{"name": "alice", "type": "admin"}],
+        )
+        mock_module.check_mode = True
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {"alice": "other-policy"})
+        )
+        try:
+            create_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "replace_existing" in mock_module.fail_json.call_args[1]["msg"]
+        mock_blade.post_management_authentication_policies.assert_not_called()
+
+    def test_create_policy_check_mode_fails_on_nonexistent_member(self):
+        """Test check-mode create catches a nonexistent member before the POST"""
+        mock_module = _mock_module(
+            ssh_allowed_methods=["key"],
+            members=[{"name": "ghost", "type": "admin"}],
+        )
+        mock_module.check_mode = True
+        mock_blade = Mock()
+        error = Mock()
+        error.status_code = 400
+        mock_blade.get_admins.return_value = error
+        try:
+            create_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "does not exist" in mock_module.fail_json.call_args[1]["msg"]
+        mock_blade.post_management_authentication_policies.assert_not_called()
+
+    def test_create_policy_replace_existing_moves_member(self):
+        """Test create with replace_existing moves a conflicted member"""
+        mock_module = _mock_module(
+            ssh_allowed_methods=["key"],
+            members=[{"name": "alice", "type": "admin"}],
+            replace_existing=True,
+        )
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {"alice": "other-policy"})
+        )
+        mock_blade.post_management_authentication_policies.return_value = _ok_response()
+        mock_blade.delete_management_authentication_policies_members.return_value = (
+            _ok_response()
+        )
+        mock_blade.post_management_authentication_policies_members.return_value = (
+            _ok_response()
+        )
+        try:
+            create_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        detach = mock_blade.delete_management_authentication_policies_members.call_args[
+            1
+        ]
+        assert detach["policy_names"] == ["other-policy"]
+        mock_blade.post_management_authentication_policies_members.assert_called_once()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    def test_create_policy_api_error_fails(self):
+        """Test create surfaces an API failure"""
+        mock_module = _mock_module(ssh_allowed_methods=["password"])
+        mock_blade = Mock()
+        error = Mock()
+        error.status_code = 400
+        error.errors = []
+        mock_blade.post_management_authentication_policies.return_value = error
+        try:
+            create_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "Failed to create policy" in mock_module.fail_json.call_args[1]["msg"]
+
+    # ==== update_policy ====
+
+    def test_update_policy_no_changes(self):
+        """Test update exits changed=False when nothing differs"""
+        mock_module = _mock_module(ssh_allowed_methods=["password", "key"])
+        mock_blade = Mock()
+        existing = _mock_policy(allowed=["key", "password"])
+        try:
+            update_policy(mock_module, mock_blade, {}, existing)
+        except SystemExit:
+            pass
+        mock_blade.patch_management_authentication_policies.assert_not_called()
+        mock_module.exit_json.assert_called_once_with(changed=False)
+
+    def test_update_policy_enabled_change(self):
+        """Test update PATCHes an enabled flip"""
+        mock_module = _mock_module(enabled=False)
+        mock_blade = Mock()
+        mock_blade.patch_management_authentication_policies.return_value = (
+            _ok_response()
+        )
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        existing = _mock_policy(enabled=True, allowed=["password"])
+        try:
+            update_policy(mock_module, mock_blade, {}, existing)
+        except SystemExit:
+            pass
+        mock_blade.patch_management_authentication_policies.assert_called_once()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    @patch(
+        "plugins.modules.purefb_mgmt_auth_policy.ManagementAuthenticationPolicyConfig"
+    )
+    def test_update_policy_mode_switch(self, mock_config_cls):
+        """Test switching allowed -> required PATCHes with the old list cleared"""
+        mock_module = _mock_module(ssh_required_methods=["password", "key"])
+        mock_blade = Mock()
+        mock_blade.patch_management_authentication_policies.return_value = (
+            _ok_response()
+        )
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        existing = _mock_policy(allowed=["password"])
+        try:
+            update_policy(mock_module, mock_blade, {}, existing)
+        except SystemExit:
+            pass
+        mock_blade.patch_management_authentication_policies.assert_called_once()
+        assert mock_config_cls.call_args[1] == {
+            "allowed_methods": [],
+            "required_methods": ["key", "password"],
+        }
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    def test_update_policy_warns_when_members_attached(self):
+        """Test a config change on an attached policy emits a lockout warning"""
+        mock_module = _mock_module(ssh_required_methods=["key"])
+        mock_blade = Mock()
+        mock_blade.patch_management_authentication_policies.return_value = (
+            _ok_response()
+        )
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([_member_item("ssh-mfa", "admins", "alice")], {})
+        )
+        existing = _mock_policy(allowed=["password"])
+        # members param omitted -> reconcile is a no-op; only the warning
+        # path reads membership.
+        try:
+            update_policy(mock_module, mock_blade, {}, existing)
+        except SystemExit:
+            pass
+        mock_module.warn.assert_called_once()
+        assert "subsequent SSH logins" in mock_module.warn.call_args[0][0]
+
+    def test_update_policy_check_mode_skips_patch(self):
+        """Test check mode reports the pending update without PATCHing"""
+        mock_module = _mock_module(enabled=False)
+        mock_module.check_mode = True
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        existing = _mock_policy(enabled=True, allowed=["password"])
+        try:
+            update_policy(mock_module, mock_blade, {}, existing)
+        except SystemExit:
+            pass
+        mock_blade.patch_management_authentication_policies.assert_not_called()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    def test_update_policy_api_error_fails(self):
+        """Test update surfaces an API failure"""
+        mock_module = _mock_module(enabled=False)
+        mock_blade = Mock()
+        error = Mock()
+        error.status_code = 400
+        error.errors = []
+        mock_blade.patch_management_authentication_policies.return_value = error
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        existing = _mock_policy(enabled=True, allowed=["password"])
+        try:
+            update_policy(mock_module, mock_blade, {}, existing)
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "Failed to update policy" in mock_module.fail_json.call_args[1]["msg"]
+
+    def test_update_policy_members_only_change(self):
+        """Test membership-only reconciliation reports changed without PATCH"""
+        mock_module = _mock_module(members=[{"name": "alice", "type": "admin"}])
+        mock_blade = Mock()
+        _members_exist(mock_blade)
+        mock_blade.get_management_authentication_policies_members.side_effect = (
+            _members_side_effect([], {})
+        )
+        mock_blade.post_management_authentication_policies_members.return_value = (
+            _ok_response()
+        )
+        existing = _mock_policy(allowed=["password"])
+        try:
+            update_policy(mock_module, mock_blade, {}, existing)
+        except SystemExit:
+            pass
+        mock_blade.patch_management_authentication_policies.assert_not_called()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    # ==== delete_policy ====
+
+    def test_delete_policy_fails_when_members_attached(self):
+        """Test the client-side delete guard (the array itself would allow it)"""
+        mock_module = _mock_module(state="absent")
+        mock_blade = Mock()
+        mock_blade.get_management_authentication_policies_members.return_value = (
+            _ok_response([_member_item("ssh-mfa", "arrays", "fb1")])
+        )
+        try:
+            delete_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "has attached members" in msg
+        assert "Detach members first" in msg
+        mock_blade.delete_management_authentication_policies.assert_not_called()
+
+    def test_delete_policy_success(self):
+        """Test delete removes an unattached policy"""
+        mock_module = _mock_module(state="absent")
+        mock_blade = Mock()
+        mock_blade.get_management_authentication_policies_members.return_value = (
+            _ok_response([])
+        )
+        mock_blade.delete_management_authentication_policies.return_value = (
+            _ok_response()
+        )
+        try:
+            delete_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_blade.delete_management_authentication_policies.assert_called_once()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    def test_delete_policy_check_mode_skips_delete(self):
+        """Test check mode reports the pending delete without DELETEing"""
+        mock_module = _mock_module(state="absent")
+        mock_module.check_mode = True
+        mock_blade = Mock()
+        mock_blade.get_management_authentication_policies_members.return_value = (
+            _ok_response([])
+        )
+        try:
+            delete_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_blade.delete_management_authentication_policies.assert_not_called()
+        mock_module.exit_json.assert_called_once_with(changed=True)
+
+    def test_delete_policy_api_error_fails(self):
+        """Test delete surfaces an API failure"""
+        mock_module = _mock_module(state="absent")
+        mock_blade = Mock()
+        mock_blade.get_management_authentication_policies_members.return_value = (
+            _ok_response([])
+        )
+        error = Mock()
+        error.status_code = 400
+        error.errors = []
+        mock_blade.delete_management_authentication_policies.return_value = error
+        try:
+            delete_policy(mock_module, mock_blade, {})
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        assert "Failed to delete policy" in mock_module.fail_json.call_args[1]["msg"]
+
+    # ==== main / version gating ====
+
+    @patch("plugins.modules.purefb_mgmt_auth_policy.LooseVersion")
+    @patch("plugins.modules.purefb_mgmt_auth_policy.get_rest_api_version")
+    @patch("plugins.modules.purefb_mgmt_auth_policy.get_system")
+    @patch("plugins.modules.purefb_mgmt_auth_policy.AnsibleModule")
+    def test_main_fails_below_minimum_api_version(
+        self, mock_ansible_module, mock_get_system, mock_get_version, mock_loose
+    ):
+        """Test main fails when the array REST version predates 2.22"""
+        mock_module = _mock_module()
+        mock_ansible_module.return_value = mock_module
+        mock_get_system.return_value = Mock()
+        mock_get_version.return_value = "2.21"
+        mock_loose.side_effect = lambda v: tuple(int(p) for p in v.split("."))
+        try:
+            main()
+        except SystemExit:
+            pass
+        mock_module.fail_json.assert_called_once()
+        msg = mock_module.fail_json.call_args[1]["msg"]
+        assert "does not support management authentication policies" in msg
+        assert "2.22" in msg
+
+    @patch("plugins.modules.purefb_mgmt_auth_policy.get_error_message")
+    @patch("plugins.modules.purefb_mgmt_auth_policy.LooseVersion")
+    @patch("plugins.modules.purefb_mgmt_auth_policy.get_rest_api_version")
+    @patch("plugins.modules.purefb_mgmt_auth_policy.get_system")
+    @patch("plugins.modules.purefb_mgmt_auth_policy.AnsibleModule")
+    def test_main_absent_nonexistent_policy_no_change(
+        self,
+        mock_ansible_module,
+        mock_get_system,
+        mock_get_version,
+        mock_loose,
+        mock_gem,
+    ):
+        """Test state=absent on a missing policy exits changed=False"""
+        mock_gem.return_value = "Management authentication policy does not exist."
+        mock_module = _mock_module(state="absent")
+        mock_ansible_module.return_value = mock_module
+        mock_blade = Mock()
+        error = Mock()
+        error.status_code = 400
+        mock_blade.get_management_authentication_policies.return_value = error
+        mock_get_system.return_value = mock_blade
+        mock_get_version.return_value = "2.28"
+        mock_loose.side_effect = lambda v: tuple(int(p) for p in v.split("."))
+        try:
+            main()
+        except SystemExit:
+            pass
+        mock_module.exit_json.assert_called_once_with(changed=False)

--- a/tests/unit/plugins/modules/test_purefb_mgmt_auth_policy.py
+++ b/tests/unit/plugins/modules/test_purefb_mgmt_auth_policy.py
@@ -81,7 +81,6 @@ from plugins.modules.purefb_mgmt_auth_policy import (
     _desired_ssh_config,
     _current_ssh_config,
     _build_ssh_config,
-    _warn_if_live,
     reconcile_members,
     create_policy,
     update_policy,


### PR DESCRIPTION
##### SUMMARY

New module `purefb_mgmt_auth_policy` for FlashBlade Management Authentication Policies (Purity//FB REST 2.22+). A policy defines which authentication factors administrators may or must present for SSH logins, and which members (local admins, the array, or both) it applies to.

The module manages both halves of the object declaratively.

- **Policy configuration.** Create, update, and delete policies, set the `enabled` flag, and set the SSH methods in either of the array's two modes: `ssh_allowed_methods` (any one listed method suffices: `password`, `key`, `default`) or `ssh_required_methods` (all listed methods must be presented: `password`, `key`). The modes are mutually exclusive. Supplying one list switches the policy's mode and clears the other, which matches the array's PATCH behavior of replacing the whole SSH object.
- **Membership reconciliation.** `members` is a declarative list of `{name, type}` entries (`type: admin | array`). The module attaches missing members and detaches unlisted ones. `members: []` detaches everything; omitting the parameter leaves membership alone. A member can belong to at most one policy, so attaching a member that already belongs elsewhere fails unless `replace_existing: true`, which moves it. A move is a detach followed by an attach, since the array has no atomic move.

A few things to note:

- **Client-side delete guard.** The array deletes an attached policy without error and silently detaches its members, which then fall back to the default authentication behavior. For an MFA policy that is a quiet security downgrade. So `state: absent` fails while members are attached; detach first with `members: []`.
- **Check-mode parity.** The module validates member existence and cross-policy conflicts before the create POST, and in check mode too, so `--check` fails exactly where a real run would and a refused attach never leaves a half-created policy behind. Existence has to come from the `admins` and `arrays` endpoints, because the members relationship GET returns 200 with no items for a nonexistent member.
- **Protected accounts.** The built-in `ir` and `pureeng` admins are exempt from authentication policies by product design. The module refuses to attach them and never detaches them, even when the array reports them as members.
- **Bounded move failure.** Each move runs as its own detach-then-attach pair, so a failure mid-move orphans at most one member, and the error message names that member and says to re-run the task.


##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

purefb_mgmt_auth_policy

##### ADDITIONAL INFORMATION

###### Supported operations

| Operation | Task shape | REST calls | Notes |
|---|---|---|---|
| Create policy | `state=present`, policy absent | `POST management-authentication-policies` | Requires one of `ssh_allowed_methods` / `ssh_required_methods`; `enabled` defaults to `true`; existence and conflict checks run before the POST |
| Update policy | `state=present`, policy exists | `PATCH management-authentication-policies` | Diff-based; only changed values are sent; the PATCH replaces the SSH config wholesale (array semantics); warns when the policy has attached members |
| Reconcile members | `members:` supplied | `GET`/`POST`/`DELETE …/members` | Declarative attach and detach; at most one `array` member; `ir`/`pureeng` never touched |
| Move member | `members:` plus `replace_existing=true` | `DELETE` from other policy, then `POST` | Per-member detach-then-attach pair; not atomic (API limit); a failure orphans at most one member, named in the error |
| Delete policy | `state=absent` | `DELETE management-authentication-policies` | Fails while members are attached (client-side guard; the array itself would silently drop memberships) |


Version gates: policy and member management 2.22, fleet `context` 2.17. All mutating paths honor check mode, including existence and conflict validation.

