### PR TITLE
Migrate module version gating to get_rest_api_version and LooseVersion

### DIFF
--- a/changelogs/fragments/585_version_gating_looseversion.yaml
+++ b/changelogs/fragments/585_version_gating_looseversion.yaml
@@ -31,4 +31,4 @@ minor_changes:
   - purefb_userquota - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
   - purefb_virtualhost - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
 bugfixes:
-  - purefb_info - Default subset version gating previously compared against a single version string instead of the supported-versions list, so encryption, network access protocol and remote assist duration details were never reported; these now appear when the array supports them
+  - purefb_info - Fix default subset version gating so encryption, network access protocol and remote assist duration details are reported when the array supports them

--- a/changelogs/fragments/585version-gating-looseversion.yaml
+++ b/changelogs/fragments/585version-gating-looseversion.yaml
@@ -1,0 +1,34 @@
+minor_changes:
+  - purefb_ad - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_admin - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_bucket - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_bucket_access - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_bucket_replica - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_certs - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_connect - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_dns - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_ds - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_export - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_fs - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_fs_replica - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_groupquota - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_hardware - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_info - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_inventory - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_lifecycle - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_pingtrace - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_policy - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_ra - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_remote_cred - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_s3acc - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_s3user - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_saml - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_smtp - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_snap - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_syslog - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_user - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_userpolicy - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_userquota - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+  - purefb_virtualhost - Migrate REST API version checks to get_rest_api_version and LooseVersion comparisons
+bugfixes:
+  - purefb_info - Default subset version gating previously compared against a single version string instead of the supported-versions list, so encryption, network access protocol and remote assist duration details were never reported; these now appear when the array supports them

--- a/plugins/modules/purefb_ad.py
+++ b/plugins/modules/purefb_ad.py
@@ -239,8 +239,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 GC_SERVERS_API_VERSION = "2.12"
@@ -264,9 +268,9 @@ def delete_account(module, blade):
 def create_account(module, blade):
     """Create Active Directory Account"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.params["existing"]:
-        if GC_SERVERS_API_VERSION in api_version:
+        if LooseVersion(GC_SERVERS_API_VERSION) <= LooseVersion(api_version):
             ad_config = ActiveDirectoryPost(
                 computer_name=module.params["computer"],
                 directory_servers=module.params["directory_servers"],
@@ -302,7 +306,7 @@ def create_account(module, blade):
                     )
                 )
     else:
-        if GC_SERVERS_API_VERSION in api_version:
+        if LooseVersion(GC_SERVERS_API_VERSION) <= LooseVersion(api_version):
             ad_config = ActiveDirectoryPost(
                 computer_name=module.params["computer"],
                 directory_servers=module.params["directory_servers"],
@@ -340,7 +344,7 @@ def create_account(module, blade):
 
 def update_account(module, blade):
     """Update Active Directory Account"""
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     changed = False
     mod_ad = False
     current_ad = list(blade.get_active_directory(names=[module.params["name"]]).items)[
@@ -384,7 +388,7 @@ def update_account(module, blade):
             ):
                 attr["service_principal_names"] = module.params["service_principals"]
                 mod_ad = True
-    if GC_SERVERS_API_VERSION in api_version:
+    if LooseVersion(GC_SERVERS_API_VERSION) <= LooseVersion(api_version):
         if module.params["global_catalog_servers"]:
             if current_ad.global_catalog_servers:
                 if sorted(current_ad.global_catalog_servers) != sorted(
@@ -516,8 +520,11 @@ def main():
 
     if not module.params["computer"]:
         module.params["computer"] = module.params["name"].replace("_", "-")
-    api_version = list(blade.get_versions().items)
-    if SERVERS_API_VERSION in api_version and module.params["server"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(SERVERS_API_VERSION) <= LooseVersion(api_version)
+        and module.params["server"]
+    ):
         if blade.get_servers(names=[module.params["server"]]).status_code != 200:
             module.fail_json(
                 msg="Server {0} does not exist on this FlashBlade.".format(

--- a/plugins/modules/purefb_admin.py
+++ b/plugins/modules/purefb_admin.py
@@ -70,6 +70,7 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
 )
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 
@@ -92,7 +93,7 @@ def main():
     if not 1 <= module.params["min_password"] <= 100:
         module.fail_json(msg="Minimum password length must be between 1 and 100")
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     changed = False
     current_settings = list(blade.get_admins_settings().items)[0]
     lockout = getattr(current_settings, "lockout_duration", None)

--- a/plugins/modules/purefb_bucket.py
+++ b/plugins/modules/purefb_bucket.py
@@ -243,9 +243,13 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
-    human_to_bytes,
     get_error_message,
+    get_rest_api_version,
+    human_to_bytes,
 )
 
 SEC_PER_DAY = 86400000
@@ -258,8 +262,11 @@ CONTEXT_API_VERSION = "2.17"
 
 def get_s3acc(module, blade):
     """Return Object Store Account or None"""
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_object_store_accounts(
             context_names=[module.params["context"]],
             names=[module.params["account"]],
@@ -273,8 +280,11 @@ def get_s3acc(module, blade):
 
 def get_bucket(module, blade):
     """Return Bucket or None"""
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_buckets(
             context_names=[module.params["context"]],
             names=[module.params["name"]],
@@ -289,10 +299,13 @@ def get_bucket(module, blade):
 def create_bucket(module, blade):
     """Create bucket"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
-        if VSO_VERSION in api_version:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if LooseVersion(VSO_VERSION) <= LooseVersion(api_version):
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 account_defaults = list(
                     blade.get_object_store_accounts(
                         names=[module.params["account"]],
@@ -305,7 +318,7 @@ def create_bucket(module, blade):
                         names=[module.params["account"]]
                     ).items
                 )[0]
-            if QUOTA_VERSION in api_version:
+            if LooseVersion(QUOTA_VERSION) <= LooseVersion(api_version):
                 if not module.params["hard_limit"]:
                     module.params["hard_limit"] = account_defaults.hard_limit_enabled
                 if module.params["quota"]:
@@ -342,7 +355,10 @@ def create_bucket(module, blade):
                     account=ReferenceWritable(name=module.params["account"]),
                     bucket_type=module.params["mode"],
                 )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_buckets(
                     names=[module.params["name"]],
                     bucket=bucket,
@@ -359,7 +375,7 @@ def create_bucket(module, blade):
                     )
                 )
             if module.params["versioning"] != "absent":
-                if QUOTA_VERSION in api_version:
+                if LooseVersion(QUOTA_VERSION) <= LooseVersion(api_version):
                     bucket = BucketPatch(
                         retention_lock=module.params["retention_lock"],
                         object_lock_config=ObjectLockConfigRequestBody(
@@ -378,7 +394,7 @@ def create_bucket(module, blade):
                         versioning=module.params["versioning"],
                     )
             else:
-                if QUOTA_VERSION in api_version:
+                if LooseVersion(QUOTA_VERSION) <= LooseVersion(api_version):
                     bucket = BucketPatch(
                         retention_lock=module.params["retention_lock"],
                         object_lock_config=ObjectLockConfigRequestBody(
@@ -397,7 +413,10 @@ def create_bucket(module, blade):
                         versioning=None,
                     )
 
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_buckets(
                     names=[module.params["name"]],
                     bucket=bucket,
@@ -416,7 +435,10 @@ def create_bucket(module, blade):
             bucket = BucketPost(
                 account=ReferenceWritable(name=module.params["account"]),
             )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_buckets(
                     names=[module.params["name"]],
                     bucket=bucket,
@@ -433,7 +455,10 @@ def create_bucket(module, blade):
                     )
                 )
             if module.params["versioning"] != "absent":
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.buckets.patch_buckets(
                         names=[module.params["name"]],
                         bucket=BucketPatch(versioning=module.params["versioning"]),
@@ -450,7 +475,7 @@ def create_bucket(module, blade):
                             module.params["name"], get_error_message(res)
                         )
                     )
-        if MODE_VERSION in api_version:
+        if LooseVersion(MODE_VERSION) <= LooseVersion(api_version):
             if not module.params["block_new_public_policies"]:
                 module.params["block_new_public_policies"] = False
             if not module.params["block_public_access"]:
@@ -463,7 +488,10 @@ def create_bucket(module, blade):
                     block_public_access=module.params["block_public_access"],
                 )
             )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_buckets(
                     bucket=pac,
                     names=[module.params["name"]],
@@ -485,7 +513,10 @@ def create_bucket(module, blade):
                 policy = BucketAccessPolicyPost(
                     name=module.params["name"],
                 )
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.post_buckets_bucket_access_policies(
                         bucket_names=[module.params["name"]],
                         policy=policy,
@@ -507,7 +538,10 @@ def create_bucket(module, blade):
                     principals=BucketAccessPolicyRulePrincipal(all=True),
                     resources=[module.params["name"] + "/*"],
                 )
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.post_buckets_bucket_access_policies_rules(
                         bucket_names=[module.params["name"]],
                         rule=rule,
@@ -526,7 +560,10 @@ def create_bucket(module, blade):
                             module.params["name"], get_error_message(res)
                         )
                     )
-        if WORM_VERSION in api_version and module.params["eradication_mode"]:
+        if (
+            LooseVersion(WORM_VERSION) <= LooseVersion(api_version)
+            and module.params["eradication_mode"]
+        ):
             if not module.params["eradication_delay"]:
                 module.params["eradication_delay"] = SEC_PER_DAY
             else:
@@ -544,7 +581,10 @@ def create_bucket(module, blade):
                     eradication_delay=module.params["eradication_delay"],
                 )
             )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_buckets(
                     bucket=worm,
                     names=[module.params["name"]],
@@ -561,8 +601,11 @@ def create_bucket(module, blade):
 
 
 def _delete_bucket(module, blade):
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         blade.patch_buckets(
             names=[module.params["name"]],
             bucket=BucketPatch(destroyed=True),
@@ -582,9 +625,12 @@ def _delete_bucket(module, blade):
 def delete_bucket(module, blade):
     """Delete Bucket"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.patch_buckets(
                 names=[module.params["name"]],
                 bucket=BucketPatch(destroyed=True),
@@ -600,7 +646,10 @@ def delete_bucket(module, blade):
                 "Error: {1}".format(module.params["name"], get_error_message(res))
             )
         if module.params["eradicate"]:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.delete_buckets(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -618,9 +667,12 @@ def delete_bucket(module, blade):
 def recover_bucket(module, blade):
     """Recover Bucket"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.patch_buckets(
                 names=[module.params["name"]],
                 bucket=BucketPatch(destroyed=False),
@@ -645,8 +697,11 @@ def update_bucket(module, blade, bucket):
     change_pac = False
     change_worm = False
     change_quota = False
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         bucket_detail = list(
             blade.get_buckets(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -654,10 +709,10 @@ def update_bucket(module, blade, bucket):
         )[0]
     else:
         bucket_detail = list(blade.get_buckets(names=[module.params["name"]]).items)[0]
-    if VSO_VERSION in api_version:
+    if LooseVersion(VSO_VERSION) <= LooseVersion(api_version):
         if module.params["mode"] and bucket_detail.bucket_type != module.params["mode"]:
             module.warn("Changing bucket type is not permitted.")
-        if QUOTA_VERSION in api_version:
+        if LooseVersion(QUOTA_VERSION) <= LooseVersion(api_version):
             if (
                 bucket_detail.retention_lock == "ratcheted"
                 and getattr(
@@ -697,7 +752,10 @@ def update_bucket(module, blade, bucket):
         if bucket.versioning != versioning:
             changed = True
             if not module.check_mode:
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.patch_buckets(
                         names=[module.params["name"]],
                         bucket=BucketPatch(versioning=versioning),
@@ -717,7 +775,10 @@ def update_bucket(module, blade, bucket):
     elif module.params["versioning"] != "absent":
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_buckets(
                     names=[module.params["name"]],
                     bucket=BucketPatch(versioning=module.params["versioning"]),
@@ -734,7 +795,7 @@ def update_bucket(module, blade, bucket):
                         module.params["name"], get_error_message(res)
                     )
                 )
-    if QUOTA_VERSION in api_version:
+    if LooseVersion(QUOTA_VERSION) <= LooseVersion(api_version):
         current_quota = {
             "quota": bucket_detail.quota_limit,
             "hard": bucket_detail.hard_limit_enabled,
@@ -768,7 +829,10 @@ def update_bucket(module, blade, bucket):
                     quota_limit=str(new_quota["quota"]),
                     hard_limit_enabled=new_quota["hard"],
                 )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_buckets(
                     bucket=bucket,
                     names=[module.params["name"]],
@@ -781,7 +845,7 @@ def update_bucket(module, blade, bucket):
                     msg="Failed to update quota settings correctly for bucket {0}. "
                     "Error: {1}".format(module.params["name"], get_error_message(res))
                 )
-    if MODE_VERSION in api_version:
+    if LooseVersion(MODE_VERSION) <= LooseVersion(api_version):
         current_pac = {
             "block_new_public_policies": bucket_detail.public_access_config.block_new_public_policies,
             "block_public_access": bucket_detail.public_access_config.block_public_access,
@@ -807,7 +871,10 @@ def update_bucket(module, blade, bucket):
                 )
             )
         if change_pac and not module.check_mode:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_buckets(
                     bucket=pac,
                     names=[module.params["name"]],
@@ -820,7 +887,7 @@ def update_bucket(module, blade, bucket):
                     msg="Failed to update Public Access config correctly for bucket {0}. "
                     "Error: {1}".format(module.params["name"], get_error_message(res))
                 )
-    if WORM_VERSION in api_version:
+    if LooseVersion(WORM_VERSION) <= LooseVersion(api_version):
         current_worm = {
             "eradication_delay": bucket_detail.eradication_config.eradication_delay,
             "manual_eradication": bucket_detail.eradication_config.manual_eradication,
@@ -859,7 +926,10 @@ def update_bucket(module, blade, bucket):
                 )
             )
         if change_worm and not module.check_mode:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_buckets(
                     bucket=worm,
                     names=[module.params["name"]],
@@ -878,9 +948,12 @@ def update_bucket(module, blade, bucket):
 def eradicate_bucket(module, blade):
     """Eradicate Bucket"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.delete_buckets(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -945,15 +1018,18 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):
             module.params["context"] = list(blade.get_arrays().items)[0].name
 
     # From REST 2.12 classic is no longer the default mode
-    if MODE_VERSION in api_version:
+    if LooseVersion(MODE_VERSION) <= LooseVersion(api_version):
         if not module.params["mode"]:
             module.params["mode"] = "multi-site-writable"
     elif not module.params["mode"]:

--- a/plugins/modules/purefb_bucket_access.py
+++ b/plugins/modules/purefb_bucket_access.py
@@ -200,8 +200,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 MIN_API_VERSION = "2.12"
@@ -210,11 +214,14 @@ CONTEXT_API_VERSION = "2.17"
 
 def delete_cors_policy(module, blade):
     """Delete cross-origin resource sharing policy or rule"""
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     changed = True
     if not module.check_mode:
         if module.params["rule"]:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.get_buckets_cross_origin_resource_sharing_policies_rules(
                     bucket_names=[module.params["name"]],
                     names=[module.params["rule"]],
@@ -228,7 +235,10 @@ def delete_cors_policy(module, blade):
                 changed = False
                 module.exit_json(changed=changed)
 
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.delete_buckets_cross_origin_resource_sharing_policies_rules(
                     names=module.params["rule"],
                     bucket_names=module.params["name"],
@@ -247,7 +257,10 @@ def delete_cors_policy(module, blade):
                     )
                 )
         else:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.get_buckets_cross_origin_resource_sharing_policies(
                     bucket_names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -260,7 +273,10 @@ def delete_cors_policy(module, blade):
                 changed = False
                 module.exit_json(changed=changed)
 
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.delete_buckets_cross_origin_resource_sharing_policies(
                     bucket_names=module.params["name"],
                     context_names=[module.params["context"]],
@@ -283,10 +299,13 @@ def delete_access_policy(module, blade):
     """Delete bucket access policy or rule"""
 
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         if module.params["rule"]:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.get_buckets_bucket_access_policies_rules(
                     bucket_names=[module.params["name"]],
                     names=[module.params["rule"]],
@@ -300,7 +319,10 @@ def delete_access_policy(module, blade):
                 changed = False
                 module.exit_json(changed=changed)
 
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.delete_buckets_bucket_access_policies_rules(
                     names=module.params["rule"],
                     bucket_names=module.params["name"],
@@ -319,7 +341,10 @@ def delete_access_policy(module, blade):
                     )
                 )
         else:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.get_buckets_bucket_access_policies(
                     bucket_names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -332,7 +357,10 @@ def delete_access_policy(module, blade):
                 changed = False
                 module.exit_json(changed=changed)
 
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.delete_buckets_bucket_access_policies(
                     bucket_names=module.params["name"],
                     context_names=[module.params["context"]],
@@ -354,8 +382,11 @@ def delete_access_policy(module, blade):
 def create_access_policy(module, blade):
     """Create bucket access policy or rule"""
     changed = False
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_buckets_bucket_access_policies(
             bucket_names=[module.params["name"]],
             context_names=[module.params["context"]],
@@ -368,7 +399,10 @@ def create_access_policy(module, blade):
         # Need to create the policy with its first rule
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_buckets_bucket_access_policies(
                     bucket_names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -386,7 +420,10 @@ def create_access_policy(module, blade):
     # Create a new rule for the policy
     if not module.check_mode:
         changed = True
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_buckets_bucket_access_policies_rules(
                 bucket_names=[module.params["name"]],
                 names=[module.params["rule"]],
@@ -403,7 +440,10 @@ def create_access_policy(module, blade):
         all_resources = []
         for resource in module.params["resources"]:
             all_resources.append(module.params["name"] + "/" + resource)
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.post_buckets_bucket_access_policies_rules(
                 bucket_names=[module.params["name"]],
                 names=module.params["rule"],
@@ -443,8 +483,11 @@ def create_access_policy(module, blade):
 def create_cors_policy(module, blade):
     """Create CORS policy or rule"""
     changed = False
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_buckets_cross_origin_resource_sharing_policies(
             bucket_names=[module.params["name"]],
             context_names=[module.params["context"]],
@@ -457,7 +500,10 @@ def create_cors_policy(module, blade):
         # Need to create the policy with its first rule
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_buckets_cross_origin_resource_sharing_policies(
                     bucket_names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -475,7 +521,10 @@ def create_cors_policy(module, blade):
     # Create a new rule for the policy
     if not module.check_mode:
         changed = True
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_buckets_cross_origin_resource_sharing_policies_rules(
                 bucket_names=[module.params["name"]],
                 names=[module.params["rule"]],
@@ -489,7 +538,10 @@ def create_cors_policy(module, blade):
             changed = False
             module.exit_json(changed=changed)
 
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.post_buckets_cross_origin_resource_sharing_policies_rules(
                 bucket_names=[module.params["name"]],
                 names=module.params["rule"],
@@ -615,19 +667,25 @@ def main():
     if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client sdk is required for this module")
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):
             module.params["context"] = list(blade.get_arrays().items)[0].name
-    if MIN_API_VERSION not in api_version:
+    if LooseVersion(MIN_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg=(
                 "Minimum FlashBlade REST version required: {0}".format(MIN_API_VERSION)
             )
         )
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_buckets(
             names=[module.params["name"]],
             destroyed=False,

--- a/plugins/modules/purefb_bucket_replica.py
+++ b/plugins/modules/purefb_bucket_replica.py
@@ -125,15 +125,22 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 
 def get_local_bucket(module, blade):
     """Return Bucket or None"""
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_buckets(
             context_names=[module.params["context"]],
             names=[module.params["name"]],
@@ -149,8 +156,11 @@ def get_local_bucket(module, blade):
 
 def get_remote_cred(module, blade, target):
     """Return Remote Credential or None"""
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_object_store_remote_credentials(
             names=[target + "/" + module.params["credential"]],
             context_names=[module.params["context"]],
@@ -168,8 +178,11 @@ def get_remote_cred(module, blade, target):
 
 def get_local_rl(module, blade):
     """Return Bucket Replica Link or None"""
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_bucket_replica_links(
             local_bucket_names=[module.params["name"]],
             context_names=[module.params["context"]],
@@ -184,8 +197,11 @@ def get_local_rl(module, blade):
 
 
 def get_connected(module, blade):
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         connected_blades = blade.get_array_connections(
             context_names=[module.params["context"]]
         )
@@ -198,7 +214,10 @@ def get_connected(module, blade):
             "partially_connected",
         ]:
             return item.remote.name
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         connected_targets = blade.get_targets(context_names=[module.params["context"]])
     else:
         connected_targets = blade.get_targets()
@@ -215,7 +234,7 @@ def get_connected(module, blade):
 def create_rl(module, blade, remote_cred):
     """Create Bucket Replica Link"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         if not module.params["target_bucket"]:
             module.params["target_bucket"] = module.params["name"]
@@ -225,7 +244,10 @@ def create_rl(module, blade, remote_cred):
             cascading_enabled=module.params["cascading"],
             paused=module.params["paused"],
         )
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.post_bucket_replica_links(
                 local_bucket_names=[module.params["name"]],
                 remote_bucket_names=[module.params["target_bucket"]],
@@ -251,7 +273,7 @@ def create_rl(module, blade, remote_cred):
 
 def update_rl_policy(module, blade, local_replica_link):
     """Update Bucket Replica Link"""
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     changed = False
     new_cred = local_replica_link.remote.name + "/" + module.params["credential"]
     if local_replica_link.paused != module.params["paused"]:
@@ -270,7 +292,10 @@ def update_rl_policy(module, blade, local_replica_link):
     else:
         cascading = local_replica_link.cascading_enabled
     if not module.check_mode and changed:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.patch_bucket_replica_links(
                 local_bucket_names=[module.params["name"]],
                 remote_bucket_names=[local_replica_link.remote_bucket.name],
@@ -304,10 +329,13 @@ def update_rl_policy(module, blade, local_replica_link):
 
 def delete_rl_policy(module, blade, local_replica_link):
     """Delete Bucket Replica Link"""
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     changed = True
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.delete_bucket_replica_links(
                 remote_names=[local_replica_link.remote.name],
                 local_bucket_names=[module.params["name"]],
@@ -352,8 +380,11 @@ def main():
     state = module.params["state"]
     module.params["name"] = module.params["name"].lower()
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):

--- a/plugins/modules/purefb_certs.py
+++ b/plugins/modules/purefb_certs.py
@@ -225,8 +225,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 CERT_TYPE_VERSION = "2.15"
@@ -235,9 +239,9 @@ CSR_API_VERSION = "2.20"
 
 def update_cert(module, blade):
     """Update existing SSL Certificate"""
-    api_versions = list(blade.get_versions().items)
+    api_versions = get_rest_api_version(blade)
 
-    if CSR_API_VERSION in api_versions:
+    if LooseVersion(CSR_API_VERSION) <= LooseVersion(api_versions):
         changed = True
         certificate = CertificatePatch(
             certificate=module.params["certificate"],
@@ -295,8 +299,8 @@ def update_cert(module, blade):
 def create_cert(module, blade):
     # let the rest-api itself deal with errors
     changed = True
-    api_versions = list(blade.get_versions().items)
-    if CSR_API_VERSION in api_versions:
+    api_versions = get_rest_api_version(blade)
+    if LooseVersion(CSR_API_VERSION) <= LooseVersion(api_versions):
         certificate = CertificatePost(
             certificate_type=module.params["certificate_type"],
             certificate=module.params["certificate"],
@@ -315,7 +319,7 @@ def create_cert(module, blade):
             subject_alternative_names=module.params["subject_alternative_names"],
         )
     else:
-        if CERT_TYPE_VERSION in api_versions:
+        if LooseVersion(CERT_TYPE_VERSION) <= LooseVersion(api_versions):
             certificate = CertificatePost(
                 certificate_type=module.params["certificate_type"],
                 certificate=module.params["certificate"],
@@ -463,7 +467,7 @@ def main():
 
     email_pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
     blade = get_system(module)
-    api_versions = list(blade.get_versions().items)
+    api_versions = get_rest_api_version(blade)
 
     if module.params["email"]:
         if not re.search(email_pattern, module.params["email"]):
@@ -498,7 +502,7 @@ def main():
     elif exists and state == "present":
         update_cert(module, blade)
     elif state == "sign":
-        if CSR_API_VERSION not in api_versions:
+        if LooseVersion(CSR_API_VERSION) > LooseVersion(api_versions):
             module.fail_json(msg="Purity//FB 4.6.3+ is required for CSRs")
         create_csr(module, blade)
     elif not exists and state == "import":

--- a/plugins/modules/purefb_connect.py
+++ b/plugins/modules/purefb_connect.py
@@ -142,8 +142,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
 from ansible_collections.everpure.flashblade.plugins.module_utils.time_utils import (
     time_to_milliseconds,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 CONTEXT_API_VERSION = "2.17"
@@ -152,8 +156,11 @@ FAN_OUT_MAXIMUM = 5
 
 
 def _check_connected(module, blade):
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         connected_blades = list(
             blade.get_array_connections(context_names=[module.params["context"]]).items
         )
@@ -188,10 +195,13 @@ def _check_connected(module, blade):
 
 def break_connection(module, blade, target_blade):
     """Break connection between arrays"""
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     changed = True
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             source_blade = (
                 blade.get_arrays(context_names=[module.params["context"]]).items[0].name
             )
@@ -201,7 +211,10 @@ def break_connection(module, blade, target_blade):
             module.fail_json(
                 msg="Disconnect can only happen from the array that formed the connection"
             )
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.delete_array_connections(
                 remote_names=[target_blade.remote.name],
                 context_names=[module.params["context"]],
@@ -221,9 +234,12 @@ def break_connection(module, blade, target_blade):
 
 def create_connection(module, blade):
     """Create connection between REST 2 capable arrays"""
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     changed = True
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_array_connections(context_names=[module.params["context"]])
     else:
         res = blade.get_array_connections()
@@ -295,7 +311,10 @@ def create_connection(module, blade):
             connection_key=connection_key,
         )
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.post_array_connections(
                 array_connection=connection_info,
                 context_names=[module.params["context"]],
@@ -314,7 +333,7 @@ def create_connection(module, blade):
 def update_connection(module, blade):
     """Update REST 2 based array connection"""
     changed = False
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     remote_blade = Client(
         target=module.params["target_url"], api_token=module.params["target_api"]
     )
@@ -327,7 +346,10 @@ def update_connection(module, blade):
             msg="Update can only happen from the array that formed the connection"
         )
     if module.params["encrypted"] != remote_connection.encrypted:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_file_system_replica_links(
                 context_names=[module.params["context"]]
             )
@@ -346,7 +368,10 @@ def update_connection(module, blade):
         not remote_connection.throttle.default_limit
         and not remote_connection.throttle.window_limit
     ):
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             blade.get_bucket_replica_links(context_names=[module.params["context"]])
         else:
             blade.get_bucket_replica_links()
@@ -417,7 +442,10 @@ def update_connection(module, blade):
                 encrypted=new_connection["encrypted"],
                 throttle=throttle,
             )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_array_connections(
                     remote_names=[remote_name],
                     array_connection=connection_info,
@@ -464,8 +492,11 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):

--- a/plugins/modules/purefb_dns.py
+++ b/plugins/modules/purefb_dns.py
@@ -104,9 +104,13 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
-    remove_duplicates,
     get_error_message,
+    get_rest_api_version,
+    remove_duplicates,
 )
 
 NON_MGMT_DNS = "2.15"
@@ -275,11 +279,11 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if module.params["nameservers"]:
         module.params["nameservers"] = remove_duplicates(module.params["nameservers"])
 
-    if NON_MGMT_DNS in api_version:
+    if LooseVersion(NON_MGMT_DNS) <= LooseVersion(api_version):
         configs = list(blade.get_dns().items)
         exists = False
         for config in configs:

--- a/plugins/modules/purefb_ds.py
+++ b/plugins/modules/purefb_ds.py
@@ -206,8 +206,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 
@@ -505,8 +509,11 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if NO_SMB_VERSION in api_version and module.params["dstype"] == "smb":
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(NO_SMB_VERSION) <= LooseVersion(api_version)
+        and module.params["dstype"] == "smb"
+    ):
         module.warn("Directory Service for SMB no longer supported by FlashBlade")
         module.exit_json(changed=False)
     ds_name = module.params["dstype"]

--- a/plugins/modules/purefb_export.py
+++ b/plugins/modules/purefb_export.py
@@ -136,8 +136,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 MIN_API_VERSION = "2.17"
@@ -339,8 +343,11 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if MIN_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(MIN_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):

--- a/plugins/modules/purefb_fs.py
+++ b/plugins/modules/purefb_fs.py
@@ -352,9 +352,13 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
-    get_filesystem,
     get_error_message,
+    get_filesystem,
+    get_rest_api_version,
 )
 
 EXPORT_POLICY_API_VERSION = "2.3"
@@ -368,7 +372,7 @@ REALM_API_VERSION = "2.19"
 def create_fs(module, blade):
     """Create Filesystem"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         # Determine realm from either realm parameter or name prefix (realm::fs)
         realm_name = None
@@ -380,7 +384,7 @@ def create_fs(module, blade):
 
         # Validate realm if present
         if realm_name:
-            if REALM_API_VERSION not in api_version:
+            if LooseVersion(REALM_API_VERSION) > LooseVersion(api_version):
                 module.fail_json(
                     msg="Realm support requires Purity//FB 4.6.1+ (REST API 2.19+)"
                 )
@@ -478,7 +482,10 @@ def create_fs(module, blade):
         }
 
         # Add context if API supports it
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             post_kwargs["context_names"] = [module.params["context"]]
 
         # Add default_exports=[""] for realm filesystems (empty string)
@@ -493,7 +500,10 @@ def create_fs(module, blade):
                 )
             )
         if module.params["policy"]:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.get_policies(
                     names=[module.params["policy"]],
                     context_names=[module.params["context"]],
@@ -505,7 +515,10 @@ def create_fs(module, blade):
                 module.fail_json(
                     msg="Policy {0} doesn't exist.".format(module.params["policy"])
                 )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_policies_file_systems(
                     policy_names=[module.params["policy"]],
                     member_names=[fs_name],
@@ -526,7 +539,7 @@ def create_fs(module, blade):
                     )
                 )
         if (
-            EXPORT_POLICY_API_VERSION in api_version
+            LooseVersion(EXPORT_POLICY_API_VERSION) <= LooseVersion(api_version)
             and module.params["export_policy"]
             and (module.params["nfsv3"] or module.params["nfsv4"])
         ):
@@ -535,7 +548,10 @@ def create_fs(module, blade):
                     export_policy=Reference(name=module.params["export_policy"])
                 )
             )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=export_attr,
@@ -552,14 +568,20 @@ def create_fs(module, blade):
                         get_error_message(res),
                     )
                 )
-        if SMB_POLICY_API_VERSION in api_version and module.params["smb"]:
+        if (
+            LooseVersion(SMB_POLICY_API_VERSION) <= LooseVersion(api_version)
+            and module.params["smb"]
+        ):
             if module.params["client_policy"]:
                 export_attr = FileSystemPatch(
                     smb=Smb(
                         client_policy=Reference(name=module.params["client_policy"])
                     )
                 )
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.patch_file_systems(
                         names=[fs_name],
                         file_system=export_attr,
@@ -582,7 +604,10 @@ def create_fs(module, blade):
                 export_attr = FileSystemPatch(
                     smb=Smb(share_policy=Reference(name=module.params["share_policy"]))
                 )
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.patch_file_systems(
                         names=[fs_name],
                         file_system=export_attr,
@@ -602,7 +627,7 @@ def create_fs(module, blade):
                             get_error_message(res),
                         )
                     )
-            if CA_API_VERSION in api_version:
+            if LooseVersion(CA_API_VERSION) <= LooseVersion(api_version):
                 ca_attr = FileSystemPatch(
                     smb=Smb(
                         continuous_availability_enabled=module.params[
@@ -610,7 +635,10 @@ def create_fs(module, blade):
                         ]
                     )
                 )
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.patch_file_systems(
                         names=[fs_name],
                         file_system=ca_attr,
@@ -626,11 +654,17 @@ def create_fs(module, blade):
                             get_error_message(res),
                         )
                     )
-            if GOWNER_API_VERSION in api_version and module.params["group_ownership"]:
+            if (
+                LooseVersion(GOWNER_API_VERSION) <= LooseVersion(api_version)
+                and module.params["group_ownership"]
+            ):
                 go_attr = FileSystemPatch(
                     group_ownership=module.params["group_ownership"]
                 )
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.patch_file_systems(
                         names=[fs_name],
                         file_system=go_attr,
@@ -646,7 +680,10 @@ def create_fs(module, blade):
                             get_error_message(res),
                         )
                     )
-            if CONTEXT_API_VERSION in api_version and module.params["storage_class"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["storage_class"]
+            ):
                 sc_patch = {
                     "names": [fs_name],
                     "file_system": FileSystemPatch(
@@ -684,9 +721,12 @@ def modify_fs(module, blade):
     fs_name = module.params["name"]
     if realm_name and "::" not in fs_name:
         fs_name = "{0}::{1}".format(realm_name, fs_name)
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if module.params["policy"] and module.params["policy_state"] == "present":
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_policies(
                 names=[module.params["policy"]],
                 context_names=[module.params["context"]],
@@ -697,7 +737,10 @@ def modify_fs(module, blade):
             module.fail_json(
                 msg="Policy {0} doesn't exist.".format(module.params["policy"])
             )
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_policies_file_systems(
                 policy_names=[module.params["policy"]],
                 member_names=[fs_name],
@@ -709,7 +752,10 @@ def modify_fs(module, blade):
                 member_names=[fs_name],
             )
         if res.status_code != 200 or getattr(res, "total_item_count", 0) == 0:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_policies_file_systems(
                     policy_names=[module.params["policy"]],
                     member_names=[fs_name],
@@ -730,7 +776,10 @@ def modify_fs(module, blade):
                     )
                 )
     if module.params["policy"] and module.params["policy_state"] == "absent":
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_policies(
                 names=[module.params["policy"]],
                 context_names=[module.params["context"]],
@@ -738,7 +787,10 @@ def modify_fs(module, blade):
         else:
             res = blade.get_policies(names=[module.params["policy"]])
         if res.status_code == 200:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.get_policies_file_systems(
                     policy_names=[module.params["policy"]],
                     member_names=[fs_name],
@@ -750,7 +802,10 @@ def modify_fs(module, blade):
                     member_names=[fs_name],
                 )
             if res.status_code == 200:
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.delete_policies_file_systems(
                         policy_names=[module.params["policy"]],
                         member_names=[fs_name],
@@ -849,7 +904,10 @@ def modify_fs(module, blade):
             mod_fs = True
         if not module.params["promote"] and fsys.promotion_status == "promoted":
             # Demotion only allowed on filesystems in a replica-link
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.get_file_system_replica_links(
                     local_file_system_names=[fs_name],
                     context_names=[module.params["context"]],
@@ -869,7 +927,10 @@ def modify_fs(module, blade):
     if mod_fs:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 if new_fsys["destroyed"] != fsys.destroyed:
                     delres = blade.patch_file_systems(
                         names=[fs_name],
@@ -949,7 +1010,10 @@ def modify_fs(module, blade):
                         fs_name, get_error_message(res)
                     )
                 )
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         current_fs = list(
             blade.get_file_systems(
                 context_names=[module.params["context"]],
@@ -961,7 +1025,7 @@ def modify_fs(module, blade):
             blade.get_file_systems(filter="name='" + fs_name + "'").items
         )[0]
     if (
-        EXPORT_POLICY_API_VERSION in api_version
+        LooseVersion(EXPORT_POLICY_API_VERSION) <= LooseVersion(api_version)
         and module.params["export_policy"]
         and (current_fs.nfs.v3_enabled or current_fs.nfs.v4_1_enabled)
     ):
@@ -979,7 +1043,10 @@ def modify_fs(module, blade):
                     export_policy=Reference(name=module.params["export_policy"])
                 )
             )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=export_attr,
@@ -1013,7 +1080,10 @@ def modify_fs(module, blade):
                 rules_attr = FileSystemPatch(
                     nfs=NfsPatch(rules=module.params["nfs_rules"])
                 )
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.patch_file_systems(
                         names=[fs_name],
                         file_system=rules_attr,
@@ -1032,7 +1102,7 @@ def modify_fs(module, blade):
                         )
                     )
     if (
-        SMB_POLICY_API_VERSION in api_version
+        LooseVersion(SMB_POLICY_API_VERSION) <= LooseVersion(api_version)
         and module.params["client_policy"]
         and current_fs.smb.enabled
     ):
@@ -1047,7 +1117,10 @@ def modify_fs(module, blade):
             client_attr = FileSystemPatch(
                 smb=Smb(client_policy=Reference(name=module.params["client_policy"]))
             )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=client_attr,
@@ -1065,7 +1138,7 @@ def modify_fs(module, blade):
                     )
                 )
     if (
-        SMB_POLICY_API_VERSION in api_version
+        LooseVersion(SMB_POLICY_API_VERSION) <= LooseVersion(api_version)
         and module.params["share_policy"]
         and current_fs.smb.enabled
     ):
@@ -1080,7 +1153,10 @@ def modify_fs(module, blade):
             share_attr = FileSystemPatch(
                 smb=Smb(share_policy=Reference(name=module.params["share_policy"]))
             )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=share_attr,
@@ -1097,7 +1173,10 @@ def modify_fs(module, blade):
                         get_error_message(res),
                     )
                 )
-    if CA_API_VERSION in api_version and current_fs.smb.enabled:
+    if (
+        LooseVersion(CA_API_VERSION) <= LooseVersion(api_version)
+        and current_fs.smb.enabled
+    ):
         if (
             module.params["continuous_availability"]
             != current_fs.smb.continuous_availability_enabled
@@ -1111,7 +1190,10 @@ def modify_fs(module, blade):
                     ]
                 )
             )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=ca_attr,
@@ -1127,12 +1209,15 @@ def modify_fs(module, blade):
                         get_error_message(res),
                     )
                 )
-    if GOWNER_API_VERSION in api_version:
+    if LooseVersion(GOWNER_API_VERSION) <= LooseVersion(api_version):
         if module.params["group_ownership"] != current_fs.group_ownership:
             change_go = True
         if not module.check_mode and change_go:
             go_attr = FileSystemPatch(group_ownership=module.params["group_ownership"])
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_file_systems(
                     names=[fs_name],
                     file_system=go_attr,
@@ -1148,7 +1233,10 @@ def modify_fs(module, blade):
                         get_error_message(res),
                     )
                 )
-    if CONTEXT_API_VERSION in api_version and module.params["storage_class"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["storage_class"]
+    ):
         if module.params["storage_class"] != current_fs.storage_class:
             change_sc = True
         sc_patch = {
@@ -1333,8 +1421,11 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # Only default the context to the local array name when this array is a
         # member of a fleet. A standalone array is "not in a fleet" and rejects
         # fleet context, so leave context unset - no context_names is then sent.

--- a/plugins/modules/purefb_fs_replica.py
+++ b/plugins/modules/purefb_fs_replica.py
@@ -104,8 +104,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 DELETE_RL_API_VERSION = "2.10"
@@ -297,7 +301,7 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
 
     local_fs = get_local_fs(module, blade)
     local_replica_link = get_local_rl(module, blade)
@@ -325,7 +329,7 @@ def main():
     if state == "present" and not local_replica_link:
         create_rl(module, blade)
     elif state == "absent" and local_replica_link:
-        if DELETE_RL_API_VERSION not in versions:
+        if LooseVersion(DELETE_RL_API_VERSION) > LooseVersion(versions):
             module.fail_json("Deleting a replica link requires REST 2.10 or higher")
         else:
             delete_rl(module, blade)

--- a/plugins/modules/purefb_groupquota.py
+++ b/plugins/modules/purefb_groupquota.py
@@ -134,17 +134,24 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
-    get_filesystem,
     get_error_message,
+    get_filesystem,
+    get_rest_api_version,
 )
 
 
 def get_quota(module, blade):
     """Return Filesystem User Quota or None"""
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if module.params["gid"]:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_quotas_groups(
                 file_system_names=[module.params["name"]],
                 filter="group.id=" + str(module.params["gid"]),
@@ -156,7 +163,10 @@ def get_quota(module, blade):
                 filter="group.id=" + str(module.params["gid"]),
             )
     else:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_quotas_groups(
                 file_system_names=[module.params["name"]],
                 filter="group.name='" + module.params["gname"] + "'",
@@ -175,10 +185,13 @@ def get_quota(module, blade):
 def create_quota(module, blade):
     """Create Filesystem User Quota"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         if module.params["gid"]:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_quotas_groups(
                     file_system_names=[module.params["name"]],
                     gids=[module.params["gid"]],
@@ -204,7 +217,10 @@ def create_quota(module, blade):
                     )
                 )
         else:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_quotas_groups(
                     file_system_names=[module.params["name"]],
                     group_names=[module.params["gname"]],
@@ -235,13 +251,16 @@ def create_quota(module, blade):
 def update_quota(module, blade):
     """Upodate Filesystem User Quota"""
     changed = False
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     current_quota = get_quota(module, blade)
     if current_quota.quota != human_to_bytes(module.params["quota"]):
         changed = True
         if not module.check_mode:
             if module.params["gid"]:
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.patch_quotas_groups(
                         file_system_names=[module.params["name"]],
                         gids=[module.params["gid"]],
@@ -267,7 +286,10 @@ def update_quota(module, blade):
                         )
                     )
             else:
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.patch_quotas_groups(
                         file_system_names=[module.params["name"]],
                         group_names=[module.params["gname"]],
@@ -298,10 +320,13 @@ def update_quota(module, blade):
 def delete_quota(module, blade):
     """Delete Filesystem User Quota"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         if module.params["gid"]:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.delete_quotas_groups(
                     file_system_names=[module.params["name"]],
                     gids=[module.params["gid"]],
@@ -319,7 +344,10 @@ def delete_quota(module, blade):
                     )
                 )
         else:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.delete_quotas_groups(
                     file_system_names=[module.params["name"]],
                     group_names=[module.params["gname"]],
@@ -368,8 +396,11 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):

--- a/plugins/modules/purefb_hardware.py
+++ b/plugins/modules/purefb_hardware.py
@@ -89,6 +89,7 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
 )
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 
@@ -114,7 +115,7 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
 
     if module.params["speed"]:
         speed = module.params["speed"] * 1000000000

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -90,6 +90,13 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
+    get_error_message,
+    get_rest_api_version,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.time_utils import (
     milliseconds_to_time,
 )
@@ -124,7 +131,12 @@ def _bytes_to_human(bytes_number):
 
 def generate_default_dict(blade):
     default_info = {}
-    api_version = list(blade.get_versions().items)[0]
+    # NOTE(latent bug): this previously read list(blade.get_versions().items)[0]
+    # - a single version string - so the SECURITY/NAP/RA_DURATION gates below
+    # were substring checks that could never match as intended. The
+    # get_rest_api_version()/LooseVersion migration makes these gates evaluate
+    # correctly, so the gated sections can now appear where they never did.
+    api_version = get_rest_api_version(blade)
     defaults = list(blade.get_arrays().items)[0]
     default_info["flashblade_name"] = defaults.name
     default_info["purity_version"] = defaults.version
@@ -195,7 +207,7 @@ def generate_default_dict(blade):
     default_info["smb_mode"] = getattr(defaults, "smb_mode", None)
     default_info["timezone"] = defaults.time_zone
     default_info["product_type"] = getattr(defaults, "product_type", "Unknown")
-    if SECURITY_API_VERSION in api_version:
+    if LooseVersion(SECURITY_API_VERSION) <= LooseVersion(api_version):
         dar = defaults.encryption.data_at_rest
         default_info["encryption"] = {
             "data_at_rest_enabled": dar.enabled,
@@ -208,7 +220,7 @@ def generate_default_dict(blade):
             keyname = key.name
             default_info["support_keys"][keyname] = {key.verification_key}
         default_info["security_update"] = getattr(defaults, "security_update", None)
-    if NAP_API_VERSION in api_version:
+    if LooseVersion(NAP_API_VERSION) <= LooseVersion(api_version):
         default_info["network_access_protocol"] = getattr(
             defaults.network_access_policy, "name", "None"
         )
@@ -230,7 +242,7 @@ def generate_default_dict(blade):
         "ra_opened": ra_opened,
         "ra_status": ra_info.remote_assist_status,
     }
-    if RA_DURATION_API_VERSION in api_version:
+    if LooseVersion(RA_DURATION_API_VERSION) <= LooseVersion(api_version):
         default_info["remote_assist"]["ra_duration"] = ra_info.remote_assist_duration
     return default_info
 
@@ -321,7 +333,7 @@ def generate_perf_dict(blade):
 
 def generate_config_dict(blade):
     config_info = {}
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     config_info["dns"] = {}
     dns_configs = list(blade.get_dns().items)
     for config in dns_configs:
@@ -466,7 +478,7 @@ def generate_config_dict(blade):
             config_info["snmp_managers"][mgr_name]["user"] = getattr(
                 manager.v3, "user", None
             )
-    if SMTP_ENCRYPT_API_VERSION in api_version:
+    if LooseVersion(SMTP_ENCRYPT_API_VERSION) <= LooseVersion(api_version):
         config_info["saml2sso"] = {}
         saml2 = list(blade.get_sso_saml2_idps().items)
         if saml2:
@@ -707,7 +719,7 @@ def generate_capacity_dict(blade):
 def generate_snap_dict(blade):
     snap_info = {}
     snaps = list(blade.get_file_system_snapshots().items)
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     for snap in snaps:
         snapshot = snap.name
         snap_info[snapshot] = {
@@ -727,7 +739,7 @@ def generate_snap_dict(blade):
             "source_location": snap.source.location.name,
             "policies": [],
         }
-        if PUBLIC_API_VERSION in api_version:
+        if LooseVersion(PUBLIC_API_VERSION) <= LooseVersion(api_version):
             if hasattr(snap, "policies"):
                 for policy in snap.policies:
                     snap_info[snapshot]["policies"].append(
@@ -1354,7 +1366,7 @@ def main():
     module = AnsibleModule(argument_spec, supports_check_mode=True)
 
     blade = get_system(module)
-    api_versions = list(blade.get_versions().items)
+    api_versions = get_rest_api_version(blade)
 
     if not module.params["gather_subset"]:
         module.params["gather_subset"] = ["minimum"]
@@ -1432,19 +1444,27 @@ def main():
         info["kerberos"] = generate_kerb_dict(blade)
     if "policies" in subset or "all" in subset:
         info["access_policies"] = generate_object_store_access_policies_dict(blade)
-        if PUBLIC_API_VERSION in api_versions:
+        if LooseVersion(PUBLIC_API_VERSION) <= LooseVersion(api_versions):
             info["bucket_access_policies"] = generate_bucket_access_policies_dict(blade)
             info["bucket_cross_origin_policies"] = (
                 generate_bucket_cross_object_policies_dict(blade)
             )
         info["export_policies"] = generate_nfs_export_policies_dict(blade)
-        if SMB_CLIENT_API_VERSION in api_versions:
+        if LooseVersion(SMB_CLIENT_API_VERSION) <= LooseVersion(api_versions):
             info["share_policies"] = generate_smb_client_policies_dict(blade)
-        if FLEET_API_VERSION in api_versions:
+        if LooseVersion(FLEET_API_VERSION) <= LooseVersion(api_versions):
             info["fleet"] = generate_fleet_dict(blade)
-    if "drives" in subset or "all" in subset and DRIVES_API_VERSION in api_versions:
+    if (
+        "drives" in subset
+        or "all" in subset
+        and LooseVersion(DRIVES_API_VERSION) <= LooseVersion(api_versions)
+    ):
         info["drives"] = generate_drives_dict(blade)
-    if "servers" in subset or "all" in subset and SERVERS_API_VERSION in api_versions:
+    if (
+        "servers" in subset
+        or "all" in subset
+        and LooseVersion(SERVERS_API_VERSION) <= LooseVersion(api_versions)
+    ):
         info["servers"] = generate_servers_dict(blade)
     module.exit_json(changed=False, purefb_info=info)
 

--- a/plugins/modules/purefb_info.py
+++ b/plugins/modules/purefb_info.py
@@ -94,7 +94,6 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.version import
     LooseVersion,
 )
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
-    get_error_message,
     get_rest_api_version,
 )
 from ansible_collections.everpure.flashblade.plugins.module_utils.time_utils import (

--- a/plugins/modules/purefb_inventory.py
+++ b/plugins/modules/purefb_inventory.py
@@ -59,7 +59,6 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.version import
     LooseVersion,
 )
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
-    get_error_message,
     get_rest_api_version,
 )
 

--- a/plugins/modules/purefb_inventory.py
+++ b/plugins/modules/purefb_inventory.py
@@ -55,12 +55,19 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
+    get_error_message,
+    get_rest_api_version,
+)
 
 PART_NUMBER_API_VERSION = "2.8"
 
 
 def generate_hardware_dict(blade):
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     hw_info = {
         "modules": {},
         "ethernet": {},
@@ -83,7 +90,7 @@ def generate_hardware_dict(blade):
             "model": component.model,
             "identify": component.identify_enabled,
         }
-        if PART_NUMBER_API_VERSION in api_version:
+        if LooseVersion(PART_NUMBER_API_VERSION) <= LooseVersion(api_version):
             hw_info["modules"][component_name]["part_number"] = component.part_number
     components = list(blade.get_hardware(filter="type='eth'").items)
     for component in components:
@@ -95,7 +102,7 @@ def generate_hardware_dict(blade):
             "model": component.model,
             "speed": component.speed,
         }
-        if PART_NUMBER_API_VERSION in api_version:
+        if LooseVersion(PART_NUMBER_API_VERSION) <= LooseVersion(api_version):
             hw_info["ethernet"][component_name]["part_number"] = component.part_number
     components = list(blade.get_hardware(filter="type='mgmt_port'").items)
     for component in components:
@@ -107,7 +114,7 @@ def generate_hardware_dict(blade):
             "model": component.model,
             "speed": component.speed,
         }
-        if PART_NUMBER_API_VERSION in api_version:
+        if LooseVersion(PART_NUMBER_API_VERSION) <= LooseVersion(api_version):
             hw_info["mgmt_ports"][component_name]["part_number"] = component.part_number
     components = list(blade.get_hardware(filter="type='fan'").items)
     for component in components:
@@ -117,7 +124,7 @@ def generate_hardware_dict(blade):
             "status": component.status,
             "identify": component.identify_enabled,
         }
-        if PART_NUMBER_API_VERSION in api_version:
+        if LooseVersion(PART_NUMBER_API_VERSION) <= LooseVersion(api_version):
             hw_info["fans"][component_name]["part_number"] = component.part_number
     components = list(blade.get_hardware(filter="type='fb'").items)
     for component in components:
@@ -130,7 +137,7 @@ def generate_hardware_dict(blade):
             "temperature": component.temperature,
             "identify": component.identify_enabled,
         }
-        if PART_NUMBER_API_VERSION in api_version:
+        if LooseVersion(PART_NUMBER_API_VERSION) <= LooseVersion(api_version):
             hw_info["blades"][component_name]["part_number"] = component.part_number
     components = list(blade.get_hardware(filter="type='pwr'").items)
     for component in components:
@@ -141,7 +148,7 @@ def generate_hardware_dict(blade):
             "serial": component.serial,
             "model": component.model,
         }
-        if PART_NUMBER_API_VERSION in api_version:
+        if LooseVersion(PART_NUMBER_API_VERSION) <= LooseVersion(api_version):
             hw_info["power"][component_name]["part_number"] = component.part_number
     components = list(blade.get_hardware(filter="type='xfm'").items)
     for component in components:
@@ -152,7 +159,7 @@ def generate_hardware_dict(blade):
             "serial": component.serial,
             "model": component.model,
         }
-        if PART_NUMBER_API_VERSION in api_version:
+        if LooseVersion(PART_NUMBER_API_VERSION) <= LooseVersion(api_version):
             hw_info["switch"][component_name]["part_number"] = component.part_number
     components = list(blade.get_hardware(filter="type='ch'").items)
     for component in components:
@@ -164,7 +171,7 @@ def generate_hardware_dict(blade):
             "serial": component.serial,
             "model": component.model,
         }
-        if PART_NUMBER_API_VERSION in api_version:
+        if LooseVersion(PART_NUMBER_API_VERSION) <= LooseVersion(api_version):
             hw_info["chassis"][component_name]["part_number"] = component.part_number
     components = list(blade.get_hardware(filter="type='bay'").items)
     for component in components:
@@ -177,7 +184,7 @@ def generate_hardware_dict(blade):
             "model": component.model,
             "identify": component.identify_enabled,
         }
-        if PART_NUMBER_API_VERSION in api_version:
+        if LooseVersion(PART_NUMBER_API_VERSION) <= LooseVersion(api_version):
             hw_info["bays"][component_name]["part_number"] = component.part_number
 
     return hw_info

--- a/plugins/modules/purefb_lifecycle.py
+++ b/plugins/modules/purefb_lifecycle.py
@@ -132,11 +132,15 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.time_utils import (
     time_to_milliseconds,
 )
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 from datetime import datetime
 
@@ -144,8 +148,11 @@ CONTEXT_API_VERSION = "2.17"
 
 
 def _get_bucket(module, blade):
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_buckets(
             names=[module.params["bucket"]], context_names=[module.params["context"]]
         )
@@ -173,9 +180,12 @@ def _convert_date_to_epoch(module):
 def delete_rule(module, blade):
     """Delete lifecycle rule"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.delete_lifecycle_rules(
                 names=[module.params["bucket"] + "/" + module.params["name"]],
                 context_names=[module.params["context"]],
@@ -198,7 +208,7 @@ def delete_rule(module, blade):
 def create_rule(module, blade):
     """Create lifecycle policy"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if (
         not module.params["keep_previous_for"]
         and not module.params["keep_current_until"]
@@ -232,7 +242,10 @@ def create_rule(module, blade):
             prefix=module.params["prefix"],
         )
         if attr.keep_current_version_until:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_lifecycle_rules(
                     rule=attr,
                     confirm_date=True,
@@ -241,7 +254,10 @@ def create_rule(module, blade):
             else:
                 res = blade.post_lifecycle_rules(rule=attr, confirm_date=True)
         else:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_lifecycle_rules(
                     rule=attr, context_names=[module.params["context"]]
                 )
@@ -257,7 +273,10 @@ def create_rule(module, blade):
             )
         if not module.params["enabled"]:
             attr = LifecycleRulePatch(enabled=module.params["enabled"])
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_lifecycle_rules(
                     names=[module.params["bucket"] + "/" + module.params["name"]],
                     lifecycle=attr,
@@ -279,7 +298,7 @@ def create_rule(module, blade):
 def update_rule(module, blade, rule):
     """Update snapshot policy"""
     changed = False
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     current_rule = {
         "prefix": rule.prefix,
         "abort_incomplete_multipart_uploads_after": rule.abort_incomplete_multipart_uploads_after,
@@ -330,7 +349,10 @@ def update_rule(module, blade, rule):
                 enabled=new_rule["enabled"],
             )
             if attr.keep_current_version_until:
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.patch_lifecycle_rules(
                         names=[module.params["bucket"] + "/" + module.params["name"]],
                         lifecycle=attr,
@@ -344,7 +366,10 @@ def update_rule(module, blade, rule):
                         confirm_date=True,
                     )
             else:
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.patch_lifecycle_rules(
                         names=[module.params["bucket"] + "/" + module.params["name"]],
                         lifecycle=attr,
@@ -396,8 +421,11 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):
@@ -429,7 +457,10 @@ def main():
     rule = None
     if module.params["keep_current_until"]:
         module.params["keep_current_until"] = _convert_date_to_epoch(module)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_lifecycle_rules(
             names=[module.params["bucket"] + "/" + module.params["name"]],
             context_names=[module.params["context"]],

--- a/plugins/modules/purefb_pingtrace.py
+++ b/plugins/modules/purefb_pingtrace.py
@@ -118,8 +118,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 import re
 
@@ -278,9 +282,9 @@ def main():
     module = AnsibleModule(argument_spec, supports_check_mode=True)
 
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
 
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashBlade REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)

--- a/plugins/modules/purefb_policy.py
+++ b/plugins/modules/purefb_policy.py
@@ -629,9 +629,13 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     _findstr,
     get_error_message,
+    get_rest_api_version,
 )
 from ansible_collections.everpure.flashblade.plugins.module_utils.time_utils import (
     time_to_milliseconds,
@@ -727,11 +731,14 @@ def delete_smb_share_policy(module, blade):
     """
 
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     policy_delete = True
     if module.params["principal"]:
         policy_delete = False
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             prin_rule = blade.get_smb_share_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="principal='" + module.params["principal"] + "'",
@@ -746,7 +753,10 @@ def delete_smb_share_policy(module, blade):
             rule = list(prin_rule.items)[0]
             changed = True
             if not module.check_mode:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.delete_smb_share_policies_rules(
                         names=[rule.name], context_names=[module.params["context"]]
                     )
@@ -764,7 +774,10 @@ def delete_smb_share_policy(module, blade):
     if policy_delete:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.delete_smb_share_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -784,9 +797,12 @@ def rename_smb_share_policy(module, blade):
     """Rename SMB Share Policy"""
 
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.patch_smb_share_policies(
                 names=[module.params["name"]],
                 policy=SmbSharePolicy(name=module.params["rename"]),
@@ -811,9 +827,12 @@ def rename_smb_share_policy(module, blade):
 def create_smb_share_policy(module, blade):
     """Create SMB Share Policy"""
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.post_smb_share_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -826,7 +845,10 @@ def create_smb_share_policy(module, blade):
                 )
             )
         if not module.params["enabled"]:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.patch_smb_share_policies(
                     policy=SmbSharePolicy(enabled=False),
                     names=[module.params["name"]],
@@ -837,7 +859,10 @@ def create_smb_share_policy(module, blade):
                     policy=SmbSharePolicy(enabled=False), names=[module.params["name"]]
                 )
             if res.status_code != 200:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     blade.delete_smb_share_policies(
                         names=[module.params["name"]],
                         context_names=[module.params["context"]],
@@ -858,7 +883,10 @@ def create_smb_share_policy(module, blade):
                 read=module.params["read"],
                 full_control=module.params["full_control"],
             )
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.post_smb_share_policies_rules(
                     policy_names=[module.params["name"]],
                     rule=rule,
@@ -883,9 +911,12 @@ def update_smb_share_policy(module, blade):
     """Update SMB Share Policy Rule"""
 
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if module.params["principal"]:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             current_policy_rule = blade.get_smb_share_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="principal='" + module.params["principal"] + "'",
@@ -919,7 +950,10 @@ def update_smb_share_policy(module, blade):
                     before_name = (
                         module.params["name"] + "." + str(module.params["before_rule"])
                     )
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.post_smb_share_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -933,7 +967,10 @@ def update_smb_share_policy(module, blade):
                             before_rule_name=before_name,
                         )
                 else:
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.post_smb_share_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -1021,7 +1058,10 @@ def update_smb_share_policy(module, blade):
                             else old_policy_rule.full_control
                         ),
                     )
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.patch_smb_share_policies_rules(
                             names=[
                                 module.params["name"] + "." + str(old_policy_rule.index)
@@ -1054,7 +1094,10 @@ def update_smb_share_policy(module, blade):
                     before_name = (
                         module.params["name"] + "." + str(module.params["before_rule"])
                     )
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.patch_smb_share_policies_rules(
                             names=[
                                 module.params["name"] + "." + str(old_policy_rule.index)
@@ -1080,7 +1123,10 @@ def update_smb_share_policy(module, blade):
                                 get_error_message(res),
                             )
                         )
-    if CONTEXT_API_VERSION in versions and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+        and module.params["context"]
+    ):
         current_policy = list(
             blade.get_smb_share_policies(names=[module.params["name"]]).items,
             context_names=[module.params["context"]],
@@ -1092,7 +1138,10 @@ def update_smb_share_policy(module, blade):
     if current_policy.enabled != module.params["enabled"]:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.patch_smb_share_policies(
                     policy=SmbSharePolicy(enabled=module.params["enabled"]),
                     names=[module.params["name"]],
@@ -1119,11 +1168,14 @@ def delete_smb_client_policy(module, blade):
     """
 
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     policy_delete = True
     if module.params["client"]:
         policy_delete = False
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.get_smb_client_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -1142,7 +1194,10 @@ def delete_smb_client_policy(module, blade):
                 if module.params["client"] == rule.client:
                     changed = True
                     if not module.check_mode:
-                        if CONTEXT_API_VERSION in versions and module.params["context"]:
+                        if (
+                            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                            and module.params["context"]
+                        ):
                             res = blade.delete_smb_client_policies_rules(
                                 names=[rule.name],
                                 context_names=[module.params["context"]],
@@ -1167,7 +1222,8 @@ def delete_smb_client_policy(module, blade):
                         changed = True
                         if not module.check_mode:
                             if (
-                                CONTEXT_API_VERSION in versions
+                                LooseVersion(CONTEXT_API_VERSION)
+                                <= LooseVersion(versions)
                                 and module.params["context"]
                             ):
                                 res = blade.delete_smb_client_policies_rules(
@@ -1190,7 +1246,10 @@ def delete_smb_client_policy(module, blade):
     if policy_delete:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.delete_smb_client_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -1210,9 +1269,12 @@ def rename_smb_client_policy(module, blade):
     """Rename SMB Client Policy"""
 
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.patch_smb_client_policies(
                 names=[module.params["name"]],
                 policy=SmbClientPolicy(name=module.params["rename"]),
@@ -1237,9 +1299,12 @@ def rename_smb_client_policy(module, blade):
 def create_smb_client_policy(module, blade):
     """Create SMB Client Policy"""
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.post_smb_client_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -1252,7 +1317,10 @@ def create_smb_client_policy(module, blade):
                 )
             )
         if not module.params["enabled"]:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.patch_smb_client_policies(
                     policy=SmbClientPolicy(enabled=False),
                     names=[module.params["name"]],
@@ -1263,7 +1331,10 @@ def create_smb_client_policy(module, blade):
                     policy=SmbClientPolicy(enabled=False), names=[module.params["name"]]
                 )
             if res.status_code != 200:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     blade.delete_smb_client_policies(
                         names=[module.params["name"]],
                         context_names=[module.params["context"]],
@@ -1278,7 +1349,7 @@ def create_smb_client_policy(module, blade):
         if not module.params["client"]:
             module.fail_json(msg="client is required to create a new rule")
         else:
-            if SMB_ENCRYPT_API_VERSION in versions:
+            if LooseVersion(SMB_ENCRYPT_API_VERSION) <= LooseVersion(versions):
                 rule = SmbClientPolicyRule(
                     client=module.params["client"],
                     permission=module.params["permission"],
@@ -1291,7 +1362,10 @@ def create_smb_client_policy(module, blade):
                     access=module.params["access"],
                     permission=module.params["permission"],
                 )
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.post_smb_client_policies_rules(
                     policy_names=[module.params["name"]],
                     rule=rule,
@@ -1315,9 +1389,12 @@ def create_smb_client_policy(module, blade):
 def create_network_access_policy(module, blade):
     """Create Network Access Policy"""
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.post_network_access_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -1330,7 +1407,10 @@ def create_network_access_policy(module, blade):
                 )
             )
         if not module.params["enabled"]:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.patch_network_access_policies(
                     policy=SmbClientPolicy(enabled=False),
                     names=[module.params["name"]],
@@ -1341,7 +1421,10 @@ def create_network_access_policy(module, blade):
                     policy=SmbClientPolicy(enabled=False), names=[module.params["name"]]
                 )
             if res.status_code != 200:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     blade.delete_network_access_policies(
                         names=[module.params["name"]],
                         context_names=[module.params["context"]],
@@ -1361,7 +1444,10 @@ def create_network_access_policy(module, blade):
                 effect=module.params["effect"],
                 interfaces=module.params["interfaces"],
             )
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.post_network_access_policies_rules(
                     policy_names=[module.params["name"]],
                     rule=rule,
@@ -1385,12 +1471,15 @@ def create_network_access_policy(module, blade):
 def create_worm_data_policy(module, blade):
     """Create WORM Data Policy"""
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
         min_retention = time_to_milliseconds(module.params["min_retention"])
         max_retention = time_to_milliseconds(module.params["max_retention"])
         default_retention = time_to_milliseconds(module.params["default_retention"])
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.post_worm_data_policies(
                 policy=WormDataPolicy(
                     enabled=module.params["enabled"],
@@ -1416,7 +1505,10 @@ def create_worm_data_policy(module, blade):
                 names=[module.params["name"]],
             )
         if res.status_code != 200:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 blade.delete_worm_data_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -1435,9 +1527,12 @@ def update_smb_client_policy(module, blade):
     """Update SMB Client Policy Rule"""
 
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if module.params["client"]:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             current_policy_rule = blade.get_smb_client_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -1456,7 +1551,7 @@ def update_smb_client_policy(module, blade):
             current_policy_rule.status_code != 200
             or current_policy_rule.total_item_count == 0
         ):
-            if SMB_ENCRYPT_API_VERSION in versions:
+            if LooseVersion(SMB_ENCRYPT_API_VERSION) <= LooseVersion(versions):
                 rule = SmbClientPolicyRule(
                     client=module.params["client"],
                     permission=module.params["permission"],
@@ -1475,7 +1570,10 @@ def update_smb_client_policy(module, blade):
                     before_name = (
                         module.params["name"] + "." + str(module.params["before_rule"])
                     )
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.post_smb_client_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -1489,7 +1587,10 @@ def update_smb_client_policy(module, blade):
                             before_rule_name=before_name,
                         )
                 else:
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.post_smb_client_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -1518,7 +1619,7 @@ def update_smb_client_policy(module, blade):
                     if cli.client == "*":
                         cli_count = cli
                 if not cli_count:
-                    if SMB_ENCRYPT_API_VERSION in versions:
+                    if LooseVersion(SMB_ENCRYPT_API_VERSION) <= LooseVersion(versions):
                         rule = SmbClientPolicyRule(
                             client=module.params["client"],
                             permission=module.params["permission"],
@@ -1536,7 +1637,8 @@ def update_smb_client_policy(module, blade):
                     if not module.check_mode:
                         if module.params["before_rule"]:
                             if (
-                                CONTEXT_API_VERSION in versions
+                                LooseVersion(CONTEXT_API_VERSION)
+                                <= LooseVersion(versions)
                                 and module.params["context"]
                             ):
                                 res = blade.post_smb_client_policies_rules(
@@ -1561,7 +1663,8 @@ def update_smb_client_policy(module, blade):
                                 )
                         else:
                             if (
-                                CONTEXT_API_VERSION in versions
+                                LooseVersion(CONTEXT_API_VERSION)
+                                <= LooseVersion(versions)
                                 and module.params["context"]
                             ):
                                 res = blade.post_smb_client_policies_rules(
@@ -1585,7 +1688,7 @@ def update_smb_client_policy(module, blade):
                             )
             if not done:
                 old_policy_rule = rules[0]
-                if SMB_ENCRYPT_API_VERSION in versions:
+                if LooseVersion(SMB_ENCRYPT_API_VERSION) <= LooseVersion(versions):
                     current_rule = {
                         "client": sorted(old_policy_rule.client),
                         "permission": sorted(old_policy_rule.permission),
@@ -1596,7 +1699,7 @@ def update_smb_client_policy(module, blade):
                         "client": sorted(old_policy_rule.client),
                         "permission": sorted(old_policy_rule.permission),
                     }
-                if SMB_ENCRYPT_API_VERSION in versions:
+                if LooseVersion(SMB_ENCRYPT_API_VERSION) <= LooseVersion(versions):
                     if module.params["smb_encryption"]:
                         new_encryption = module.params["smb_encryption"]
                     else:
@@ -1609,7 +1712,7 @@ def update_smb_client_policy(module, blade):
                     new_client = sorted(module.params["client"])
                 else:
                     new_client = sorted(current_rule["client"])
-                if SMB_ENCRYPT_API_VERSION in versions:
+                if LooseVersion(SMB_ENCRYPT_API_VERSION) <= LooseVersion(versions):
                     new_rule = {
                         "client": new_client,
                         "permission": new_permission,
@@ -1637,7 +1740,9 @@ def update_smb_client_policy(module, blade):
                             if module.params["permission"]
                             else old_policy_rule.permission
                         )
-                        if SMB_ENCRYPT_API_VERSION in versions:
+                        if LooseVersion(SMB_ENCRYPT_API_VERSION) <= LooseVersion(
+                            versions
+                        ):
                             rule = SmbClientPolicyRule(
                                 client=rule_client,
                                 permission=rule_permission,
@@ -1648,7 +1753,10 @@ def update_smb_client_policy(module, blade):
                                 client=rule_client,
                                 permission=rule_permission,
                             )
-                        if CONTEXT_API_VERSION in versions and module.params["context"]:
+                        if (
+                            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                            and module.params["context"]
+                        ):
                             res = blade.patch_smb_client_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -1687,7 +1795,10 @@ def update_smb_client_policy(module, blade):
                             + "."
                             + str(module.params["before_rule"])
                         )
-                        if CONTEXT_API_VERSION in versions and module.params["context"]:
+                        if (
+                            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                            and module.params["context"]
+                        ):
                             res = blade.patch_smb_client_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -1717,7 +1828,10 @@ def update_smb_client_policy(module, blade):
                                     get_error_message(res),
                                 )
                             )
-    if CONTEXT_API_VERSION in versions and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+        and module.params["context"]
+    ):
         current_policy = list(
             blade.get_smb_client_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -1730,7 +1844,10 @@ def update_smb_client_policy(module, blade):
     if current_policy.enabled != module.params["enabled"]:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.patch_smb_client_policies(
                     policy=SmbClientPolicy(enabled=module.params["enabled"]),
                     names=[module.params["name"]],
@@ -1757,11 +1874,14 @@ def delete_nfs_policy(module, blade):
     """
 
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     policy_delete = True
     if module.params["client"]:
         policy_delete = False
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.get_nfs_export_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -1780,7 +1900,10 @@ def delete_nfs_policy(module, blade):
                 if module.params["client"] == rule.client:
                     changed = True
                     if not module.check_mode:
-                        if CONTEXT_API_VERSION in versions and module.params["context"]:
+                        if (
+                            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                            and module.params["context"]
+                        ):
                             res = blade.delete_nfs_export_policies_rules(
                                 names=[rule.name],
                                 context_names=[module.params["context"]],
@@ -1805,7 +1928,8 @@ def delete_nfs_policy(module, blade):
                         changed = True
                         if not module.check_mode:
                             if (
-                                CONTEXT_API_VERSION in versions
+                                LooseVersion(CONTEXT_API_VERSION)
+                                <= LooseVersion(versions)
                                 and module.params["context"]
                             ):
                                 res = blade.delete_nfs_export_policies_rules(
@@ -1828,7 +1952,10 @@ def delete_nfs_policy(module, blade):
     if policy_delete:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.delete_nfs_export_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -1848,9 +1975,12 @@ def update_network_access_policy(module, blade):
     """Update Networkk Access Policy Rule"""
 
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if module.params["client"]:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             current_policy_rule = blade.get_network_access_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -1880,7 +2010,10 @@ def update_network_access_policy(module, blade):
                     before_name = (
                         module.params["name"] + "." + str(module.params["before_rule"])
                     )
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.post_network_access_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -1894,7 +2027,10 @@ def update_network_access_policy(module, blade):
                             before_rule_name=before_name,
                         )
                 else:
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.post_network_access_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -1933,7 +2069,8 @@ def update_network_access_policy(module, blade):
                     if not module.check_mode:
                         if module.params["before_rule"]:
                             if (
-                                CONTEXT_API_VERSION in versions
+                                LooseVersion(CONTEXT_API_VERSION)
+                                <= LooseVersion(versions)
                                 and module.params["context"]
                             ):
                                 res = blade.post_network_access_policies_rules(
@@ -1958,7 +2095,8 @@ def update_network_access_policy(module, blade):
                                 )
                         else:
                             if (
-                                CONTEXT_API_VERSION in versions
+                                LooseVersion(CONTEXT_API_VERSION)
+                                <= LooseVersion(versions)
                                 and module.params["context"]
                             ):
                                 res = blade.post_network_access_policies_rules(
@@ -2020,7 +2158,10 @@ def update_network_access_policy(module, blade):
                             effect=new_rule["effect"],
                             interfaces=new_rule["interfaces"],
                         )
-                        if CONTEXT_API_VERSION in versions and module.params["context"]:
+                        if (
+                            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                            and module.params["context"]
+                        ):
                             res = blade.patch_network_access_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -2059,7 +2200,10 @@ def update_network_access_policy(module, blade):
                             + "."
                             + str(module.params["before_rule"])
                         )
-                        if CONTEXT_API_VERSION in versions and module.params["context"]:
+                        if (
+                            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                            and module.params["context"]
+                        ):
                             res = blade.patch_network_access_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -2089,7 +2233,10 @@ def update_network_access_policy(module, blade):
                                     get_error_message(res),
                                 )
                             )
-    if CONTEXT_API_VERSION in versions and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+        and module.params["context"]
+    ):
         current_policy = list(
             blade.get_network_access_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -2102,7 +2249,10 @@ def update_network_access_policy(module, blade):
     if current_policy.enabled != module.params["enabled"]:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.patch_network_access_policies(
                     policy=NetworkAccessPolicy(enabled=module.params["enabled"]),
                     names=[module.params["name"]],
@@ -2129,11 +2279,14 @@ def delete_network_access_policy(module, blade):
     """
 
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     policy_delete = True
     if module.params["client"]:
         policy_delete = False
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.get_network_access_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -2152,7 +2305,10 @@ def delete_network_access_policy(module, blade):
                 if module.params["client"] == rule.client:
                     changed = True
                     if not module.check_mode:
-                        if CONTEXT_API_VERSION in versions and module.params["context"]:
+                        if (
+                            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                            and module.params["context"]
+                        ):
                             res = blade.delete_network_access_policies_rules(
                                 names=[rule.name],
                                 context_names=[module.params["context"]],
@@ -2177,7 +2333,8 @@ def delete_network_access_policy(module, blade):
                         changed = True
                         if not module.check_mode:
                             if (
-                                CONTEXT_API_VERSION in versions
+                                LooseVersion(CONTEXT_API_VERSION)
+                                <= LooseVersion(versions)
                                 and module.params["context"]
                             ):
                                 res = blade.delete_network_access_policies_rules(
@@ -2200,7 +2357,10 @@ def delete_network_access_policy(module, blade):
     if policy_delete:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.delete_network_Access_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -2222,9 +2382,12 @@ def delete_worm_data_policy(module, blade):
     """Delete WORM data Policy"""
 
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.delete_worm_data_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -2251,9 +2414,12 @@ def rename_network_access_policy(module, blade):
     """Rename Network Access Policy"""
 
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.patch_network_access_policies(
                 names=[module.params["name"]],
                 policy=NfsExportPolicy(name=module.params["rename"]),
@@ -2279,9 +2445,12 @@ def rename_nfs_policy(module, blade):
     """Rename NFS Export Policy"""
 
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.patch_nfs_export_policies(
                 names=[module.params["name"]],
                 policy=NfsExportPolicy(name=module.params["rename"]),
@@ -2307,8 +2476,11 @@ def update_worm_data_policy(module, blade):
     """Update WORM data policy"""
 
     changed = False
-    versions = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in versions and module.params["context"]:
+    versions = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+        and module.params["context"]
+    ):
         current_policy_config = list(
             blade.get_worm_data_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -2373,7 +2545,10 @@ def update_worm_data_policy(module, blade):
                 max_retention=new_policy["max_retention"],
                 default_retention=new_policy["default_retention"],
             )
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.patch_worm_data_policies(
                     names=[module.params["name"]],
                     policy=worm_policy,
@@ -2397,9 +2572,12 @@ def update_nfs_policy(module, blade):
     """Update NFS Export Policy Rule"""
 
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if module.params["client"]:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             current_policy_rule = blade.get_nfs_export_policies_rules(
                 policy_names=[module.params["name"]],
                 filter="client='" + module.params["client"] + "'",
@@ -2435,7 +2613,10 @@ def update_nfs_policy(module, blade):
                     before_name = (
                         module.params["name"] + "." + str(module.params["before_rule"])
                     )
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.post_nfs_export_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -2449,7 +2630,10 @@ def update_nfs_policy(module, blade):
                             before_rule_name=before_name,
                         )
                 else:
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.post_nfs_export_policies_rules(
                             policy_names=[module.params["name"]],
                             rule=rule,
@@ -2494,7 +2678,8 @@ def update_nfs_policy(module, blade):
                     if not module.check_mode:
                         if module.params["before_rule"]:
                             if (
-                                CONTEXT_API_VERSION in versions
+                                LooseVersion(CONTEXT_API_VERSION)
+                                <= LooseVersion(versions)
                                 and module.params["context"]
                             ):
                                 res = blade.post_nfs_export_policies_rules(
@@ -2519,7 +2704,8 @@ def update_nfs_policy(module, blade):
                                 )
                         else:
                             if (
-                                CONTEXT_API_VERSION in versions
+                                LooseVersion(CONTEXT_API_VERSION)
+                                <= LooseVersion(versions)
                                 and module.params["context"]
                             ):
                                 res = blade.post_nfs_export_policies_rules(
@@ -2631,7 +2817,10 @@ def update_nfs_policy(module, blade):
                                 else old_policy_rule.security
                             ),
                         )
-                        if CONTEXT_API_VERSION in versions and module.params["context"]:
+                        if (
+                            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                            and module.params["context"]
+                        ):
                             res = blade.patch_nfs_export_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -2670,7 +2859,10 @@ def update_nfs_policy(module, blade):
                             + "."
                             + str(module.params["before_rule"])
                         )
-                        if CONTEXT_API_VERSION in versions and module.params["context"]:
+                        if (
+                            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                            and module.params["context"]
+                        ):
                             res = blade.patch_nfs_export_policies_rules(
                                 names=[
                                     module.params["name"]
@@ -2700,7 +2892,10 @@ def update_nfs_policy(module, blade):
                                     get_error_message(res),
                                 )
                             )
-    if CONTEXT_API_VERSION in versions and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+        and module.params["context"]
+    ):
         current_policy = list(
             blade.get_nfs_export_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -2713,7 +2908,10 @@ def update_nfs_policy(module, blade):
     if current_policy.enabled != module.params["enabled"]:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.patch_nfs_export_policies(
                     policy=NfsExportPolicy(enabled=module.params["enabled"]),
                     names=[module.params["name"]],
@@ -2736,9 +2934,12 @@ def update_nfs_policy(module, blade):
 def create_nfs_policy(module, blade):
     """Create NFS Export Policy"""
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.post_nfs_export_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -2751,7 +2952,10 @@ def create_nfs_policy(module, blade):
                 )
             )
         if not module.params["enabled"]:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.patch_nfs_export_policies(
                     policy=NfsExportPolicy(enabled=False),
                     names=[module.params["name"]],
@@ -2762,7 +2966,10 @@ def create_nfs_policy(module, blade):
                     policy=NfsExportPolicy(enabled=False), names=[module.params["name"]]
                 )
             if res.status_code != 200:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     blade.delete_nfs_export_policies(
                         names=[module.params["name"]],
                         context_names=[module.params["context"]],
@@ -2786,7 +2993,10 @@ def create_nfs_policy(module, blade):
                 secure=module.params["secure"],
                 security=module.params["security"],
             )
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.post_nfs_export_policies_rules(
                     policy_names=[module.params["name"]],
                     rule=rule,
@@ -2818,12 +3028,15 @@ def delete_os_policy(module, blade):
     """
 
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     policy_name = module.params["account"] + "/" + module.params["name"]
     policy_delete = True
     if module.params["rule"]:
         policy_delete = False
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.get_object_store_access_policies_rules(
                 policy_names=[policy_name],
                 names=[module.params["rule"]],
@@ -2836,7 +3049,10 @@ def delete_os_policy(module, blade):
         if res.status_code == 200 and res.total_item_count != 0:
             changed = True
             if not module.check_mode:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.delete_object_store_access_policies_rules(
                         policy_names=[policy_name],
                         names=[module.params["rule"]],
@@ -2856,7 +3072,10 @@ def delete_os_policy(module, blade):
     if module.params["user"]:
         member_name = module.params["account"] + "/" + module.params["user"]
         policy_delete = False
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.get_object_store_access_policies_object_store_users(
                 policy_names=[policy_name],
                 member_names=[member_name],
@@ -2870,7 +3089,10 @@ def delete_os_policy(module, blade):
             changed = True
             if not module.check_mode:
                 member_name = module.params["account"] + "/" + module.params["user"]
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.delete_object_store_access_policies_object_store_users(
                         policy_names=[policy_name],
                         member_names=[member_name],
@@ -2890,7 +3112,10 @@ def delete_os_policy(module, blade):
     if policy_delete:
         if module.params["account"].lower() == "pure:policy":
             module.fail_json(msg="System-Wide policies cannot be deleted.")
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             policy_users = list(
                 blade.get_object_store_access_policies_object_store_users(
                     policy_names=[policy_name], context_names=[module.params["context"]]
@@ -2905,7 +3130,10 @@ def delete_os_policy(module, blade):
         if len(policy_users) == 0:
             changed = True
             if not module.check_mode:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.delete_object_store_access_policies(
                         names=[policy_name], context_names=[module.params["context"]]
                     )
@@ -2922,7 +3150,10 @@ def delete_os_policy(module, blade):
                 changed = True
                 if not module.check_mode:
                     for user in policy_users:
-                        if CONTEXT_API_VERSION in versions and module.params["context"]:
+                        if (
+                            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                            and module.params["context"]
+                        ):
                             res = blade.delete_object_store_access_policies_object_store_users(
                                 member_names=[user.member.name],
                                 policy_names=[policy_name],
@@ -2942,7 +3173,10 @@ def delete_os_policy(module, blade):
                                     get_error_message(res),
                                 )
                             )
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.delete_object_store_access_policies(
                             names=[policy_name],
                             context_names=[module.params["context"]],
@@ -2970,9 +3204,12 @@ def create_os_policy(module, blade):
     """Create Object Store Access Policy"""
     changed = True
     policy_name = module.params["account"] + "/" + module.params["name"]
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.post_object_store_access_policies(
                 names=[policy_name],
                 policy=ObjectStoreAccessPolicyPost(description=module.params["desc"]),
@@ -2998,7 +3235,7 @@ def create_os_policy(module, blade):
                 s3_delimiters=module.params["s3_delimiters"],
                 s3_prefixes=module.params["s3_prefixes"],
             )
-            if SMB_ENCRYPT_API_VERSION in versions:
+            if LooseVersion(SMB_ENCRYPT_API_VERSION) <= LooseVersion(versions):
                 rule = PolicyRuleObjectAccessPost(
                     actions=module.params["actions"],
                     resources=module.params["object_resources"],
@@ -3011,7 +3248,10 @@ def create_os_policy(module, blade):
                     resources=module.params["object_resources"],
                     conditions=conditions,
                 )
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.post_object_store_access_policies_rules(
                     policy_names=policy_name,
                     names=[module.params["rule"]],
@@ -3034,7 +3274,10 @@ def create_os_policy(module, blade):
                 )
         if module.params["user"]:
             member_name = module.params["account"] + "/" + module.params["user"]
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.post_object_store_access_policies_object_store_users(
                     member_names=[member_name],
                     policy_names=[policy_name],
@@ -3056,10 +3299,13 @@ def create_os_policy(module, blade):
 def update_os_policy(module, blade):
     """Update Object Store Access Policy"""
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     policy_name = module.params["account"] + "/" + module.params["name"]
     if module.params["rule"]:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             current_policy_rule = blade.get_object_store_access_policies_rules(
                 policy_names=[policy_name],
                 names=[module.params["rule"]],
@@ -3082,7 +3328,10 @@ def update_os_policy(module, blade):
                     resources=module.params["object_resources"],
                     conditions=conditions,
                 )
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.post_object_store_access_policies_rules(
                         policy_names=policy_name,
                         names=[module.params["rule"]],
@@ -3160,7 +3409,10 @@ def update_os_policy(module, blade):
                         resources=new_rule["resources"],
                         conditions=conditions,
                     )
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.patch_object_store_access_policies_rules(
                             policy_names=[policy_name],
                             names=[module.params["rule"]],
@@ -3189,7 +3441,10 @@ def update_os_policy(module, blade):
                         )
     if module.params["user"]:
         member_name = module.params["account"] + "/" + module.params["user"]
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.get_object_store_access_policies_object_store_users(
                 policy_names=[policy_name],
                 member_names=[member_name],
@@ -3204,7 +3459,10 @@ def update_os_policy(module, blade):
         ):
             changed = True
             if not module.check_mode:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.post_object_store_access_policies_object_store_users(
                         member_names=[member_name],
                         policy_names=[policy_name],
@@ -3226,11 +3484,14 @@ def update_os_policy(module, blade):
 def copy_os_policy_rule(module, blade):
     """Copy an existing policy rule to a new policy"""
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     policy_name = module.params["account"] + "/" + module.params["name"]
     if not module.params["target_rule"]:
         module.params["target_rule"] = module.params["rule"]
-    if CONTEXT_API_VERSION in versions and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+        and module.params["context"]
+    ):
         res = blade.get_object_store_access_policies_rules(
             policy_names=[module.params["target"]],
             names=[module.params["target_rule"]],
@@ -3246,7 +3507,10 @@ def copy_os_policy_rule(module, blade):
                 module.params["target_rule"], policy_name
             )
         )
-    if CONTEXT_API_VERSION in versions and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+        and module.params["context"]
+    ):
         current_rule = list(
             blade.get_object_store_access_policies_rules(
                 policy_names=[policy_name],
@@ -3271,7 +3535,10 @@ def copy_os_policy_rule(module, blade):
             resources=current_rule.resources,
             conditions=conditions,
         )
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.post_object_store_access_policies_rules(
                 policy_names=module.params["target"],
                 names=[module.params["target_rule"]],
@@ -3308,7 +3575,7 @@ def delete_snap_policy(module, blade):
     """
 
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     rule_delete = False
     if (
         module.params["at"]
@@ -3318,7 +3585,10 @@ def delete_snap_policy(module, blade):
     ):
         rule_delete = True
     if rule_delete:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             current_rules = list(
                 blade.get_policies(
                     names=[module.params["name"]],
@@ -3362,7 +3632,10 @@ def delete_snap_policy(module, blade):
                 changed = True
                 attr = SnapshotPolicyPatch(remove_rules=[delete_rule])
                 if not module.check_mode:
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.patch_policies(
                             destroy_snapshots=module.params["destroy_snapshots"],
                             names=[module.params["name"]],
@@ -3384,7 +3657,10 @@ def delete_snap_policy(module, blade):
     else:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.delete_policies(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -3403,7 +3679,7 @@ def delete_snap_policy(module, blade):
 def create_snap_policy(module, blade):
     """Create snapshot policy"""
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if (
         module.params["keep_for"]
         and not module.params["every"]
@@ -3478,7 +3754,10 @@ def create_snap_policy(module, blade):
                 )
         else:
             attr = Policy(enabled=module.params["enabled"])
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.post_policies(
                 names=[module.params["name"]],
                 policy=attr,
@@ -3494,7 +3773,10 @@ def create_snap_policy(module, blade):
             )
         if module.params["filesystem"]:
             for filesystem in module.params["filesystem"]:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.get_file_systems(
                         names=[filesystem],
                         destroyed=False,
@@ -3507,7 +3789,10 @@ def create_snap_policy(module, blade):
                         msg="Filesystems to assign to {0} does not "
                         "exist, or is deleted.".format(module.params["name"])
                     )
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.post_policies_file_systems(
                         policy_names=[module.params["name"]],
                         member_names=[filesystem],
@@ -3528,7 +3813,10 @@ def create_snap_policy(module, blade):
         if module.params["replica_link"]:
             repl_link = []
             for link in module.params["replica_link"]:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.get_file_system_replica_links(
                         local_file_system_names=[link],
                         context_names=[module.params["context"]],
@@ -3543,7 +3831,10 @@ def create_snap_policy(module, blade):
                     )
                 else:
                     repl_link = list(res.items)[0]
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.post_policies_file_system_replica_links(
                         policy_names=[module.params["name"]],
                         local_file_system_names=[link],
@@ -3581,7 +3872,7 @@ def update_snap_policy(module, blade):
     """
 
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if (
         module.params["keep_for"]
         and not module.params["every"]
@@ -3593,7 +3884,10 @@ def update_snap_policy(module, blade):
         module.fail_json(msg="`timezone` requires `at` to be provided.")
     if module.params["at"] and not module.params["every"]:
         module.fail_json(msg="`at` requires `every` to be provided.")
-    if CONTEXT_API_VERSION in versions and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+        and module.params["context"]
+    ):
         current_rules = list(
             blade.get_policies(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -3699,7 +3993,10 @@ def update_snap_policy(module, blade):
                     )
             else:
                 attr = SnapshotPolicyPatch(enabled=module.params["enabled"])
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.patch_policies(
                     names=[module.params["name"]],
                     policy=attr,
@@ -3719,7 +4016,10 @@ def update_snap_policy(module, blade):
 
     if module.params["filesystem"]:
         current_filesystems = []
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             policy_fs_details = list(
                 blade.get_policies_file_systems(
                     policy_names=[module.params["name"]],
@@ -3742,7 +4042,10 @@ def update_snap_policy(module, blade):
             ]
             for new_fs in difference_set:
                 changed = True
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.get_file_systems(
                         names=[new_fs],
                         destroyed=False,
@@ -3755,7 +4058,10 @@ def update_snap_policy(module, blade):
                         msg="Filesystem {0} to assign to {1} does not "
                         "exist, or is deleted.".format(new_fs, module.params["name"])
                     )
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.post_policies_file_systems(
                         policy_names=[module.params["name"]],
                         member_names=[new_fs],
@@ -3777,7 +4083,10 @@ def update_snap_policy(module, blade):
             for old_fs in module.params["filesystem"]:
                 if old_fs in current_filesystems:
                     changed = True
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.delete_policies_file_systems(
                             policy_names=[module.params["name"]],
                             member_names=[old_fs],
@@ -3797,7 +4106,10 @@ def update_snap_policy(module, blade):
                         )
     if module.params["replica_link"]:
         current_rls = []
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             policy_rl_details = list(
                 blade.get_policies_file_system_replica_links(
                     policy_names=[module.params["name"]],
@@ -3820,7 +4132,10 @@ def update_snap_policy(module, blade):
             ]
             for new_rl in difference_set:
                 changed = True
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.get_file_systems_replica_links(
                         names=[new_rl], context_names=[module.params["context"]]
                     )
@@ -3831,7 +4146,10 @@ def update_snap_policy(module, blade):
                         msg="Replica link {0} to assign to {1} does not "
                         "exist, or is deleted.".format(new_rl, module.params["name"])
                     )
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.post_policies_file_system_replica_links(
                         policy_names=[module.params["name"]],
                         member_names=[new_rl],
@@ -3853,7 +4171,10 @@ def update_snap_policy(module, blade):
             for old_rl in module.params["replica_link"]:
                 if old_rl in current_rls:
                     changed = True
-                    if CONTEXT_API_VERSION in versions and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                        and module.params["context"]
+                    ):
                         res = blade.delete_policies_file_system_replica_links(
                             policy_names=[module.params["name"]],
                             member_names=[old_rl],
@@ -4024,8 +4345,11 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    versions = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in versions and not module.params["context"]:
+    versions = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+        and not module.params["context"]
+    ):
         # Only default the context to the local array name when this array is a
         # member of a fleet. A standalone array is "not in a fleet" and rejects
         # fleet context, so leave context unset - no context_names is then sent.
@@ -4036,7 +4360,10 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 policy = list(
                     blade.get_object_store_access_policies(
                         names=[module.params["account"] + "/" + module.params["name"]],
@@ -4053,7 +4380,10 @@ def main():
             policy = None
         if module.params["user"]:
             member_name = module.params["account"] + "/" + module.params["user"]
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.get_object_store_users(
                     names=[member_name], context_names=[module.params["context"]]
                 )
@@ -4078,7 +4408,10 @@ def main():
                 module.fail_json(
                     msg='Incorrect format for target policy. Must be "<account>/<name>"'
                 )
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.get_object_store_access_policies(
                     names=[module.params["target"]],
                     context_names=[module.params["context"]],
@@ -4096,7 +4429,7 @@ def main():
             copy_os_policy_rule(module, blade)
     elif module.params["policy_type"] == "nfs":
         new_policy = None
-        if NFS_POLICY_API_VERSION not in versions:
+        if LooseVersion(NFS_POLICY_API_VERSION) > LooseVersion(versions):
             module.fail_json(
                 msg=(
                     "Minimum FlashBlade REST version required: {0}".format(
@@ -4107,7 +4440,10 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 policy = list(
                     blade.get_nfs_export_policies(
                         names=[module.params["name"]],
@@ -4122,7 +4458,10 @@ def main():
             policy = None
         if module.params["rename"]:
             try:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     new_policy = list(
                         blade.get_nfs_export_policies(
                             names=[module.params["rename"]],
@@ -4139,7 +4478,10 @@ def main():
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.get_nfs_export_policies_rules(
                         policy_names=[module.params["name"]],
                         names=[
@@ -4174,7 +4516,7 @@ def main():
         elif state == "absent" and policy:
             delete_nfs_policy(module, blade)
     elif module.params["policy_type"] == "smb_client":
-        if SMB_POLICY_API_VERSION not in versions:
+        if LooseVersion(SMB_POLICY_API_VERSION) > LooseVersion(versions):
             module.fail_json(
                 msg=(
                     "Minimum FlashBlade REST version required: {0}".format(
@@ -4185,7 +4527,10 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 policy = list(
                     blade.get_smb_client_policies(
                         names=[module.params["name"]],
@@ -4200,7 +4545,10 @@ def main():
             policy = None
         if module.params["rename"]:
             try:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     new_policy = list(
                         blade.get_smb_client_policies(
                             names=[module.params["rename"]],
@@ -4217,7 +4565,10 @@ def main():
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.get_smb_client_policies_rules(
                         policy_names=[module.params["name"]],
                         names=[
@@ -4252,7 +4603,7 @@ def main():
         elif state == "absent" and policy:
             delete_smb_client_policy(module, blade)
     elif module.params["policy_type"] == "smb_share":
-        if SMB_POLICY_API_VERSION not in versions:
+        if LooseVersion(SMB_POLICY_API_VERSION) > LooseVersion(versions):
             module.fail_json(
                 msg=(
                     "Minimum FlashBlade REST version required: {0}".format(
@@ -4263,7 +4614,10 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 policy = list(
                     blade.get_smb_share_policies(
                         names=[module.params["name"]],
@@ -4278,7 +4632,10 @@ def main():
             policy = None
         if module.params["rename"]:
             try:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     new_policy = list(
                         blade.get_smb_share_policies(
                             names=[module.params["rename"]],
@@ -4295,7 +4652,10 @@ def main():
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.get_smb_share_policies_rules(
                         policy_names=[module.params["name"]],
                         names=[
@@ -4330,7 +4690,7 @@ def main():
         elif state == "absent" and policy:
             delete_smb_share_policy(module, blade)
     elif module.params["policy_type"] == "network":
-        if NET_POLICY_API_VERSION not in versions:
+        if LooseVersion(NET_POLICY_API_VERSION) > LooseVersion(versions):
             module.fail_json(
                 msg=(
                     "Minimum FlashBlade REST version required: {0}".format(
@@ -4341,7 +4701,10 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 policy = list(
                     blade.get_network_access_policies(
                         names=[module.params["name"]],
@@ -4358,7 +4721,10 @@ def main():
             policy = None
         if module.params["rename"]:
             try:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     new_policy = list(
                         blade.get_network_access_policies(
                             names=[module.params["rename"]],
@@ -4375,7 +4741,10 @@ def main():
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.get_network_access_policies_rules(
                         policy_names=[module.params["name"]],
                         names=[
@@ -4410,7 +4779,7 @@ def main():
         elif state == "absent" and policy:
             delete_network_access_policy(module, blade)
     elif module.params["policy_type"] == "worm":
-        if WORM_POLICY_API_VERSION not in versions:
+        if LooseVersion(WORM_POLICY_API_VERSION) > LooseVersion(versions):
             module.fail_json(
                 msg=(
                     "Minimum FlashBlade REST version required: {0}".format(
@@ -4421,7 +4790,10 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 policy = list(
                     blade.get_worm_data_policies(
                         names=[module.params["name"]],
@@ -4436,7 +4808,10 @@ def main():
             policy = None
         if module.params["rename"]:
             try:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     new_policy = list(
                         blade.get_worm_data_policies(
                             names=[module.params["rename"]],
@@ -4453,7 +4828,10 @@ def main():
                 new_policy = None
         if policy and state == "present" and not module.params["rename"]:
             if module.params["before_rule"]:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.get_worm_data_policies_rules(
                         policy_names=[module.params["name"]],
                         names=[
@@ -4491,7 +4869,10 @@ def main():
         if not HAS_PYPURECLIENT:
             module.fail_json(msg="py-pure-client sdk is required for this module")
         try:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 policy = list(
                     blade.get_policies(
                         names=[module.params["name"]],

--- a/plugins/modules/purefb_ra.py
+++ b/plugins/modules/purefb_ra.py
@@ -70,8 +70,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
@@ -84,7 +88,8 @@ def enable_ra(module, blade):
     """Enable Remote Assist"""
     changed = True
     if not module.check_mode:
-        if DURATION_API in list(blade.get_versions().items):
+        api_version = get_rest_api_version(blade)
+        if LooseVersion(DURATION_API) <= LooseVersion(api_version):
             duration = module.params["duration"] * 3600000
             ra_settings = Support(
                 remote_assist_active=True, remote_assist_duration=duration

--- a/plugins/modules/purefb_remote_cred.py
+++ b/plugins/modules/purefb_remote_cred.py
@@ -99,8 +99,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
@@ -111,8 +115,11 @@ CONTEXT_API_VERSION = "2.17"
 
 def get_connected(module, blade):
     """Return connected device or None"""
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         connected_blades = list(
             blade.get_array_connections(context_names=[module.params["context"]]).items
         )
@@ -128,7 +135,10 @@ def get_connected(module, blade):
             "partially_connected",
         ]:
             return target.remote.name
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         connected_targets = list(
             blade.get_targets(context_names=[module.params["context"]]).items
         )
@@ -146,8 +156,11 @@ def get_connected(module, blade):
 
 def get_remote_cred(module, blade):
     """Return Remote Credential or None"""
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_object_store_remote_credentials(
             names=[module.params["target"] + "/" + module.params["name"]],
             context_names=[module.params["context"]],
@@ -164,14 +177,17 @@ def get_remote_cred(module, blade):
 def create_credential(module, blade):
     """Create remote credential"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         remote_cred = module.params["target"] + "/" + module.params["name"]
         remote_credentials = ObjectStoreRemoteCredentialsPost(
             access_key_id=module.params["access_key"],
             secret_access_key=module.params["secret"],
         )
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.post_object_store_remote_credentials(
                 names=[remote_cred],
                 remote_credentials=remote_credentials,
@@ -193,14 +209,17 @@ def create_credential(module, blade):
 def update_credential(module, blade):
     """Update remote credential"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         remote_cred = module.params["target"] + "/" + module.params["name"]
         new_attr = ObjectStoreRemoteCredentials(
             access_key_id=module.params["access_key"],
             secret_access_key=module.params["secret"],
         )
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.patch_object_store_remote_credentials(
                 names=[remote_cred],
                 remote_credentials=new_attr,
@@ -222,10 +241,13 @@ def update_credential(module, blade):
 def delete_credential(module, blade):
     """Delete remote credential"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         remote_cred = module.params["target"] + "/" + module.params["name"]
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.delete_object_store_remote_credentials(
                 names=[remote_cred], context_names=[module.params["context"]]
             )
@@ -263,8 +285,11 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):

--- a/plugins/modules/purefb_s3acc.py
+++ b/plugins/modules/purefb_s3acc.py
@@ -129,8 +129,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
@@ -142,8 +146,11 @@ CONTEXT_API_VERSION = "2.17"
 
 def get_s3acc(module, blade):
     """Return Object Store Account or None"""
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_object_store_accounts(
             names=[module.params["name"]], context_names=[module.params["context"]]
         )
@@ -157,9 +164,12 @@ def get_s3acc(module, blade):
 def update_s3acc(module, blade):
     """Update Object Store Account"""
     changed = False
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     public = False
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         acc_settings = list(
             blade.get_object_store_accounts(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -169,7 +179,7 @@ def update_s3acc(module, blade):
         acc_settings = list(
             blade.get_object_store_accounts(names=[module.params["name"]]).items
         )[0]
-    if PUBLIC_API_VERSION in api_version:
+    if LooseVersion(PUBLIC_API_VERSION) <= LooseVersion(api_version):
         public = True
         current_account = {
             "hard_limit": acc_settings.hard_limit_enabled,
@@ -263,7 +273,10 @@ def update_s3acc(module, blade):
                         quota_limit=new_account["default_quota"],
                     ),
                 )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_object_store_accounts(
                     object_store_account=osa,
                     names=[module.params["name"]],
@@ -285,9 +298,12 @@ def update_s3acc(module, blade):
 def create_s3acc(module, blade):
     """Create Object Store Account"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.post_object_store_accounts(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -321,7 +337,10 @@ def create_s3acc(module, blade):
                     quota_limit=default_quota,
                 ),
             )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_object_store_accounts(
                     object_store_account=osa,
                     names=[module.params["name"]],
@@ -332,7 +351,10 @@ def create_s3acc(module, blade):
                     object_store_account=osa, names=[module.params["name"]]
                 )
             if res.status_code != 200:
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     blade.object_store_accounts.delete_object_store_accounts(
                         names=[module.params["name"]],
                         context_names=[module.params["context"]],
@@ -345,7 +367,7 @@ def create_s3acc(module, blade):
                     msg="Failed to set quotas correctly for account {0}. "
                     "Error: {1}".format(module.params["name"], get_error_message(res))
                 )
-        if PUBLIC_API_VERSION in api_version:
+        if LooseVersion(PUBLIC_API_VERSION) <= LooseVersion(api_version):
             if not module.params["block_new_public_policies"]:
                 module.params["block_new_public_policies"] = False
             if not module.params["block_public_access"]:
@@ -358,7 +380,10 @@ def create_s3acc(module, blade):
                     block_public_access=module.params["block_public_access"],
                 )
             )
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.patch_object_store_accounts(
                     object_store_account=osa,
                     names=[module.params["name"]],
@@ -380,9 +405,12 @@ def create_s3acc(module, blade):
 def delete_s3acc(module, blade):
     """Delete Object Store Account"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_object_store_users(
                 names=[module.params["name"] + "/*'"],
                 context_names=[module.params["context"]],
@@ -393,7 +421,10 @@ def delete_s3acc(module, blade):
             module.fail_json(msg="Remove all Users from Object Store Account {0} \
                                  before deletion".format(module.params["name"]))
         else:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.delete_object_store_accounts(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -429,8 +460,11 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):

--- a/plugins/modules/purefb_s3user.py
+++ b/plugins/modules/purefb_s3user.py
@@ -172,8 +172,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 CONTEXT_API_VERSION = "2.17"
@@ -181,8 +185,11 @@ CONTEXT_API_VERSION = "2.17"
 
 def get_s3acc(module, blade):
     """Return Object Store Account or None"""
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_object_store_accounts(
             names=[module.params["account"]], context_names=[module.params["context"]]
         )
@@ -195,9 +202,12 @@ def get_s3acc(module, blade):
 
 def get_s3user(module, blade):
     """Return Object Store Account or None"""
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     full_user = module.params["account"] + "/" + module.params["name"]
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_object_store_users(
             names=[full_user], context_names=[module.params["context"]]
         )
@@ -211,13 +221,16 @@ def get_s3user(module, blade):
 def update_s3user(module, blade):
     """Update Object Store User"""
     changed = False
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     exists = False
     s3user_facts = {}
     user = module.params["account"] + "/" + module.params["name"]
     if module.params["access_key"] or module.params["imported_key"]:
         key_count = 0
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             keys = list(
                 blade.get_object_store_access_keys(
                     context_names=[module.params["context"]]
@@ -243,7 +256,8 @@ def update_s3user(module, blade):
                         changed = True
                         if not module.check_mode:
                             if (
-                                CONTEXT_API_VERSION in api_version
+                                LooseVersion(CONTEXT_API_VERSION)
+                                <= LooseVersion(api_version)
                                 and module.params["context"]
                             ):
                                 res = blade.post_object_store_access_keys(
@@ -262,7 +276,8 @@ def update_s3user(module, blade):
                                 result = list(res.items)[0]
                                 if not module.params["enable_key"]:
                                     if (
-                                        CONTEXT_API_VERSION in api_version
+                                        LooseVersion(CONTEXT_API_VERSION)
+                                        <= LooseVersion(api_version)
                                         and module.params["context"]
                                     ):
                                         blade.patch_object_store_access_keys(
@@ -297,7 +312,8 @@ def update_s3user(module, blade):
                     changed = True
                     if not module.check_mode:
                         if (
-                            CONTEXT_API_VERSION in api_version
+                            LooseVersion(CONTEXT_API_VERSION)
+                            <= LooseVersion(api_version)
                             and module.params["context"]
                         ):
                             res = blade.post_object_store_access_keys(
@@ -320,7 +336,8 @@ def update_s3user(module, blade):
                             result = list(res.items)[0]
                             if not module.params["enable_key"]:
                                 if (
-                                    CONTEXT_API_VERSION in api_version
+                                    LooseVersion(CONTEXT_API_VERSION)
+                                    <= LooseVersion(api_version)
                                     and module.params["context"]
                                 ):
                                     blade.patch_object_store_access_keys(
@@ -358,10 +375,13 @@ def create_s3user(module, blade):
     """Create Object Store Account"""
     s3user_facts = {}
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         user = module.params["account"] + "/" + module.params["name"]
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.post_object_store_users(
                 names=[user], context_names=[module.params["context"]]
             )
@@ -376,7 +396,10 @@ def create_s3user(module, blade):
         if module.params["access_key"] and module.params["imported_key"]:
             module.warn("'access_key: true' overrides imported keys")
         if module.params["access_key"]:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_object_store_access_keys(
                     object_store_access_key=ObjectStoreAccessKeyPost(
                         user={"name": user}
@@ -392,7 +415,10 @@ def create_s3user(module, blade):
             if res.status_code == 200:
                 result = list(res.items)[0]
                 if not module.params["enable_key"]:
-                    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                        and module.params["context"]
+                    ):
                         blade.patch_object_store_access_keys(
                             names=[result.name],
                             object_store_access_key=ObjectStoreAccessKey(enabled=False),
@@ -418,7 +444,10 @@ def create_s3user(module, blade):
                 )
         else:
             if module.params["imported_key"]:
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.post_object_store_access_keys(
                         names=[module.params["imported_key"]],
                         object_store_access_key=ObjectStoreAccessKeyPost(
@@ -439,7 +468,8 @@ def create_s3user(module, blade):
                     result = list(res.items)[0]
                     if not module.params["enable_key"]:
                         if (
-                            CONTEXT_API_VERSION in api_version
+                            LooseVersion(CONTEXT_API_VERSION)
+                            <= LooseVersion(api_version)
                             and module.params["context"]
                         ):
                             blade.patch_object_store_access_keys(
@@ -465,7 +495,10 @@ def create_s3user(module, blade):
         if module.params["policy"]:
             policy_list = module.params["policy"]
             for policy in policy_list:
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.get_object_store_access_policies(
                         names=[policy],
                         context_names=[module.params["context"]],
@@ -477,7 +510,10 @@ def create_s3user(module, blade):
                     policy_list.remove(policy)
             username = module.params["account"] + "/" + module.params["name"]
             for policy in policy_list:
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.get_object_store_users_object_store_access_policies(
                         member_names=[username],
                         policy_names=[policy],
@@ -488,7 +524,10 @@ def create_s3user(module, blade):
                         member_names=[username], policy_names=[policy]
                     )
                 if not list(res.items):
-                    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                    if (
+                        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                        and module.params["context"]
+                    ):
                         res = (
                             blade.post_object_store_access_policies_object_store_users(
                                 member_names=[username],
@@ -524,8 +563,11 @@ def create_s3user(module, blade):
 def remove_key(module, blade):
     """Remove Access Key from User"""
     changed = False
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_object_store_access_keys(
             names=[module.params["key_name"]], context_names=[module.params["context"]]
         )
@@ -534,7 +576,10 @@ def remove_key(module, blade):
     if res.status_code == 200:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.delete_object_store_access_keys(
                     names=[module.params["key_name"]],
                     context_names=[module.params["context"]],
@@ -556,9 +601,12 @@ def remove_key(module, blade):
 def change_key(module, blade):
     """Change state of Access Key"""
     changed = False
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_object_store_access_keys(
                 names=[module.params["key_name"]],
                 context_names=[module.params["context"]],
@@ -569,7 +617,10 @@ def change_key(module, blade):
             key = list(res.items)[0]
             if key.enabled != module.params["enable_key"]:
                 changed = True
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.patch_object_store_access_keys(
                         names=[module.params["key_name"]],
                         object_store_access_key=ObjectStoreAccessKey(
@@ -597,10 +648,13 @@ def change_key(module, blade):
 def delete_s3user(module, blade, internal=False):
     """Delete Object Store Account"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         user = module.params["account"] + "/" + module.params["name"]
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.delete_object_store_users(
                 names=[user], context_names=[module.params["context"]]
             )
@@ -653,8 +707,11 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):

--- a/plugins/modules/purefb_saml.py
+++ b/plugins/modules/purefb_saml.py
@@ -129,8 +129,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 MIN_REQUIRED_API_VERSION = "2.15"
@@ -370,15 +374,15 @@ def main():
         module.fail_json(msg="py-pure-client sdk is required for this module")
 
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
 
-    if MIN_REQUIRED_API_VERSION not in api_version:
+    if LooseVersion(MIN_REQUIRED_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashBlade REST version not supported. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)
         )
     state = module.params["state"]
-    if state == "test" and TEST_API_VERSION not in api_version:
+    if state == "test" and LooseVersion(TEST_API_VERSION) > LooseVersion(api_version):
         module.fail_json(
             msg="FlashBlade REST version not supported for SAML2 testing. "
             "Minimum version required: {0}".format(MIN_REQUIRED_API_VERSION)

--- a/plugins/modules/purefb_smtp.py
+++ b/plugins/modules/purefb_smtp.py
@@ -69,8 +69,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 SMTP_ENCRYPT_API_VERSION = "2.15"
@@ -96,7 +100,9 @@ def set_smtp(module, blade):
         encrypt = module.params["encryption"]
         changed = True
     if changed and not module.check_mode:
-        if SMTP_ENCRYPT_API_VERSION in list(blade.get_versions().items):
+        if LooseVersion(SMTP_ENCRYPT_API_VERSION) <= LooseVersion(
+            get_rest_api_version(blade)
+        ):
             res = blade.patch_smtp_servers(
                 smtp=SmtpServer(
                     relay_host=relay_host, sender_domain=domain, encryption_mode=encrypt
@@ -128,10 +134,13 @@ def main():
     module = AnsibleModule(argument_spec, supports_check_mode=True)
 
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not HAS_PYPURECLIENT:
         module.fail_json(msg="py-pure-client SDK is required for this module")
-    if SMTP_ENCRYPT_API_VERSION not in api_version and module.params["encryption"]:
+    if (
+        LooseVersion(SMTP_ENCRYPT_API_VERSION) > LooseVersion(api_version)
+        and module.params["encryption"]
+    ):
         module.fail_json(msg="Purity//FB must be upgraded to support encryption.")
 
     set_smtp(module, blade)

--- a/plugins/modules/purefb_snap.py
+++ b/plugins/modules/purefb_snap.py
@@ -141,9 +141,13 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
-    get_filesystem,
     get_error_message,
+    get_filesystem,
+    get_rest_api_version,
 )
 
 from datetime import datetime
@@ -165,8 +169,11 @@ CONTEXT_API_VERSION = "2.17"
 
 def get_latest_fssnapshot(module, blade):
     """Get the name of the latest snpshot or None"""
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_file_system_snapshots(
             names_or_owner_names=[module.params["name"]],
             context_names=[module.params["context"]],
@@ -194,8 +201,11 @@ def get_latest_fssnapshot(module, blade):
 
 def get_fssnapshot(module, blade):
     """Return Snapshot or None"""
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         res = blade.get_file_system_snapshots(
             names_or_owner_names=[
                 module.params["name"] + "." + module.params["suffix"]
@@ -215,13 +225,16 @@ def get_fssnapshot(module, blade):
 
 def create_snapshot(module, blade):
     """Create Snapshot"""
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     changed = False
     # Special case as we have changed 'target' to be a string not a list of one string
     # so this provides backwards compatability
     # target = module.params["target"].replace("[", "").replace("'", "").replace("]", "")
     blade_exists = False
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         connected_blades = list(
             blade.get_array_connections(context_names=[module.params["context"]]).items
         )
@@ -240,7 +253,10 @@ def create_snapshot(module, blade):
     changed = True
     if not module.check_mode:
         if module.params["target"]:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_file_system_snapshots(
                     source_names=[module.params["name"]],
                     send=module.params["now"],
@@ -260,7 +276,10 @@ def create_snapshot(module, blade):
                     ),
                 )
         else:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_file_system_snapshots(
                     source_names=[module.params["name"]],
                     file_system_snapshot=FileSystemSnapshotPost(
@@ -287,11 +306,14 @@ def create_snapshot(module, blade):
 def restore_snapshot(module, blade):
     """Restore a filesystem back from the latest snapshot"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     snapname = get_latest_fssnapshot(module, blade)
     if snapname is not None:
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.post_file_systems(
                     names=[module.params["name"]],
                     overwrite=True,
@@ -324,10 +346,13 @@ def restore_snapshot(module, blade):
 def recover_snapshot(module, blade):
     """Recover deleted Snapshot"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         snapname = module.params["name"] + "." + module.params["suffix"]
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.patch_file_system_snapshots(
                 names=[snapname],
                 file_system_snapshot=FileSystemSnapshot(destroyed=False),
@@ -356,10 +381,13 @@ def update_snapshot(module, blade):
 def delete_snapshot(module, blade):
     """Delete Snapshot"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         snapname = module.params["name"] + "." + module.params["suffix"]
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.patch_file_system_snapshots(
                 names=[snapname],
                 latest_replica=module.params["latest_replica"],
@@ -379,7 +407,10 @@ def delete_snapshot(module, blade):
                 )
             )
         if module.params["eradicate"]:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.delete_file_system_snapshots(
                     names=[snapname], context_names=[module.params["context"]]
                 )
@@ -397,10 +428,13 @@ def delete_snapshot(module, blade):
 def eradicate_snapshot(module, blade):
     """Eradicate Snapshot"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
         snapname = module.params["name"] + "." + module.params["suffix"]
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.delete_file_system_snapshots(
                 names=[snapname], context_names=[module.params["context"]]
             )
@@ -446,14 +480,17 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):
             module.params["context"] = list(blade.get_arrays().items)[0].name
 
-    if SNAP_NOW_API not in api_version and module.params["now"]:
+    if LooseVersion(SNAP_NOW_API) > LooseVersion(api_version) and module.params["now"]:
         module.fail_json(
             msg="Minimum FlashBlade REST version for immeadiate remote snapshots: {0}".format(
                 SNAP_NOW_API

--- a/plugins/modules/purefb_syslog.py
+++ b/plugins/modules/purefb_syslog.py
@@ -101,8 +101,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 SYSLOG_SERVICES_API = "2.14"
@@ -132,11 +136,11 @@ def add_syslog(module, blade):
         full_address = noport_address + ":" + module.params["port"]
     else:
         full_address = noport_address
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
 
     changed = True
     if not module.check_mode:
-        if SYSLOG_SERVICES_API in api_version:
+        if LooseVersion(SYSLOG_SERVICES_API) <= LooseVersion(api_version):
             res = blade.post_syslog_servers(
                 names=[module.params["name"]],
                 syslog_server=SyslogServerPost(
@@ -167,8 +171,8 @@ def add_syslog(module, blade):
 def update_syslog(module, blade):
     """Update Syslog Server"""
     changed = False
-    api_version = list(blade.get_versions().items)
-    if SYSLOG_SERVICES_API not in api_version:
+    api_version = get_rest_api_version(blade)
+    if LooseVersion(SYSLOG_SERVICES_API) > LooseVersion(api_version):
         module.exit_json(
             msg="Purity//FB needs upgrading to support modification of existing syslog server"
         )

--- a/plugins/modules/purefb_user.py
+++ b/plugins/modules/purefb_user.py
@@ -143,8 +143,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 import re
 
@@ -420,8 +424,8 @@ def main():
     )
 
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if MIN_LOCAL_USER not in api_version:
+    api_version = get_rest_api_version(blade)
+    if LooseVersion(MIN_LOCAL_USER) > LooseVersion(api_version):
         module.fail_json(
             msg="Purity//FB must be upgraded to support managing local users."
         )

--- a/plugins/modules/purefb_userpolicy.py
+++ b/plugins/modules/purefb_userpolicy.py
@@ -114,16 +114,23 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
     get_error_message,
+    get_rest_api_version,
 )
 
 CONTEXT_API_VERSION = "2.17"
 
 
 def _check_valid_policy(module, blade, policy):
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         return bool(
             blade.get_object_store_access_policies(
                 names=[policy], context_names=[module.params["context"]]
@@ -135,7 +142,7 @@ def _check_valid_policy(module, blade, policy):
 def add_policy(module, blade):
     """Add a single or list of policies to an account user"""
     changed = False
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     user_policy_list = []
     policy_list = module.params["policy"]
     for policy in policy_list:
@@ -143,7 +150,10 @@ def add_policy(module, blade):
             module.fail_json(msg="Policy {0} is not valid.".format(policy))
     username = module.params["account"] + "/" + module.params["name"]
     for policy in policy_list:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_object_store_users_object_store_access_policies(
                 member_names=[username],
                 policy_names=[policy],
@@ -155,7 +165,10 @@ def add_policy(module, blade):
             )
         if not list(res.items):
             if not module.check_mode:
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.post_object_store_access_policies_object_store_users(
                         member_names=[username],
                         policy_names=[policy],
@@ -172,7 +185,10 @@ def add_policy(module, blade):
                         )
                     )
                 changed = True
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     user_policies = list(
                         blade.get_object_store_access_policies_object_store_users(
                             member_names=[username],
@@ -193,7 +209,7 @@ def add_policy(module, blade):
 def remove_policy(module, blade):
     """Remove a single or list of policies to an account user"""
     changed = False
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     user_policy_list = []
     policy_list = module.params["policy"]
     for policy in policy_list:
@@ -201,7 +217,10 @@ def remove_policy(module, blade):
             module.fail_json(msg="Policy {0} is not valid.".format(policy))
     username = module.params["account"] + "/" + module.params["name"]
     for policy in policy_list:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.get_object_store_users_object_store_access_policies(
                 member_names=[username],
                 policy_names=[policy],
@@ -214,7 +233,10 @@ def remove_policy(module, blade):
         if res == 1:
             if not module.check_mode:
                 changed = True
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     res = blade.delete_object_store_access_policies_object_store_users(
                         member_names=[username],
                         policy_names=[policy],
@@ -224,7 +246,10 @@ def remove_policy(module, blade):
                     res = blade.delete_object_store_access_policies_object_store_users(
                         member_names=[username], policy_names=[policy]
                     )
-                if CONTEXT_API_VERSION in api_version and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                    and module.params["context"]
+                ):
                     user_policies = list(
                         blade.get_object_store_access_policies_object_store_users(
                             member_names=[username],
@@ -251,12 +276,15 @@ def remove_policy(module, blade):
 def list_policy(module, blade):
     """List Object Store User Access Policies"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     policy_list = []
     if not module.check_mode:
         if module.params["account"] and module.params["name"]:
             username = module.params["account"] + "/" + module.params["name"]
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 user_policies = list(
                     blade.get_object_store_access_policies_object_store_users(
                         member_names=[username],
@@ -272,7 +300,10 @@ def list_policy(module, blade):
             for user_policy in user_policies:
                 policy_list.append(user_policy.policy.name)
         else:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 policies = blade.get_object_store_access_policies(
                     context_names=[module.params["context"]]
                 )
@@ -308,8 +339,11 @@ def main():
     )
 
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):

--- a/plugins/modules/purefb_userquota.py
+++ b/plugins/modules/purefb_userquota.py
@@ -132,9 +132,13 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
 from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
-    get_filesystem,
     get_error_message,
+    get_filesystem,
+    get_rest_api_version,
 )
 
 CONTEXT_API_VERSION = "2.17"
@@ -142,9 +146,12 @@ CONTEXT_API_VERSION = "2.17"
 
 def get_quota(module, blade):
     """Return Filesystem User Quota or None"""
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if module.params["uid"]:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.get_quotas_users(
                 file_system_names=[module.params["name"]],
                 filter="user.id=" + str(module.params["uid"]),
@@ -156,7 +163,10 @@ def get_quota(module, blade):
                 filter="user.id=" + str(module.params["uid"]),
             )
     else:
-        if CONTEXT_API_VERSION in versions and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+            and module.params["context"]
+        ):
             res = blade.get_quotas_users(
                 file_system_names=[module.params["name"]],
                 filter="user.name='" + module.params["uname"] + "'",
@@ -175,11 +185,14 @@ def get_quota(module, blade):
 def create_quota(module, blade):
     """Create Filesystem User Quota"""
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     quota = int(human_to_bytes(module.params["quota"]))
     if not module.check_mode:
         if module.params["uid"]:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.post_quotas_users(
                     file_system_names=[module.params["name"]],
                     uids=[module.params["uid"]],
@@ -193,7 +206,10 @@ def create_quota(module, blade):
                     quota=UserQuotaPost(quota=quota),
                 )
         else:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.post_quotas_users(
                     file_system_names=[module.params["name"]],
                     user_names=[module.params["uname"]],
@@ -229,14 +245,17 @@ def create_quota(module, blade):
 def update_quota(module, blade):
     """Upodate Filesystem User Quota"""
     changed = False
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     current_quota = get_quota(module, blade)
     quota = int(human_to_bytes(module.params["quota"]))
     if current_quota.quota != quota:
         changed = True
         if not module.check_mode:
             if module.params["uid"]:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.patch_quotas_users(
                         file_system_names=[module.params["name"]],
                         uids=[module.params["uid"]],
@@ -258,7 +277,10 @@ def update_quota(module, blade):
                         )
                     )
             else:
-                if CONTEXT_API_VERSION in versions and module.params["context"]:
+                if (
+                    LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                    and module.params["context"]
+                ):
                     res = blade.patch_quotas_users(
                         file_system_names=[module.params["name"]],
                         user_names=[module.params["uname"]],
@@ -285,10 +307,13 @@ def update_quota(module, blade):
 def delete_quota(module, blade):
     """Delete Filesystem User Quota"""
     changed = True
-    versions = list(blade.get_versions().items)
+    versions = get_rest_api_version(blade)
     if not module.check_mode:
         if module.params["uid"]:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.delete_quotas_users(
                     file_system_names=[module.params["name"]],
                     uids=[module.params["uid"]],
@@ -300,7 +325,10 @@ def delete_quota(module, blade):
                     uids=[module.params["uid"]],
                 )
         else:
-            if CONTEXT_API_VERSION in versions and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+                and module.params["context"]
+            ):
                 res = blade.delete_quotas_users(
                     file_system_names=[module.params["name"]],
                     user_names=[module.params["uname"]],
@@ -358,8 +386,11 @@ def main():
 
     state = module.params["state"]
     blade = get_system(module)
-    versions = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in versions and not module.params["context"]:
+    versions = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(versions)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):

--- a/plugins/modules/purefb_virtualhost.py
+++ b/plugins/modules/purefb_virtualhost.py
@@ -72,6 +72,12 @@ from ansible_collections.everpure.flashblade.plugins.module_utils.purefb import 
     get_system,
     purefb_argument_spec,
 )
+from ansible_collections.everpure.flashblade.plugins.module_utils.version import (
+    LooseVersion,
+)
+from ansible_collections.everpure.flashblade.plugins.module_utils.common import (
+    get_rest_api_version,
+)
 
 MAX_HOST_COUNT = 10
 CONTEXT_API_VERSION = "2.17"
@@ -80,13 +86,16 @@ CONTEXT_API_VERSION = "2.17"
 def delete_host(module, blade):
     """Delete Object Store Virtual Host"""
     changed = False
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if module.params["name"] == "s3.amazonaws.com":
         module.warn("s3.amazonaws.com is a reserved name and cannot be deleted")
     else:
         changed = True
         if not module.check_mode:
-            if CONTEXT_API_VERSION in api_version and module.params["context"]:
+            if (
+                LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+                and module.params["context"]
+            ):
                 res = blade.delete_object_store_virtual_hosts(
                     names=[module.params["name"]],
                     context_names=[module.params["context"]],
@@ -107,9 +116,12 @@ def delete_host(module, blade):
 def add_host(module, blade):
     """Add Object Store Virtual Host"""
     changed = True
-    api_version = list(blade.get_versions().items)
+    api_version = get_rest_api_version(blade)
     if not module.check_mode:
-        if CONTEXT_API_VERSION in api_version and module.params["context"]:
+        if (
+            LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+            and module.params["context"]
+        ):
             res = blade.post_object_store_virtual_hosts(
                 names=[module.params["name"]], context_names=[module.params["context"]]
             )
@@ -137,15 +149,21 @@ def main():
     module = AnsibleModule(argument_spec, supports_check_mode=True)
 
     blade = get_system(module)
-    api_version = list(blade.get_versions().items)
-    if CONTEXT_API_VERSION in api_version and not module.params["context"]:
+    api_version = get_rest_api_version(blade)
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and not module.params["context"]
+    ):
         # If no context is provided set the context to the local array name
         fleet_res = blade.get_fleets()
         if fleet_res.status_code == 200 and list(fleet_res.items):
             module.params["context"] = list(blade.get_arrays().items)[0].name
     state = module.params["state"]
 
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         exists = bool(
             blade.get_object_store_virtual_hosts(
                 names=[module.params["name"]], context_names=[module.params["context"]]
@@ -159,7 +177,10 @@ def main():
             ).status_code
             == 200
         )
-    if CONTEXT_API_VERSION in api_version and module.params["context"]:
+    if (
+        LooseVersion(CONTEXT_API_VERSION) <= LooseVersion(api_version)
+        and module.params["context"]
+    ):
         vhosts = blade.get_object_store_virtual_hosts(
             context_names=[module.params["context"]]
         )

--- a/tests/unit/plugins/modules/test_purefb_certs.py
+++ b/tests/unit/plugins/modules/test_purefb_certs.py
@@ -54,6 +54,9 @@ sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.purefb
 sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.common"] = (
     MagicMock()
 )
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.version"] = (
+    MagicMock()
+)
 
 from plugins.modules.purefb_certs import main
 
@@ -62,12 +65,13 @@ class TestPurefbCerts:
     """Test cases for purefb_certs module"""
 
     @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.LooseVersion")
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
     def test_main_create_cert_with_intermediate(
-        self, mock_ansible_module, mock_get_system, mock_pycountry
+        self, mock_ansible_module, mock_get_system, mock_loose_version, mock_pycountry
     ):
         """Test creating a certificate with intermediate certificate"""
         # Setup mock module
@@ -106,6 +110,9 @@ class TestPurefbCerts:
         mock_version.version = "2.15"
         mock_blade.get_versions.return_value.items = [mock_version]
 
+        # Mock API version checks - all feature gates OFF (pre-2.15 behavior)
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
+
         # Mock array name
         mock_array = Mock()
         mock_array.name = "test-array"
@@ -138,12 +145,13 @@ class TestPurefbCerts:
         assert call_args["changed"] is True
 
     @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.LooseVersion")
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
     def test_main_update_cert_uses_patch(
-        self, mock_ansible_module, mock_get_system, mock_pycountry
+        self, mock_ansible_module, mock_get_system, mock_loose_version, mock_pycountry
     ):
         """Test BUG #4 fix: update_cert uses CertificatePatch, not CertificatePost"""
         # Setup mock module
@@ -181,6 +189,9 @@ class TestPurefbCerts:
         mock_version = Mock()
         mock_version.version = "2.20"
         mock_blade.get_versions.return_value.items = [mock_version]
+
+        # Mock API version check - CSR feature gate OFF (old unconfigured-mock behavior)
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
 
         # Mock array name
         mock_array = Mock()
@@ -243,11 +254,14 @@ class TestPurefbCerts:
         call_args = mock_module.exit_json.call_args[1]
         assert call_args["changed"] is True
 
+    @patch("plugins.modules.purefb_certs.LooseVersion")
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
-    def test_main_import_cert_check_mode(self, mock_ansible_module, mock_get_system):
+    def test_main_import_cert_check_mode(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
         """Test BUG #3 fix: import_cert doesn't raise NameError in check_mode"""
         # Setup mock module
         mock_module = Mock()
@@ -284,6 +298,9 @@ class TestPurefbCerts:
         mock_version = Mock()
         mock_version.version = "2.10"
         mock_blade.get_versions.return_value.items = [mock_version]
+
+        # Mock API version checks - all feature gates OFF (pre-2.15 behavior)
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
 
         # Certificate doesn't exist
         mock_blade.get_certificates.return_value.status_code = 400
@@ -572,12 +589,13 @@ class TestPurefbCerts:
         assert "Exporting Certificate failed" in call_args["msg"]
 
     @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.LooseVersion")
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
     def test_main_create_csr_success(
-        self, mock_ansible_module, mock_get_system, mock_pycountry
+        self, mock_ansible_module, mock_get_system, mock_loose_version, mock_pycountry
     ):
         """Test create_csr successfully creates CSR"""
         # Setup mock module
@@ -614,6 +632,9 @@ class TestPurefbCerts:
         mock_version = Mock()
         mock_version.version = "2.20"
         mock_blade.get_versions.return_value.items = ["2.20"]
+
+        # Mock API version check - CSR min-version gate passes (API >= 2.20)
+        mock_loose_version.return_value.__gt__ = Mock(return_value=False)
 
         # Certificate exists
         mock_blade.get_certificates.return_value.status_code = 200
@@ -657,11 +678,14 @@ class TestPurefbCerts:
         call_args = mock_module.exit_json.call_args[1]
         assert call_args["changed"] is True
 
+    @patch("plugins.modules.purefb_certs.LooseVersion")
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
-    def test_main_create_csr_old_api_fails(self, mock_ansible_module, mock_get_system):
+    def test_main_create_csr_old_api_fails(
+        self, mock_ansible_module, mock_get_system, mock_loose_version
+    ):
         """Test create_csr fails on old API version"""
         # Setup mock module
         mock_module = Mock()
@@ -697,6 +721,9 @@ class TestPurefbCerts:
         mock_version = Mock()
         mock_version.version = "2.15"
         mock_blade.get_versions.return_value.items = ["2.15"]
+
+        # Mock API version check - CSR min-version gate fails (API < 2.20)
+        mock_loose_version.return_value.__gt__ = Mock(return_value=True)
 
         mock_get_system.return_value = mock_blade
 
@@ -964,12 +991,13 @@ class TestPurefbCerts:
         assert "pycountry sdk is required" in call_args["msg"]
 
     @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.LooseVersion")
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
     def test_main_update_cert_old_api(
-        self, mock_ansible_module, mock_get_system, mock_pycountry
+        self, mock_ansible_module, mock_get_system, mock_loose_version, mock_pycountry
     ):
         """Test update_cert with old API version (< 2.20)"""
         # Setup mock module
@@ -1007,6 +1035,9 @@ class TestPurefbCerts:
         mock_version.version = "2.15"
         mock_blade.get_versions.return_value.items = ["2.15"]
 
+        # Mock API version check - CSR feature gate OFF (API < 2.20)
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
+
         # Certificate exists
         mock_blade.get_certificates.return_value.status_code = 200
 
@@ -1039,12 +1070,13 @@ class TestPurefbCerts:
         assert call_args["changed"] is True
 
     @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.LooseVersion")
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
     def test_main_update_cert_new_api(
-        self, mock_ansible_module, mock_get_system, mock_pycountry
+        self, mock_ansible_module, mock_get_system, mock_loose_version, mock_pycountry
     ):
         """Test update_cert with new API version (>= 2.20)"""
         # Setup mock module
@@ -1079,6 +1111,9 @@ class TestPurefbCerts:
         # Mock blade with new API version
         mock_blade = Mock()
         mock_blade.get_versions.return_value.items = ["2.20"]
+
+        # Mock API version check - CSR feature gate ON (API >= 2.20)
+        mock_loose_version.return_value.__le__ = Mock(return_value=True)
 
         # Certificate exists
         mock_blade.get_certificates.return_value.status_code = 200
@@ -1116,12 +1151,13 @@ class TestPurefbCerts:
         assert call_args["changed"] is True
 
     @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.LooseVersion")
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
     def test_main_update_cert_new_api_fails(
-        self, mock_ansible_module, mock_get_system, mock_pycountry
+        self, mock_ansible_module, mock_get_system, mock_loose_version, mock_pycountry
     ):
         """Test update_cert fails with new API version"""
         # Setup mock module
@@ -1157,6 +1193,9 @@ class TestPurefbCerts:
         mock_blade = Mock()
         mock_blade.get_versions.return_value.items = ["2.20"]
 
+        # Mock API version check - CSR feature gate ON (API >= 2.20)
+        mock_loose_version.return_value.__le__ = Mock(return_value=True)
+
         # Certificate exists
         mock_blade.get_certificates.return_value.status_code = 200
 
@@ -1186,12 +1225,13 @@ class TestPurefbCerts:
         assert "Updating existing SSL certificate" in call_args["msg"]
 
     @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.LooseVersion")
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
     def test_main_update_cert_old_api_fails(
-        self, mock_ansible_module, mock_get_system, mock_pycountry
+        self, mock_ansible_module, mock_get_system, mock_loose_version, mock_pycountry
     ):
         """Test update_cert fails with old API version"""
         # Setup mock module
@@ -1227,6 +1267,9 @@ class TestPurefbCerts:
         mock_blade = Mock()
         mock_blade.get_versions.return_value.items = ["2.15"]
 
+        # Mock API version check - CSR feature gate OFF (API < 2.20)
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
+
         # Certificate exists
         mock_blade.get_certificates.return_value.status_code = 200
 
@@ -1252,12 +1295,13 @@ class TestPurefbCerts:
         assert "Updating existing SSL certificate" in call_args["msg"]
 
     @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.LooseVersion")
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
     def test_main_create_cert_new_api_fails(
-        self, mock_ansible_module, mock_get_system, mock_pycountry
+        self, mock_ansible_module, mock_get_system, mock_loose_version, mock_pycountry
     ):
         """Test create_cert fails with new API version"""
         # Setup mock module
@@ -1292,6 +1336,9 @@ class TestPurefbCerts:
         # Mock blade with new API version
         mock_blade = Mock()
         mock_blade.get_versions.return_value.items = ["2.20"]
+
+        # Mock API version check - CSR feature gate ON (API >= 2.20)
+        mock_loose_version.return_value.__le__ = Mock(return_value=True)
 
         # Certificate doesn't exist
         mock_blade.get_certificates.return_value.status_code = 400
@@ -1451,12 +1498,13 @@ class TestPurefbCerts:
         assert "External Certificates cannot be reimported" in call_args["msg"]
 
     @patch("plugins.modules.purefb_certs.pycountry")
+    @patch("plugins.modules.purefb_certs.LooseVersion")
     @patch("plugins.modules.purefb_certs.get_system")
     @patch("plugins.modules.purefb_certs.AnsibleModule")
     @patch("plugins.modules.purefb_certs.HAS_PYPURECLIENT", True)
     @patch("plugins.modules.purefb_certs.HAS_PYCOUNTRY", True)
     def test_main_import_existing_cert(
-        self, mock_ansible_module, mock_get_system, mock_pycountry
+        self, mock_ansible_module, mock_get_system, mock_loose_version, mock_pycountry
     ):
         """Test importing over existing non-external certificate"""
         # Setup mock module
@@ -1491,6 +1539,9 @@ class TestPurefbCerts:
         # Mock blade
         mock_blade = Mock()
         mock_blade.get_versions.return_value.items = ["2.15"]
+
+        # Mock API version check - CSR feature gate OFF (API < 2.20)
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
 
         # Certificate exists and is NOT external
         mock_cert_response = Mock()

--- a/tests/unit/plugins/modules/test_purefb_fs.py
+++ b/tests/unit/plugins/modules/test_purefb_fs.py
@@ -83,6 +83,9 @@ sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.purefb
 sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.common"] = (
     mock_collections.everpure.flashblade.plugins.module_utils.common
 )
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.version"] = (
+    mock_collections.everpure.flashblade.plugins.module_utils.version
+)
 
 from plugins.modules.purefb_fs import (
     main,
@@ -91,6 +94,7 @@ from plugins.modules.purefb_fs import (
     eradicate_fs,
     modify_fs,
 )
+from plugins.module_utils.version import LooseVersion as RealLooseVersion
 
 
 class TestPurefbFs:
@@ -138,6 +142,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_system")
     @patch("plugins.modules.purefb_fs.AnsibleModule")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_main_create_filesystem(
         self, mock_ansible_module, mock_get_system, mock_get_filesystem
     ):
@@ -205,6 +214,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_system")
     @patch("plugins.modules.purefb_fs.AnsibleModule")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_main_delete_filesystem(
         self, mock_ansible_module, mock_get_system, mock_get_filesystem
     ):
@@ -251,6 +265,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_system")
     @patch("plugins.modules.purefb_fs.AnsibleModule")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_main_eradicate_filesystem(
         self, mock_ansible_module, mock_get_system, mock_get_filesystem
     ):
@@ -299,6 +318,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.MultiProtocolPost")
     @patch("plugins.modules.purefb_fs.human_to_bytes")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_with_size(
         self,
         mock_human_to_bytes,
@@ -363,6 +387,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.MultiProtocolPost")
     @patch("plugins.modules.purefb_fs.human_to_bytes")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_with_nfs_rules(
         self,
         mock_human_to_bytes,
@@ -433,6 +462,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.MultiProtocolPost")
     @patch("plugins.modules.purefb_fs.human_to_bytes")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.17"),
+    )
     def test_create_fs_no_context_omits_context_names(
         self,
         mock_human_to_bytes,
@@ -491,6 +525,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.MultiProtocolPost")
     @patch("plugins.modules.purefb_fs.human_to_bytes")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.17"),
+    )
     def test_create_fs_with_context_sends_context_names(
         self,
         mock_human_to_bytes,
@@ -656,6 +695,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_system")
     @patch("plugins.modules.purefb_fs.AnsibleModule")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_main_filesystem_not_exists_absent(
         self, mock_ansible_module, mock_get_system, mock_get_filesystem
     ):
@@ -690,6 +734,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_system")
     @patch("plugins.modules.purefb_fs.AnsibleModule")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_main_native_smb_aclmode_fails(
         self, mock_ansible_module, mock_get_system, mock_get_filesystem
     ):
@@ -733,6 +782,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.human_to_bytes")
     @patch("plugins.modules.purefb_fs.FileSystemPatch")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_size_change(
         self, mock_fs_patch, mock_human_to_bytes, mock_get_filesystem
     ):
@@ -801,6 +855,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_no_changes(self, mock_get_filesystem):
         """Test modifying filesystem when no changes needed"""
         # Setup mocks
@@ -918,6 +977,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_system")
     @patch("plugins.modules.purefb_fs.AnsibleModule")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_main_eradicate_warning(
         self, mock_ansible_module, mock_get_system, mock_get_filesystem
     ):
@@ -1003,6 +1067,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_with_snapshot_enabled(self, mock_get_filesystem):
         """Test creating filesystem with snapshot directory enabled"""
         # Setup mocks
@@ -1039,6 +1108,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_with_fastremove(self, mock_get_filesystem):
         """Test creating filesystem with fast remove enabled"""
         # Setup mocks
@@ -1075,6 +1149,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_with_hard_limit(self, mock_get_filesystem):
         """Test creating filesystem with hard limit enabled"""
         # Setup mocks
@@ -1111,6 +1190,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_failure(self, mock_get_filesystem):
         """Test filesystem creation failure"""
         # Setup mocks
@@ -1148,6 +1232,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.human_to_bytes")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_add_policy(self, mock_human_to_bytes, mock_get_filesystem):
         """Test adding a policy to filesystem"""
         # Setup mocks
@@ -1221,6 +1310,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.human_to_bytes")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_remove_policy(self, mock_human_to_bytes, mock_get_filesystem):
         """Test removing a policy from filesystem"""
         # Setup mocks
@@ -1290,6 +1384,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.human_to_bytes")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_user_quota(self, mock_human_to_bytes, mock_get_filesystem):
         """Test modifying filesystem user quota"""
         # Setup mocks
@@ -1352,6 +1451,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.human_to_bytes")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_group_quota(self, mock_human_to_bytes, mock_get_filesystem):
         """Test modifying filesystem group quota"""
         # Setup mocks
@@ -1413,6 +1517,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_enable_http(self, mock_get_filesystem):
         """Test enabling HTTP on filesystem"""
         # Setup mocks
@@ -1472,6 +1581,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_nfsv3_change(self, mock_get_filesystem):
         """Test modifying filesystem NFSv3 setting"""
         # Setup mocks
@@ -1531,6 +1645,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_nfsv4_change(self, mock_get_filesystem):
         """Test modifying filesystem NFSv4 setting"""
         # Setup mocks
@@ -1590,6 +1709,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_promote(self, mock_get_filesystem):
         """Test promoting a filesystem"""
         # Setup mocks
@@ -1649,6 +1773,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_writable_false(self, mock_get_filesystem):
         """Test making filesystem read-only"""
         # Setup mocks
@@ -1708,6 +1837,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_writable_true_promoted(self, mock_get_filesystem):
         """Test making promoted filesystem writable"""
         # Setup mocks
@@ -1767,6 +1901,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_snapshot_enable(self, mock_get_filesystem):
         """Test enabling snapshot directory on filesystem"""
         # Setup mocks
@@ -1826,6 +1965,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_fastremove_enable(self, mock_get_filesystem):
         """Test enabling fast remove on filesystem"""
         # Setup mocks
@@ -1885,6 +2029,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_hard_limit_enable(self, mock_get_filesystem):
         """Test enabling hard limit on filesystem"""
         # Setup mocks
@@ -1944,6 +2093,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_safeguard_acls_enable(self, mock_get_filesystem):
         """Test enabling safeguard ACLs on filesystem"""
         # Setup mocks
@@ -2003,6 +2157,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_access_control_change(self, mock_get_filesystem):
         """Test changing access control style on filesystem"""
         # Setup mocks
@@ -2062,6 +2221,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_recover_destroyed(self, mock_get_filesystem):
         """Test recovering a destroyed filesystem"""
         # Setup mocks
@@ -2121,6 +2285,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_with_policy(self, mock_get_filesystem):
         """Test creating filesystem with snapshot/access policy"""
         # Setup mocks
@@ -2161,6 +2330,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_with_invalid_policy(self, mock_get_filesystem):
         """Test creating filesystem with invalid policy"""
         # Setup mocks
@@ -2287,6 +2461,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.3"),
+    )
     def test_modify_fs_change_export_policy(self, mock_get_filesystem):
         """Test changing NFS export policy on existing filesystem"""
         # Setup mocks
@@ -2350,6 +2529,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.3"),
+    )
     def test_modify_fs_add_export_policy(self, mock_get_filesystem):
         """Test adding NFS export policy to filesystem without one"""
         # Setup mocks
@@ -2412,6 +2596,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.10"),
+    )
     def test_modify_fs_change_share_policy(self, mock_get_filesystem):
         """Test changing SMB share policy on existing filesystem"""
         # Setup mocks
@@ -2477,6 +2666,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.10"),
+    )
     def test_modify_fs_change_client_policy(self, mock_get_filesystem):
         """Test changing SMB client policy on existing filesystem"""
         # Setup mocks
@@ -2544,6 +2738,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.3"),
+    )
     def test_modify_fs_export_policy_failure(self, mock_get_filesystem):
         """Test export policy modification failure"""
         # Setup mocks
@@ -2611,6 +2810,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.10"),
+    )
     def test_modify_fs_share_policy_failure(self, mock_get_filesystem):
         """Test share policy modification failure"""
         # Setup mocks
@@ -2681,6 +2885,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.10"),
+    )
     def test_modify_fs_client_policy_failure(self, mock_get_filesystem):
         """Test client policy modification failure"""
         # Setup mocks
@@ -2753,6 +2962,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_with_user_quota(self, mock_get_filesystem):
         """Test creating filesystem with user quota"""
         # Setup mocks
@@ -2789,6 +3003,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_with_group_quota(self, mock_get_filesystem):
         """Test creating filesystem with group quota"""
         # Setup mocks
@@ -2864,6 +3083,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_smb_disabled_with_empty_nfs_rules(self, mock_get_filesystem):
         """Test creating filesystem with SMB disabled and empty NFS rules"""
         # Setup mocks
@@ -2901,6 +3125,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_add_policy_invalid(self, mock_get_filesystem):
         """Test adding invalid policy to filesystem"""
         # Setup mocks
@@ -2966,6 +3195,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_modify_fs_add_policy_attach_failure(self, mock_get_filesystem):
         """Test adding policy to filesystem with attach failure"""
         # Setup mocks
@@ -3041,6 +3275,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.3"),
+    )
     def test_create_fs_with_export_policy(self, mock_get_filesystem):
         """Test creating filesystem with export policy (API 2.3+)"""
         mock_module = Mock()
@@ -3088,6 +3327,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.3"),
+    )
     def test_create_fs_with_export_policy_failure(self, mock_get_filesystem):
         """Test creating filesystem with export policy assignment failure"""
         mock_module = Mock()
@@ -3137,6 +3381,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.10"),
+    )
     def test_create_fs_with_client_policy(self, mock_get_filesystem):
         """Test creating filesystem with SMB client policy (API 2.10+)"""
         mock_module = Mock()
@@ -3182,6 +3431,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.10"),
+    )
     def test_create_fs_with_client_policy_failure(self, mock_get_filesystem):
         """Test creating filesystem with SMB client policy assignment failure"""
         mock_module = Mock()
@@ -3231,6 +3485,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.10"),
+    )
     def test_create_fs_with_share_policy(self, mock_get_filesystem):
         """Test creating filesystem with SMB share policy (API 2.10+)"""
         mock_module = Mock()
@@ -3276,6 +3535,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.10"),
+    )
     def test_create_fs_with_share_policy_failure(self, mock_get_filesystem):
         """Test creating filesystem with SMB share policy assignment failure"""
         mock_module = Mock()
@@ -3325,6 +3589,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_without_size(self, mock_get_filesystem):
         """Test creating filesystem without size parameter (defaults to 0)"""
         mock_module = Mock()
@@ -3359,6 +3628,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.17"),
+    )
     def test_create_fs_with_context_api(self, mock_get_filesystem):
         """Test creating filesystem with context API (API 2.17+)"""
         mock_module = Mock()
@@ -3397,6 +3671,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.17"),
+    )
     def test_create_fs_with_policy_context_api(self, mock_get_filesystem):
         """Test creating filesystem with policy using context API (API 2.17+)"""
         mock_module = Mock()
@@ -3451,6 +3730,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.17"),
+    )
     def test_create_fs_policy_attach_with_context(self, mock_get_filesystem):
         """Test policy attachment during creation with context API"""
         mock_module = Mock()
@@ -3588,6 +3872,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_policy_attach_failure_cleanup(self, mock_get_filesystem):
         """Test that filesystem is cleaned up when policy attachment fails during creation"""
         mock_module = Mock()
@@ -3645,6 +3934,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.0"),
+    )
     def test_create_fs_policy_check_failure_cleanup(self, mock_get_filesystem):
         """Test that filesystem is cleaned up when policy check fails during creation"""
         mock_module = Mock()
@@ -3701,6 +3995,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.17"),
+    )
     def test_create_fs_export_policy_with_context(self, mock_get_filesystem):
         """Test creating filesystem with export policy using context API"""
         mock_module = Mock()
@@ -3747,6 +4046,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.17"),
+    )
     def test_create_fs_client_policy_with_context(self, mock_get_filesystem):
         """Test creating filesystem with client policy using context API and SMB"""
         mock_module = Mock()
@@ -3796,6 +4100,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.17"),
+    )
     def test_create_fs_share_policy_with_context(self, mock_get_filesystem):
         """Test creating filesystem with share policy using context API and SMB"""
         mock_module = Mock()
@@ -3845,6 +4154,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.17"),
+    )
     def test_create_fs_continuous_availability_with_context(self, mock_get_filesystem):
         """Test creating filesystem with continuous availability using context API"""
         mock_module = Mock()
@@ -3887,6 +4201,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.17"),
+    )
     def test_create_fs_group_ownership_with_context(self, mock_get_filesystem):
         """Test creating filesystem with group ownership using context API"""
         mock_module = Mock()
@@ -3929,6 +4248,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.HAS_PYPURECLIENT", True)
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.17"),
+    )
     def test_create_fs_storage_class_with_context(self, mock_get_filesystem):
         """Test creating filesystem with storage class using context API"""
         mock_module = Mock()
@@ -3971,6 +4295,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.get_system")
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.20"),
+    )
     def test_create_fs_with_realm_success(self, mock_get_system, mock_get_filesystem):
         """Test creating filesystem with realm succeeds on API 2.19+
 
@@ -4080,6 +4409,11 @@ class TestPurefbFs:
 
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.get_system")
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.19"),
+    )
     def test_create_fs_without_realm(self, mock_get_system, mock_get_filesystem):
         """Test creating filesystem without realm works as before"""
         mock_module = Mock()
@@ -4131,6 +4465,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.get_system")
     @patch("plugins.modules.purefb_fs.AnsibleModule")
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.20"),
+    )
     def test_delete_fs_using_name_and_realm_params(
         self, mock_ansible_module, mock_get_system, mock_get_filesystem, mock_delete_fs
     ):
@@ -4214,6 +4553,11 @@ class TestPurefbFs:
     @patch("plugins.modules.purefb_fs.get_filesystem")
     @patch("plugins.modules.purefb_fs.get_system")
     @patch("plugins.modules.purefb_fs.AnsibleModule")
+    @patch("plugins.modules.purefb_fs.LooseVersion", RealLooseVersion)
+    @patch(
+        "plugins.modules.purefb_fs.get_rest_api_version",
+        Mock(return_value="2.19"),
+    )
     def test_main_modify_fs_using_name_and_realm_params(
         self, mock_ansible_module, mock_get_system, mock_get_filesystem, mock_modify_fs
     ):

--- a/tests/unit/plugins/modules/test_purefb_info.py
+++ b/tests/unit/plugins/modules/test_purefb_info.py
@@ -61,6 +61,12 @@ sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils"] = (
 sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.purefb"] = (
     MagicMock()
 )
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.common"] = (
+    MagicMock()
+)
+sys.modules["ansible_collections.everpure.flashblade.plugins.module_utils.version"] = (
+    MagicMock()
+)
 sys.modules[
     "ansible_collections.everpure.flashblade.plugins.module_utils.time_utils"
 ] = MagicMock()
@@ -250,6 +256,7 @@ class TestPurefbInfo:
         assert "capacity" in call_args["purefb_info"]
         assert "network" in call_args["purefb_info"]
 
+    @patch("plugins.modules.purefb_info.LooseVersion")
     @patch("plugins.modules.purefb_info.generate_perf_dict")
     @patch("plugins.modules.purefb_info.generate_config_dict")
     @patch("plugins.modules.purefb_info.generate_capacity_dict")
@@ -304,6 +311,7 @@ class TestPurefbInfo:
         mock_generate_capacity,
         mock_generate_config,
         mock_generate_perf,
+        mock_loose_version,
     ):
         """Test main with 'all' subset"""
         # Setup mocks
@@ -317,6 +325,10 @@ class TestPurefbInfo:
         mock_version.version = "2.0.0"
         mock_blade.get_versions.return_value.items = [mock_version]
         mock_get_system.return_value = mock_blade
+
+        # Version feature gates OFF (matches pre-migration behavior where the
+        # membership check against the versions list never matched)
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
 
         # Set return values for all generators
         mock_generate_default.return_value = {}
@@ -367,7 +379,8 @@ class TestPurefbInfo:
         assert call_args["changed"] is False
         assert "purefb_info" in call_args
 
-    def test_generate_default_dict(self):
+    @patch("plugins.modules.purefb_info.LooseVersion")
+    def test_generate_default_dict(self, mock_loose_version):
         """Test generate_default_dict function"""
         # Setup mock blade
         mock_blade = Mock()
@@ -377,6 +390,10 @@ class TestPurefbInfo:
         mock_version.version = "2.7"  # Use version that supports SECURITY_API_VERSION
         mock_version.__contains__ = Mock(return_value=True)
         mock_blade.get_versions.return_value.items = [mock_version]
+
+        # Version feature gates ON (SECURITY/NAP/RA_DURATION) - matches the
+        # pre-migration mock where __contains__ returned True for every check
+        mock_loose_version.return_value.__le__ = Mock(return_value=True)
 
         # Mock array info
         mock_array = Mock()
@@ -615,7 +632,8 @@ class TestPurefbInfo:
         assert result["s3"]["read_bytes_per_sec"] == 200000
         assert result["nfs"]["read_bytes_per_sec"] == 300000
 
-    def test_generate_config_dict(self):
+    @patch("plugins.modules.purefb_info.LooseVersion")
+    def test_generate_config_dict(self, mock_loose_version):
         """Test generate_config_dict function"""
         # Setup mock blade
         mock_blade = Mock()
@@ -624,6 +642,10 @@ class TestPurefbInfo:
         mock_version = Mock()
         mock_version.version = "2.0.0"
         mock_blade.get_versions.return_value.items = [mock_version]
+
+        # SMTP_ENCRYPT feature gate OFF (matches pre-migration behavior where
+        # the membership check against the versions list never matched)
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
 
         # Mock DNS
         mock_dns = Mock()

--- a/tests/unit/plugins/modules/test_purefb_policy.py
+++ b/tests/unit/plugins/modules/test_purefb_policy.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import sys
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock, MagicMock, patch
 
 # Mock external dependencies before importing module
 sys.modules["pypureclient"] = MagicMock()
@@ -117,10 +117,13 @@ def _blade(existing_rule):
 class TestUpdateNfsPolicyRule:
     """Regression tests for NFS export policy rule idempotency."""
 
-    def test_access_change_triggers_patch(self):
+    @patch("plugins.modules.purefb_policy.LooseVersion")
+    def test_access_change_triggers_patch(self, mock_loose_version):
         """Changing only access (root-squash -> no-squash) must PATCH the rule."""
         import plugins.modules.purefb_policy as pol
 
+        # Context API version absent: context feature gate OFF
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
         module = _module(access="no-squash")
         blade = _blade(_existing_rule(access="root-squash"))
 
@@ -137,8 +140,11 @@ class TestUpdateNfsPolicyRule:
         assert rule_kwargs["permission"] == "rw"
         module.exit_json.assert_called_once_with(changed=True)
 
-    def test_no_change_is_idempotent(self):
+    @patch("plugins.modules.purefb_policy.LooseVersion")
+    def test_no_change_is_idempotent(self, mock_loose_version):
         """Identical desired state (incl. access) must not PATCH the rule."""
+        # Context API version absent: context feature gate OFF
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
         module = _module(access="root-squash")
         blade = _blade(_existing_rule(access="root-squash"))
 
@@ -147,10 +153,13 @@ class TestUpdateNfsPolicyRule:
         blade.patch_nfs_export_policies_rules.assert_not_called()
         module.exit_json.assert_called_once_with(changed=False)
 
-    def test_access_change_preserves_unspecified_anon(self):
+    @patch("plugins.modules.purefb_policy.LooseVersion")
+    def test_access_change_preserves_unspecified_anon(self, mock_loose_version):
         """An access-only change must not reset anonuid/anongid left unset."""
         import plugins.modules.purefb_policy as pol
 
+        # Context API version absent: context feature gate OFF
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
         module = _module(access="no-squash")
         # Task changes access only and does not re-specify the anon mappings.
         module.params["anonuid"] = None
@@ -224,11 +233,14 @@ def _snap_blade(existing_rule):
 class TestUpdateSnapPolicy:
     """Regression tests for snapshot policy rule partial updates."""
 
-    def test_retention_change_preserves_at_schedule(self):
+    @patch("plugins.modules.purefb_policy.LooseVersion")
+    def test_retention_change_preserves_at_schedule(self, mock_loose_version):
         """Updating every/keep_for on an at-scheduled policy must preserve the
         existing ``at`` time and timezone, not drop them to an interval rule."""
         import plugins.modules.purefb_policy as pol
 
+        # Context API version absent: context feature gate OFF
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
         # Existing rule keeps snapshots taken daily at 10:00 in a named tz.
         # The task changes retention/interval but does not re-specify at/timezone
         # (the guards require every and keep_for to be supplied together).
@@ -254,8 +266,11 @@ class TestUpdateSnapPolicy:
         assert rule_kwargs["time_zone"] == "America/New_York"
         module.exit_json.assert_called_once_with(changed=True)
 
-    def test_no_change_is_idempotent(self):
+    @patch("plugins.modules.purefb_policy.LooseVersion")
+    def test_no_change_is_idempotent(self, mock_loose_version):
         """Identical desired schedule must not PATCH the policy."""
+        # Context API version absent: context feature gate OFF
+        mock_loose_version.return_value.__le__ = Mock(return_value=False)
         module = _snap_module(keep_for=86400, every=86400)
         blade = _snap_blade(_snap_rule(every=86400000, keep_for=86400000))
 
@@ -291,8 +306,11 @@ def _ctx_blade():
 class TestPolicyContextGating:
     """context_names must only be sent when a context is set."""
 
-    def test_no_context_omits_context_names(self):
+    @patch("plugins.modules.purefb_policy.LooseVersion")
+    def test_no_context_omits_context_names(self, mock_loose_version):
         """Standalone array (no context) must not send context_names."""
+        # Context API version present (2.17): gate ON, context param decides
+        mock_loose_version.return_value.__le__ = Mock(return_value=True)
         module = _ctx_module(context="")
         blade = _ctx_blade()
 
@@ -302,8 +320,11 @@ class TestPolicyContextGating:
         assert "context_names" not in blade.patch_smb_share_policies.call_args[1]
         module.exit_json.assert_called_once_with(changed=True)
 
-    def test_with_context_sends_context_names(self):
+    @patch("plugins.modules.purefb_policy.LooseVersion")
+    def test_with_context_sends_context_names(self, mock_loose_version):
         """When a context is set, context_names must be sent."""
+        # Context API version present (2.17): gate ON, context param decides
+        mock_loose_version.return_value.__le__ = Mock(return_value=True)
         module = _ctx_module(context="member-array")
         blade = _ctx_blade()
 

--- a/tests/unit/plugins/modules/test_purefb_userpolicy.py
+++ b/tests/unit/plugins/modules/test_purefb_userpolicy.py
@@ -109,8 +109,9 @@ def _make_blade(already_assigned=False):
 class TestPurefbUserpolicyAddPolicy:
     """Regression tests for add_policy (issue #574)."""
 
+    @patch("plugins.modules.purefb_userpolicy.LooseVersion")
     @patch("plugins.modules.purefb_userpolicy._check_valid_policy", return_value=True)
-    def test_add_issues_single_context_scoped_post(self, _valid):
+    def test_add_issues_single_context_scoped_post(self, _valid, mock_loose_version):
         """On API >= 2.17 the add must issue exactly ONE context-scoped POST.
 
         Previously a second, non-context POST ran unconditionally (no else) and
@@ -119,6 +120,9 @@ class TestPurefbUserpolicyAddPolicy:
         """
         module = _make_module(context="array1")
         blade = _make_blade(already_assigned=False)
+
+        # API version check: context feature gate ON (2.17 <= api_version)
+        mock_loose_version.return_value.__le__ = Mock(return_value=True)
 
         try:
             add_policy(module, blade)
@@ -136,11 +140,15 @@ class TestPurefbUserpolicyAddPolicy:
         assert module.exit_json.call_args[1]["changed"] is True
         module.fail_json.assert_not_called()
 
+    @patch("plugins.modules.purefb_userpolicy.LooseVersion")
     @patch("plugins.modules.purefb_userpolicy._check_valid_policy", return_value=True)
-    def test_add_is_idempotent_when_already_assigned(self, _valid):
+    def test_add_is_idempotent_when_already_assigned(self, _valid, mock_loose_version):
         """If the policy is already assigned, no POST is issued and changed is False."""
         module = _make_module(context="array1")
         blade = _make_blade(already_assigned=True)
+
+        # API version check: context feature gate ON (2.17 <= api_version)
+        mock_loose_version.return_value.__le__ = Mock(return_value=True)
 
         try:
             add_policy(module, blade)


### PR DESCRIPTION
##### SUMMARY

Migrates the remaining 31 FlashBlade modules off the legacy REST version-check idiom (`api_version = list(blade.get_versions().items)` + `"2.X" in api_version`) to `get_rest_api_version(blade)` + `LooseVersion` comparisons, the pattern the newer modules already use. `purefb_server.py` is excluded on purpose. The conversion is 1:1: `in` becomes `<=`, `not in` becomes `>`, with branch structure, and variable names untouched. Dead constants and the unused version fetches in `purefb_admin` and `purefb_hardware` are kept; removing them is a separate cleanup.

One behavior change rides along, in `purefb_info`: `generate_default_dict` compared version constants against a single version string instead of the supported-versions list, so the encryption, network access protocol, and remote assist duration sections never appeared in the `default` subset. The migration fixes that. A `NOTE(latent bug)` comment in the module documents the old behavior.

Unit tests for `certs`, `fs`, `info`, `policy`, and `userpolicy` get the same mock plumbing the already-migrated modules' tests use (`sys.modules` entries for `module_utils.version`/`common`, per-test `LooseVersion` steering). No assertions or expected calls changed.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

purefb_ad, purefb_admin, purefb_bucket, purefb_bucket_access, purefb_bucket_replica, purefb_certs, purefb_connect, purefb_dns, purefb_ds, purefb_export, purefb_fs, purefb_fs_replica, purefb_groupquota, purefb_hardware, purefb_info, purefb_inventory, purefb_lifecycle, purefb_pingtrace, purefb_policy, purefb_ra, purefb_remote_cred, purefb_s3acc, purefb_s3user, purefb_saml, purefb_smtp, purefb_snap, purefb_syslog, purefb_user, purefb_userpolicy, purefb_userquota, purefb_virtualhost



